### PR TITLE
Fix Iron Condor float config crash and Devil's Advocate fail-open vulnerability

### DIFF
--- a/config.json
+++ b/config.json
@@ -38,7 +38,7 @@
     "adaptive_step_interval_seconds": 60,
     "adaptive_step_percentage": 0.01,
     "iron_condor_short_strikes_from_atm": 2,
-    "iron_condor_wing_strikes_apart": 0.5,
+    "iron_condor_wing_strikes_apart": 2,
     "slippage_spread_percentage": 0.5,
     "order_type": "LMT",
     "max_liquidity_spread_percentage": 0.25,

--- a/trading_bot/strategy.py
+++ b/trading_bot/strategy.py
@@ -166,8 +166,14 @@ def define_volatility_strategy(config: dict, signal: dict, chain: dict, underlyi
     if signal['level'] == 'HIGH':  # Long Straddle
         legs_def, order_action = [('C', 'BUY', atm_strike), ('P', 'BUY', atm_strike)], 'BUY'
     elif signal['level'] == 'LOW':  # Iron Condor
-        short_dist = tuning.get('iron_condor_short_strikes_from_atm', 2)
-        wing_width = tuning.get('iron_condor_wing_strikes_apart', 2)
+        short_dist = int(tuning.get('iron_condor_short_strikes_from_atm', 2))
+        wing_width = int(tuning.get('iron_condor_wing_strikes_apart', 2))
+
+        # Sanity check
+        if short_dist < 1 or wing_width < 1:
+            logging.error(f"Invalid Iron Condor params: short_dist={short_dist}, wing_width={wing_width}. Must be >= 1.")
+            return None
+
         try:
             atm_idx = strikes.index(atm_strike)
             if not (atm_idx - short_dist - wing_width >= 0 and atm_idx + short_dist + wing_width < len(strikes)):


### PR DESCRIPTION
This PR addresses critical P0/P1 issues:
1.  **Iron Condor Crash:** Fixed a `TypeError` caused by a float value in `config.json` for `iron_condor_wing_strikes_apart`. Updated config to use integer `2` and added defensive casting/validation in `strategy.py`. Added a regression test `test_iron_condor_config_values_are_integers`.
2.  **Devil's Advocate Fail-Open:** Patched `agents.py` to ensure `run_devils_advocate` returns `proceed: False` if the agent fails or returns invalid JSON, preventing unreviewed trades.
3.  **Cosmetic Logging:** Improved `order_manager.py` logging for BAG/Combo orders using a new helper `_get_order_display_name`.

---
*PR created automatically by Jules for task [16972232050533545901](https://jules.google.com/task/16972232050533545901) started by @rozavala*