### PR TITLE
Fix IB Connection Stability and Client ID Collisions

### DIFF
--- a/dashboard_utils.py
+++ b/dashboard_utils.py
@@ -282,14 +282,10 @@ def fetch_live_dashboard_data(_config):
     finally:
         if ib.isConnected():
             ib.disconnect()
-            # === NEW: Give Gateway time to cleanup ===
-            # Note: This function uses loop.run_until_complete, so we need to schedule the sleep
-            import asyncio
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                asyncio.ensure_future(asyncio.sleep(3.0))
-            else:
-                loop.run_until_complete(asyncio.sleep(3.0))
+            # FLIGHT DIRECTOR FIX: Force blocking sleep for Gateway cleanup
+            # Streamlit runs in a thread, so time.sleep is safe and necessary here.
+            import time
+            time.sleep(3.0)
 
     return data
 

--- a/pages/5_Utilities.py
+++ b/pages/5_Utilities.py
@@ -372,6 +372,10 @@ with diag_cols[0]:
                             return False, "Connection failed"
                         except Exception as e:
                             return False, str(e)
+                        finally:
+                            # FLIGHT DIRECTOR FIX: Guaranteed cleanup
+                            # This prevents the "CLOSE-WAIT" zombie accumulation
+                            await IBConnectionPool.release_connection("test_utilities")
 
                     try:
                         success, message = asyncio.run(test_connection())


### PR DESCRIPTION
- Resolves Client ID collision between 'microstructure' (200-209) and 'audit' (previously defaulted to 200, now 230-239).
- Adds explicit Client ID for 'test_utilities' (220-229).
- Fixes resource leak in 'pages/5_Utilities.py' by ensuring 'release_connection' is called in a finally block.
- Replaces non-blocking 'asyncio.ensure_future' sleep with blocking 'time.sleep' in 'dashboard_utils.py' to ensure proper socket cleanup.
- Removes dead code ('import socket' and '_check_gateway_health') from 'trading_bot/connection_pool.py'.

---
*PR created automatically by Jules for task [2165778581907326145](https://jules.google.com/task/2165778581907326145) started by @rozavala*