### PR TITLE
feat: Implement simulation mode for offline testing

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
     "port": 7497,
     "clientId": 50
   },
+  "simulation_mode": true,
   "api_base_url": "http://franciscos-mac-studio.tailccaee.ts.net:8000",
   "symbol": "KC",
   "exchange": "NYBOT",


### PR DESCRIPTION
This commit introduces a simulation mode to allow for end-to-end testing of the trading bot's logic without being constrained by market hours or executing real trades.

A `simulation_mode` flag has been added to `config.json`. When this is set to `true`, the `is_market_open` function will always return `true`, and the `wait_for_fill` function will place and then immediately cancel orders. This allows developers to verify the entire data processing and trading pipeline without executing live trades or waiting for the market to be open.