### PR TITLE
Fix CLOSE-WAIT socket accumulation in IBConnectionPool

### DIFF
--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1,0 +1,43 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock, patch, AsyncMock
+from trading_bot.connection_pool import IBConnectionPool
+
+@pytest.mark.asyncio
+async def test_get_connection_disconnects_on_failure():
+    """
+    Test that IBConnectionPool.get_connection calls disconnect() on the IB instance
+    when connectAsync raises an exception (e.g. TimeoutError).
+    """
+    # Arrange
+    purpose = "test_cleanup"
+    config = {"connection": {"host": "127.0.0.1", "port": 7497}}
+
+    # Reset pool state to ensure clean slate
+    IBConnectionPool._instances.clear()
+    IBConnectionPool._locks.clear()
+    IBConnectionPool._reconnect_backoff.clear()
+    IBConnectionPool._consecutive_failures.clear()
+
+    # Patch the IB class used in connection_pool
+    with patch('trading_bot.connection_pool.IB') as MockIB, \
+         patch('trading_bot.connection_pool.asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
+
+        # Setup the mock instance that will be returned by IB()
+        mock_ib_instance = MockIB.return_value
+        # Simulate connection timeout
+        mock_ib_instance.connectAsync = AsyncMock(side_effect=TimeoutError("Connection timed out"))
+        mock_ib_instance.disconnect = MagicMock()
+
+        # Act
+        # We expect the exception to propagate
+        with pytest.raises(TimeoutError):
+            await IBConnectionPool.get_connection(purpose, config)
+
+        # Assert
+        # This assertion verifies that disconnect() was called.
+        # Without the fix, this should fail.
+        mock_ib_instance.disconnect.assert_called()
+
+        # Verify that it waited for cleanup (the 0.5s sleep)
+        mock_sleep.assert_called_with(0.5)


### PR DESCRIPTION
This PR fixes a critical issue where failed connection attempts to the IB Gateway would leave orphaned TCP sockets in the CLOSE-WAIT state, eventually exhausting system resources.

Changes:
- Modified `trading_bot/connection_pool.py`: Added `ib.disconnect()` and `asyncio.sleep(0.5)` in the `except` block of `get_connection` to ensure the socket is properly closed upon failure (e.g., TimeoutError).
- Created `tests/test_connection_pool.py`: Added a unit test to reproduce the issue (by mocking IB) and verify that `disconnect()` is correctly called.

Verification:
- `tests/test_connection_pool.py` passes, confirming `disconnect()` is called.
- Verified that other test failures in the suite are pre-existing and unrelated to this change.

---
*PR created automatically by Jules for task [6506916363854164962](https://jules.google.com/task/6506916363854164962) started by @rozavala*