### PR TITLE
fix(ib): Resolve asyncio errors and improve API interaction

### DIFF
--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -82,7 +82,7 @@ async def generate_and_queue_orders(config: dict):
                 # Wait for the ticker to update with a valid price, with a timeout
                 start_time = time.time()
                 while util.isNan(ticker.marketPrice()):
-                    await ib.sleep(0.1) # Use ib_insync's sleep to allow it to process messages
+                    await asyncio.sleep(0.1) # Use asyncio's sleep to allow ib_insync to process messages
                     if (time.time() - start_time) > 5: # 5-second timeout
                         logger.error(f"Timeout waiting for market price for {future.localSymbol}.")
                         logger.error(f"Ticker data received: {ticker}")
@@ -143,7 +143,7 @@ async def place_queued_orders(config: dict):
             await asyncio.sleep(0.5) # Small delay between placements
 
         logger.info(f"--- Finished placing {len(placed_trades)} orders. ---")
-        send_pushover_notification(config.get('notifications', {}), "Orders Placed", f"{len(placed_trades)} DAY orders have been submitted to the exchange.")
+        send_pushover_notification(config.get('notifications', {}), "Orders Placed", f"{len(placed_trades)} DAY orders have been submitted to the. exchange.")
         ORDER_QUEUE.clear()
 
     except Exception as e:
@@ -204,13 +204,14 @@ async def cancel_all_open_orders(config: dict):
         await ib.connectAsync(host=conn_settings.get('host', '127.0.0.1'), port=conn_settings.get('port', 7497), clientId=random.randint(200, 2000))
         logger.info("Connected to IB for canceling open orders.")
 
-        open_trades = ib.reqOpenOrders()
+        # Use ib.openTrades() which is a non-blocking property
+        open_trades = ib.openTrades()
         if not open_trades:
             logger.info("No open orders found to cancel.")
             return
 
         logger.info(f"Found {len(open_trades)} open orders to cancel.")
-        for trade in open_trades:
+        for trade in list(open_trades): # Iterate over a copy
             ib.cancelOrder(trade.order)
             logger.info(f"Cancelled order ID {trade.order.orderId}.")
             await asyncio.sleep(0.2)


### PR DESCRIPTION
This commit resolves a `RuntimeError: This event loop is already running` caused by an incorrect call to `ib.sleep()` within an `async` function. It also fixes a subsequent `SyntaxError` introduced during a faulty refactoring attempt.

- Replaced `ib.sleep()` with the correct `asyncio.sleep()` in the market data polling loop to prevent conflicting event loops.
- Corrected a `SyntaxError` by overwriting the corrupted file with a clean, syntactically valid version of the code.
- Improved the order cancellation logic in `cancel_all_open_orders` by replacing the synchronous `ib.reqOpenOrders()` with the non-blocking `ib.openTrades()` property, aligning with async best practices.