### PR TITLE
Fix Signal Overlay chart visibility for short lookback periods

### DIFF
--- a/pages/6_Signal_Overlay.py
+++ b/pages/6_Signal_Overlay.py
@@ -962,8 +962,20 @@ if price_df is not None and not price_df.empty:
         row=2, col=1
     )
 
-    # Row 1 Y-axis
-    fig.update_yaxes(title_text="Price (¢/lb)", row=1, col=1)
+    # Row 1 Y-axis - CRITICAL: Set explicit range to prevent candlestick disappearing on short lookbacks
+    if not price_df.empty:
+        y_min = price_df['Low'].min()
+        y_max = price_df['High'].max()
+        y_range = y_max - y_min
+        # Add 5% buffer on each side, with minimum buffer to prevent zero-range issues
+        y_buffer = max(y_range * 0.05, 0.5)
+        fig.update_yaxes(
+            title_text="Price (¢/lb)",
+            range=[y_min - y_buffer, y_max + y_buffer],
+            row=1, col=1
+        )
+    else:
+        fig.update_yaxes(title_text="Price (¢/lb)", row=1, col=1)
 
     # Row 2 Primary Y-axis (Confidence) - LEFT
     fig.update_yaxes(


### PR DESCRIPTION
Add explicit Y-axis range calculation for the price chart (row 1) to prevent Plotly candlestick from disappearing when using categorical x-axis with small datasets. The volume chart uses simpler bar traces which handle auto-range better, but candlestick requires explicit range settings for reliable rendering with short lookback periods.

https://claude.ai/code/session_01QAR8CUBV6yE5wqnCKwHiWu