### PR TITLE
fix: Correct price handling in order generation

### DIFF
--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -102,7 +102,6 @@ async def generate_and_queue_orders(config: dict):
                 if util.isNan(price):
                     continue
 
-                price = normalize_strike(price)
                 chain = await build_option_chain(ib, future)
                 if not chain: continue
 


### PR DESCRIPTION
The order generation process was failing with an "Error 200: No security definition found" because the underlying future's price was being incorrectly scaled.

The `normalize_strike` function, intended only for option strike prices, was being erroneously applied to the future's market price in `order_manager.py`. This caused the system to search for options with invalid strike prices (e.g., 3.475 instead of ~348).

This commit removes the incorrect call to `normalize_strike` on the future's price, ensuring that the correct market price is used to determine the at-the-money strike for option strategies.