### PR TITLE
Fix critical risk calculation bug and optimize signal/order logic

### DIFF
--- a/config.json
+++ b/config.json
@@ -31,7 +31,7 @@
   "strategy": {
     "quantity": 1,
     "signal_threshold": 0.005,
-    "min_underlying_volume": 50
+    "min_underlying_volume": 20
   },
   "strategy_tuning": {
     "spread_width_percentage": 0.5,


### PR DESCRIPTION
This PR addresses critical issues preventing trade execution:
1.  **Risk Calculation Fix (P0):** Corrected a 100x multiplication error in `trading_bot/compliance.py` by converting the contract multiplier (lbs) to a dollar multiplier (dollars/cent) for risk calculations.
2.  **Signal Logic Update (P0):** Modified `trading_bot/signal_generator.py` to:
    *   Default `NEUTRAL` direction signals to `NO_TRADE` (Stand Down) instead of confusing VOLATILITY.
    *   Only trigger `VOLATILITY/HIGH` (Long Straddle) if there is an imminent catalyst or extreme agent conflict (> 0.8).
    *   Prioritize `VOLATILITY/LOW` (Iron Condor) for range-bound regimes or expensive volatility environments.
3.  **Liquidity & Capital Safety (P1):**
    *   Updated `trading_bot/order_manager.py` and `config.json` to lower the default `min_underlying_volume` from 50 to 20.
    *   Added an early abort check in the order generation loop if `committed_capital` exceeds `account_value`.
4.  **Log Cleanliness:**
    *   Suppressed "No data of type EODChart" errors for FOP contracts in `compliance.py`.
    *   Ensured proper symbol logging for BAG contracts using `_describe_bag`.

Verified with unit tests for the risk calculation logic.

---
*PR created automatically by Jules for task [6462342215397360009](https://jules.google.com/task/6462342215397360009) started by @rozavala*