### PR TITLE
fix(ib): Resolve asyncio event loop error in order manager

### DIFF
--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -82,7 +82,7 @@ async def generate_and_queue_orders(config: dict):
                 # Wait for the ticker to update with a valid price, with a timeout
                 start_time = time.time()
                 while util.isNan(ticker.marketPrice()):
-                    await ib.sleep(0.1) # Use ib_insync's sleep to allow it to process messages
+                    await asyncio.sleep(0.1) # Use asyncio's sleep to allow ib_insync to process messages
                     if (time.time() - start_time) > 5: # 5-second timeout
                         logger.error(f"Timeout waiting for market price for {future.localSymbol}.")
                         logger.error(f"Ticker data received: {ticker}")


### PR DESCRIPTION
This commit resolves a `RuntimeError: This event loop is already running` that occurred during order generation.

The error was caused by an incorrect call to `ib.sleep()` within an `async` function. This was replaced with the correct `asyncio.sleep()`, which prevents the creation of a conflicting event loop and allows the existing loop to process messages correctly.

All other logic remains as it was in the original, correct implementation.