### PR TITLE
Fix Brier Score Feedback Loop and Schema Corruption

### DIFF
--- a/scripts/fix_brier_data.py
+++ b/scripts/fix_brier_data.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+One-time script to fix Brier score data files.
+Run this ONCE after deploying the code fixes.
+
+Usage: python scripts/fix_brier_data.py
+"""
+
+import pandas as pd
+import os
+import shutil
+from datetime import datetime
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+DATA_DIR = "data"
+ACCURACY_FILE = os.path.join(DATA_DIR, "agent_accuracy.csv")
+STRUCTURED_FILE = os.path.join(DATA_DIR, "agent_accuracy_structured.csv")
+COUNCIL_FILE = os.path.join(DATA_DIR, "council_history.csv")
+
+def backup_files():
+    """Create timestamped backups before modification."""
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+
+    for filepath in [ACCURACY_FILE, STRUCTURED_FILE]:
+        if os.path.exists(filepath):
+            backup_path = filepath.replace('.csv', f'_backup_{timestamp}.csv')
+            shutil.copy(filepath, backup_path)
+            logger.info(f"Backed up {filepath} to {backup_path}")
+
+def fix_legacy_accuracy_file():
+    """
+    Fix schema corruption in agent_accuracy.csv.
+
+    The file may have a 7-column header but 5-column data.
+    We need to:
+    1. Read with correct column count
+    2. Remove duplicate/corrupt rows
+    3. Write back with correct header
+    """
+    if not os.path.exists(ACCURACY_FILE):
+        logger.info("No agent_accuracy.csv to fix")
+        return
+
+    logger.info("Fixing agent_accuracy.csv schema...")
+
+    # Read raw to detect format
+    with open(ACCURACY_FILE, 'r') as f:
+        lines = f.readlines()
+
+    if not lines:
+        logger.info("File is empty")
+        return
+
+    header = lines[0].strip()
+    logger.info(f"Current header: {header}")
+
+    # Expected 5-column format
+    correct_header = "timestamp,agent,predicted,actual,correct"
+    correct_columns = ['timestamp', 'agent', 'predicted', 'actual', 'correct']
+
+    # Parse data rows (skip header)
+    valid_rows = []
+    skipped = 0
+
+    for i, line in enumerate(lines[1:], start=2):
+        parts = line.strip().split(',')
+
+        # Handle 5-column rows (correct format)
+        if len(parts) == 5:
+            valid_rows.append({
+                'timestamp': parts[0],
+                'agent': parts[1].lower(),  # Normalize to lowercase
+                'predicted': parts[2].upper(),
+                'actual': parts[3].upper(),
+                'correct': int(parts[4]) if parts[4].isdigit() else 0
+            })
+        # Handle 7-column rows (wrong format) - try to extract useful data
+        elif len(parts) == 7:
+            # timestamp,agent,predicted,confidence,prob_bullish,actual,correct
+            valid_rows.append({
+                'timestamp': parts[0],
+                'agent': parts[1].lower(),
+                'predicted': parts[2].upper(),
+                'actual': parts[5].upper(),
+                'correct': int(parts[6]) if parts[6].isdigit() else 0
+            })
+        else:
+            logger.warning(f"Line {i}: Unexpected format ({len(parts)} columns), skipping")
+            skipped += 1
+
+    logger.info(f"Parsed {len(valid_rows)} valid rows, skipped {skipped}")
+
+    # Create DataFrame and deduplicate
+    df = pd.DataFrame(valid_rows)
+
+    if df.empty:
+        logger.warning("No valid data found!")
+        return
+
+    # Remove exact duplicates
+    before_dedup = len(df)
+    df = df.drop_duplicates()
+    logger.info(f"Removed {before_dedup - len(df)} duplicate rows")
+
+    # Write back with correct header
+    df.to_csv(ACCURACY_FILE, index=False, columns=correct_columns)
+    logger.info(f"Wrote {len(df)} rows with correct schema")
+
+def resolve_old_pending_predictions():
+    """
+    Attempt to resolve old PENDING predictions using council_history.
+    Uses a wider time window (30 minutes) for historical data.
+    """
+    if not os.path.exists(STRUCTURED_FILE) or not os.path.exists(COUNCIL_FILE):
+        logger.info("Missing required files for resolution")
+        return
+
+    logger.info("Resolving old PENDING predictions...")
+
+    predictions_df = pd.read_csv(STRUCTURED_FILE)
+    council_df = pd.read_csv(COUNCIL_FILE)
+
+    if predictions_df.empty or council_df.empty:
+        logger.info("Empty dataframes")
+        return
+
+    # Parse timestamps
+    predictions_df['timestamp'] = pd.to_datetime(predictions_df['timestamp'], utc=True)
+    council_df['timestamp'] = pd.to_datetime(council_df['timestamp'], utc=True)
+
+    # Filter to PENDING only
+    pending_mask = predictions_df['actual'] == 'PENDING'
+    pending_count = pending_mask.sum()
+
+    if pending_count == 0:
+        logger.info("No pending predictions")
+        return
+
+    logger.info(f"Found {pending_count} pending predictions")
+
+    # Get reconciled council decisions
+    reconciled = council_df[
+        (council_df['actual_trend_direction'].notna()) &
+        (council_df['actual_trend_direction'] != '')
+    ].copy()
+
+    logger.info(f"Found {len(reconciled)} reconciled council decisions")
+
+    resolved_count = 0
+
+    for idx in predictions_df[pending_mask].index:
+        pred_time = predictions_df.loc[idx, 'timestamp']
+
+        # Use wider window (30 min) for historical backfill
+        time_window = pd.Timedelta(minutes=30)
+
+        matches = reconciled[
+            (reconciled['timestamp'] >= pred_time - time_window) &
+            (reconciled['timestamp'] <= pred_time + time_window)
+        ]
+
+        if not matches.empty:
+            actual = str(matches.iloc[0]['actual_trend_direction']).upper().strip()
+
+            # Normalize direction
+            if actual == 'UP':
+                actual = 'BULLISH'
+            elif actual == 'DOWN':
+                actual = 'BEARISH'
+
+            if actual in ['BULLISH', 'BEARISH', 'NEUTRAL']:
+                predictions_df.loc[idx, 'actual'] = actual
+                resolved_count += 1
+
+    logger.info(f"Resolved {resolved_count} predictions")
+
+    if resolved_count > 0:
+        # Save updated structured file
+        predictions_df.to_csv(STRUCTURED_FILE, index=False)
+
+        # Append newly resolved to legacy file
+        newly_resolved = predictions_df[
+            (predictions_df['actual'] != 'PENDING') &
+            predictions_df.index.isin(predictions_df[pending_mask].index)
+        ].copy()
+
+        if not newly_resolved.empty:
+            # Calculate correctness
+            newly_resolved['correct'] = (
+                newly_resolved['direction'].str.upper() == newly_resolved['actual'].str.upper()
+            ).astype(int)
+
+            # Append to legacy file
+            with open(ACCURACY_FILE, 'a') as f:
+                for _, row in newly_resolved.iterrows():
+                    agent = row['agent'].lower()  # Normalize
+                    f.write(f"{row['timestamp']},{agent},{row['direction']},{row['actual']},{row['correct']}\n")
+
+            logger.info(f"Appended {len(newly_resolved)} rows to legacy file")
+
+def main():
+    logger.info("=== Brier Score Data Fix Script ===")
+
+    # Safety backup
+    backup_files()
+
+    # Fix schema corruption
+    fix_legacy_accuracy_file()
+
+    # Resolve old predictions
+    resolve_old_pending_predictions()
+
+    logger.info("=== Done ===")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_brier_scoring_new.py
+++ b/tests/test_brier_scoring_new.py
@@ -1,0 +1,92 @@
+import unittest
+import os
+import shutil
+import pandas as pd
+from datetime import datetime, timezone
+from trading_bot.brier_scoring import BrierScoreTracker, resolve_pending_predictions
+
+class TestBrierScoring(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = "tests/data_temp"
+        os.makedirs(self.test_dir, exist_ok=True)
+        self.history_file = os.path.join(self.test_dir, "agent_accuracy.csv")
+        self.tracker = BrierScoreTracker(history_file=self.history_file)
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+    def test_record_and_load_prediction(self):
+        # Record legacy style
+        self.tracker.record_prediction("agronomist", "BULLISH", "BULLISH")
+        self.tracker.record_prediction("macro", "BULLISH", "BEARISH")
+
+        # Reload
+        tracker2 = BrierScoreTracker(history_file=self.history_file)
+        scores = tracker2.scores
+
+        self.assertIn("agronomist", scores)
+        self.assertIn("macro", scores)
+
+        # agronomist: 1 correct -> 1.0 (or smoothed)
+        # macro: 0 correct -> 0.0 (or smoothed)
+        # logic: if agent not in scores: score = correct.
+        # So agronomist=1, macro=0.
+
+        self.assertEqual(scores["agronomist"], 1.0)
+        self.assertEqual(scores["macro"], 0.0)
+
+    def test_normalization(self):
+        # Record with different casing/aliases
+        self.tracker.record_prediction("Weather", "BULLISH", "BULLISH") # -> agronomist
+        self.tracker.record_prediction("MACRO_economist", "BEARISH", "BEARISH") # -> macro
+
+        tracker2 = BrierScoreTracker(history_file=self.history_file)
+        scores = tracker2.scores
+
+        self.assertIn("agronomist", scores)
+        self.assertIn("macro", scores)
+        self.assertNotIn("Weather", scores)
+
+        self.assertEqual(scores["agronomist"], 1.0)
+        self.assertEqual(scores["macro"], 1.0)
+
+    def test_weight_multiplier(self):
+        # 100% accuracy
+        self.tracker.scores['agronomist'] = 1.0
+        mult = self.tracker.get_agent_weight_multiplier('agronomist')
+        # 0.5 + (1.0 * 1.5) = 2.0
+        self.assertEqual(mult, 2.0)
+
+        # 0% accuracy
+        self.tracker.scores['bad_agent'] = 0.0
+        mult = self.tracker.get_agent_weight_multiplier('bad_agent')
+        # 0.5 + 0 = 0.5
+        self.assertEqual(mult, 0.5)
+
+        # 50% accuracy
+        self.tracker.scores['avg_agent'] = 0.5
+        mult = self.tracker.get_agent_weight_multiplier('avg_agent')
+        # 0.5 + (0.5 * 1.5) = 0.5 + 0.75 = 1.25
+        self.assertEqual(mult, 1.25)
+
+        # Unknown agent -> 1.0
+        self.assertEqual(self.tracker.get_agent_weight_multiplier('unknown'), 1.0)
+
+    def test_record_structured_schema(self):
+        # Verify it writes to _structured.csv without error and has correct schema
+        self.tracker.record_prediction_structured(
+            "agronomist", "BULLISH", 0.9, actual="PENDING"
+        )
+
+        struct_file = self.history_file.replace(".csv", "_structured.csv")
+        self.assertTrue(os.path.exists(struct_file))
+
+        df = pd.read_csv(struct_file)
+        expected_cols = ['timestamp','agent','direction','confidence','prob_bullish','actual']
+        self.assertTrue(all(col in df.columns for col in expected_cols))
+        self.assertEqual(len(df), 1)
+        self.assertEqual(df.iloc[0]['actual'], 'PENDING')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/trading_bot/agent_names.py
+++ b/trading_bot/agent_names.py
@@ -1,0 +1,115 @@
+"""
+Central agent name normalization.
+
+Different parts of the system use different names for the same agents.
+This module provides canonical names and conversion utilities.
+"""
+
+# Canonical agent names (lowercase, underscore-separated)
+CANONICAL_AGENTS = [
+    'agronomist',      # Weather/Meteorologist
+    'macro',           # Macro Economist
+    'geopolitical',    # Geopolitical Risk
+    'supply_chain',    # Supply Chain/Logistics
+    'inventory',       # Inventory/Fundamentalist
+    'sentiment',       # Sentiment/News/COT
+    'technical',       # Technical Analyst
+    'volatility',      # Volatility Analyst
+    'master_decision', # Master Strategist
+    'ml_model',        # ML Model
+]
+
+# Map various names to canonical names
+NAME_ALIASES = {
+    # Agronomist / Weather
+    'agronomist': 'agronomist',
+    'meteorologist': 'agronomist',
+    'meteorologist_sentiment': 'agronomist',
+    'weather': 'agronomist',
+
+    # Macro
+    'macro': 'macro',
+    'macro_economist': 'macro',
+    'macro_sentiment': 'macro',
+
+    # Geopolitical
+    'geopolitical': 'geopolitical',
+    'geopolitical_risk': 'geopolitical',
+    'geopolitical_sentiment': 'geopolitical',
+
+    # Supply Chain
+    'supply_chain': 'supply_chain',
+    'logistics': 'supply_chain',
+
+    # Inventory / Fundamentalist
+    'inventory': 'inventory',
+    'fundamentalist': 'inventory',
+    'fundamentalist_sentiment': 'inventory',
+    'inventory_analyst': 'inventory',
+
+    # Sentiment
+    'sentiment': 'sentiment',
+    'sentiment_cot': 'sentiment',
+    'sentiment_sentiment': 'sentiment',
+    'news': 'sentiment',
+
+    # Technical
+    'technical': 'technical',
+    'technical_sentiment': 'technical',
+
+    # Volatility
+    'volatility': 'volatility',
+    'volatility_sentiment': 'volatility',
+
+    # Master
+    'master': 'master_decision',
+    'master_decision': 'master_decision',
+    'master_strategist': 'master_decision',
+
+    # ML
+    'ml_model': 'ml_model',
+    'ml': 'ml_model',
+    'ml_signal': 'ml_model',
+}
+
+def normalize_agent_name(name: str) -> str:
+    """
+    Convert any agent name variant to canonical form.
+
+    Args:
+        name: Any agent name (case-insensitive)
+
+    Returns:
+        Canonical lowercase agent name, or original if not found
+    """
+    if not name:
+        return 'unknown'
+
+    # Lowercase and strip
+    normalized = name.lower().strip()
+
+    # Remove common suffixes
+    for suffix in ['_sentiment', '_summary', '_signal']:
+        if normalized.endswith(suffix):
+            normalized = normalized.replace(suffix, '')
+            break
+
+    # Look up in aliases
+    return NAME_ALIASES.get(normalized, normalized)
+
+
+def get_display_name(canonical_name: str) -> str:
+    """Get pretty display name for dashboards."""
+    DISPLAY_NAMES = {
+        'agronomist': '🌦️ Meteorologist',
+        'macro': '💵 Macro Economist',
+        'geopolitical': '🌍 Geopolitical',
+        'supply_chain': '🚢 Supply Chain',
+        'inventory': '📦 Fundamentalist',
+        'sentiment': '🧠 Sentiment/COT',
+        'technical': '📉 Technical',
+        'volatility': '⚡ Volatility',
+        'master_decision': '👑 Master Strategist',
+        'ml_model': '🤖 ML Model',
+    }
+    return DISPLAY_NAMES.get(canonical_name, canonical_name.title())


### PR DESCRIPTION
Implemented a fix for the Brier Score Feedback Loop.
Key changes:
1.  **Schema Repair**: Fixed `record_prediction_structured` in `trading_bot/brier_scoring.py` to stop writing a 7-column header to the legacy 5-column `agent_accuracy.csv`.
2.  **Normalization**: Created `trading_bot/agent_names.py` to normalize agent names (e.g., 'meteorologist' -> 'agronomist') across the system. Updated `brier_scoring.py` to use this normalization.
3.  **Scoring Logic**: Updated `get_agent_weight_multiplier` to use the formula `0.5 + (accuracy * 1.5)` and handle normalized names.
4.  **Migration Script**: Added `scripts/fix_brier_data.py` to repair existing corrupted data files and resolve pending predictions using `council_history.csv`.
5.  **Testing**: Added `tests/test_brier_scoring_new.py` to verify the new logic and schema handling.


---
*PR created automatically by Jules for task [15608771622523979355](https://jules.google.com/task/15608771622523979355) started by @rozavala*