### PR TITLE
fix(orders): Use reqAllOpenOrders to cancel open orders

### DIFF
--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -289,8 +289,8 @@ async def cancel_all_open_orders(config: dict):
         await ib.connectAsync(host=conn_settings.get('host', '127.0.0.1'), port=conn_settings.get('port', 7497), clientId=random.randint(200, 2000), timeout=30)
         logger.info("Connected to IB for canceling open orders.")
 
-        # Use ib.openTrades() which is a non-blocking property
-        open_trades = ib.openTrades()
+        # Use ib.reqAllOpenOrders() to get all open orders from the broker
+        open_trades = ib.reqAllOpenOrders()
         if not open_trades:
             logger.info("No open orders found to cancel.")
             return


### PR DESCRIPTION
The `cancel_all_open_orders` function was using `ib.openTrades()` to find open orders to cancel. This method only returns trades known to the current ib_insync session, which caused the function to miss orders placed in previous sessions.

This change replaces `ib.openTrades()` with `ib.reqAllOpenOrders()`, which fetches all open orders directly from the broker. This ensures that all open orders are correctly identified and canceled at the end of the day.