### PR TITLE
Fix pandas MergeError by standardizing on UTC timestamps

### DIFF
--- a/dashboard_utils.py
+++ b/dashboard_utils.py
@@ -64,7 +64,7 @@ def load_trade_data():
     try:
         df = get_trade_ledger_df()
         if not df.empty:
-            df['timestamp'] = pd.to_datetime(df['timestamp'])
+            df['timestamp'] = pd.to_datetime(df['timestamp'], utc=True)
         return df
     except Exception as e:
         st.error(f"Failed to load trade_ledger.csv: {e}")
@@ -78,7 +78,7 @@ def load_council_history():
         if os.path.exists(COUNCIL_HISTORY_PATH):
             df = pd.read_csv(COUNCIL_HISTORY_PATH)
             if not df.empty:
-                df['timestamp'] = pd.to_datetime(df['timestamp'])
+                df['timestamp'] = pd.to_datetime(df['timestamp'], utc=True)
             return df
         return pd.DataFrame()
     except Exception as e:
@@ -93,7 +93,7 @@ def load_equity_data():
         if os.path.exists(DAILY_EQUITY_PATH):
             df = pd.read_csv(DAILY_EQUITY_PATH)
             if not df.empty:
-                df['timestamp'] = pd.to_datetime(df['timestamp'])
+                df['timestamp'] = pd.to_datetime(df['timestamp'], utc=True)
                 df = df.sort_values('timestamp')
             return df
         return pd.DataFrame()

--- a/tests/test_dashboard_utils.py
+++ b/tests/test_dashboard_utils.py
@@ -16,7 +16,8 @@ class TestDashboardUtils(unittest.TestCase):
             'actual_trend_direction': ['UP', 'DOWN', 'UP', 'DOWN'],
             'ml_signal': ['LONG', 'SHORT', 'NEUTRAL', 'LONG'],
             'master_decision': ['BULLISH', 'BEARISH', 'NEUTRAL', 'BULLISH'],
-            'meteorologist_sentiment': ['BULLISH', 'BEARISH', 'BULLISH', 'BEARISH']
+            'meteorologist_sentiment': ['BULLISH', 'BEARISH', 'BULLISH', 'BEARISH'],
+            'prediction_type': ['DIRECTIONAL', 'DIRECTIONAL', 'DIRECTIONAL', 'DIRECTIONAL']
         }
         df = pd.DataFrame(data)
 

--- a/trading_bot/performance_graphs.py
+++ b/trading_bot/performance_graphs.py
@@ -30,7 +30,7 @@ def generate_performance_charts(
     output_paths = []
 
     # --- Data Prep ---
-    trade_df['timestamp'] = pd.to_datetime(trade_df['timestamp'])
+    trade_df['timestamp'] = pd.to_datetime(trade_df['timestamp'], utc=True)
 
     # --- Dynamic Granularity (Determine from trade_df or equity_df) ---
     # Default to Daily
@@ -51,7 +51,7 @@ def generate_performance_charts(
     # --- Prepare Series for Charts 1 & 2 ---
     if equity_df is not None and not equity_df.empty:
         # Use Equity Data (Net Liquidation Value)
-        equity_df['timestamp'] = pd.to_datetime(equity_df['timestamp'])
+        equity_df['timestamp'] = pd.to_datetime(equity_df['timestamp'], utc=True)
 
         # Ensure sorted by date
         equity_df = equity_df.sort_values('timestamp')
@@ -114,7 +114,7 @@ def generate_performance_charts(
     # --- Chart 3: P&L by Model Signal (Life-to-Date) ---
     # This always uses the Trade Ledger because signals match to specific trades
     if not signals_df.empty and not trade_df.empty:
-        signals_df['timestamp'] = pd.to_datetime(signals_df['timestamp'])
+        signals_df['timestamp'] = pd.to_datetime(signals_df['timestamp'], utc=True)
         merged_df = pd.merge_asof(trade_df.sort_values('timestamp'), signals_df.sort_values('timestamp'), on='timestamp', direction='backward')
         pnl_by_signal = merged_df.groupby('signal')['total_value_usd'].sum()
 


### PR DESCRIPTION
Resolved a critical `pandas.errors.MergeError` in `PerformanceAnalyzer` caused by mixing timezone-naive and timezone-aware timestamps.

Changes:
- **`trading_bot/performance_graphs.py`**: Enforced `utc=True` when converting timestamps for `trade_df`, `signals_df`, and `equity_df` to ensure all are `datetime64[ns, UTC]`.
- **`dashboard_utils.py`**: Updated `load_trade_data`, `load_council_history`, and `load_equity_data` to also enforce `utc=True` for consistency across the application.
- **`tests/test_dashboard_utils.py`**: Fixed an existing test failure in `test_calculate_agent_scores_ml_signal` by adding the required `prediction_type` column to the mock DataFrame, ensuring the test suite passes.

Verified by reproducing the issue with mismatched timestamps and confirming the fix allows successful merging and chart generation. Existing tests were also run and validated.

---
*PR created automatically by Jules for task [4364245485901423703](https://jules.google.com/task/4364245485901423703) started by @rozavala*