### PR TITLE
fix: Correct dual scaling issues in order generation

### DIFF
--- a/tests/test_ib_interface.py
+++ b/tests/test_ib_interface.py
@@ -43,8 +43,8 @@ class TestIbInterface(unittest.TestCase):
 
             self.assertIsNotNone(chain)
             self.assertEqual(chain['exchange'], 'NYBOT')
-            # Assert that the strikes have been normalized (divided by 100)
-            self.assertEqual(chain['strikes_by_expiration']['20251120'], [3.4, 3.5])
+            # Assert that the strikes are NOT normalized
+            self.assertEqual(chain['strikes_by_expiration']['20251120'], [340.0, 350.0])
 
         asyncio.run(run_test())
 

--- a/trading_bot/ib_interface.py
+++ b/trading_bot/ib_interface.py
@@ -51,7 +51,7 @@ async def build_option_chain(ib: IB, future_contract: Contract) -> dict | None:
             'exchange': chain.exchange,
             'tradingClass': chain.tradingClass,
             'expirations': sorted(chain.expirations),
-            'strikes_by_expiration': {exp: sorted([normalize_strike(s) for s in chain.strikes]) for exp in chain.expirations}
+            'strikes_by_expiration': {exp: sorted(chain.strikes) for exp in chain.expirations}
         }
     except Exception as e:
         logging.error(f"Failed to build option chain for {future_contract.localSymbol}: {e}"); return None

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -102,7 +102,6 @@ async def generate_and_queue_orders(config: dict):
                 if util.isNan(price):
                     continue
 
-                price = normalize_strike(price)
                 chain = await build_option_chain(ib, future)
                 if not chain: continue
 


### PR DESCRIPTION
This commit resolves a critical "Error 200: No security definition found" that was preventing order generation. The error was caused by two separate but related price scaling issues:

1. The underlying future's price was being incorrectly scaled down by a factor of 100 in `trading_bot/order_manager.py`.
2. The list of available option strikes fetched in `trading_bot/ib_interface.py` was also being incorrectly scaled down.

This created a mismatch where the system would compare a correctly scaled price to an incorrectly scaled list of strikes, leading to the selection of an invalid at-the-money (ATM) strike and a failed contract definition.

This patch corrects both issues by:
- Removing the erroneous `normalize_strike` call on the future's price in `order_manager.py`.
- Removing the erroneous `normalize_strike` call on the option chain strikes in `ib_interface.py`.
- Updating the corresponding unit test in `tests/test_ib_interface.py` to assert the new, correct behavior.

With these changes, both the underlying price and the option strikes are handled consistently, allowing for correct ATM strike selection and successful order generation.