### PR TITLE
fix: Implement cycle-aware Brier score resolution logic

### DIFF
--- a/tests/test_brier_scoring_new.py
+++ b/tests/test_brier_scoring_new.py
@@ -126,5 +126,138 @@ class TestBrierScoringNew(unittest.TestCase):
                         pending_rows = df_new[df_new['cycle_id'] == 'KC-test5678']
                         self.assertTrue(all(pending_rows['actual'] == 'PENDING'))
 
+    def test_cycle_aware_legacy_resolution(self):
+        """
+        New Cycle-Aware algorithm (v5) should ensure predictions match to their OWN cycle,
+        even if that cycle is unreconciled and there is a reconciled decision nearby.
+        This prevents cross-cycle contamination.
+        """
+        # Create a temporary directory for test files
+        with tempfile.TemporaryDirectory() as tmpdir:
+            struct_file = os.path.join(tmpdir, "agent_accuracy_structured.csv")
+            council_file = os.path.join(tmpdir, "council_history.csv")
+
+            # Timestamps
+            time_cycle_a = '2026-01-20 10:00:00+00:00'  # Prediction time for Cycle A
+            time_council_a = '2026-01-20 10:05:00+00:00'  # Council A decision (5 min later) - UNRECONCILED
+            time_council_b = '2026-01-20 11:30:00+00:00'  # Council B decision (90 min later) - RECONCILED
+
+            # 1. Create LEGACY PREDICTION (no cycle_id)
+            pd.DataFrame([
+                # Prediction happened at 10:00. Nearest decision is A (10:05). Next nearest is B (11:30).
+                # Under OLD logic (nearest RECONCILED), it would match B (gap=90m < 2h).
+                # Under NEW logic (nearest ANY), it matches A (gap=5m). A is unreconciled -> PENDING.
+                {'cycle_id': '', 'timestamp': time_cycle_a,
+                 'agent': 'agronomist', 'direction': 'BULLISH', 'confidence': 0.9,
+                 'prob_bullish': 0.9, 'actual': 'PENDING'},
+            ]).to_csv(struct_file, index=False)
+
+            # 2. Create COUNCIL HISTORY
+            pd.DataFrame([
+                # Cycle A: Nearest to prediction, but NOT reconciled
+                {'cycle_id': 'KC-cycleA', 'timestamp': time_council_a,
+                 'contract': 'KCH6', 'master_decision': 'BULLISH',
+                 'actual_trend_direction': '', 'exit_price': None},
+
+                # Cycle B: Further away, but RECONCILED
+                {'cycle_id': 'KC-cycleB', 'timestamp': time_council_b,
+                 'contract': 'KCH6', 'master_decision': 'BEARISH',
+                 'actual_trend_direction': 'BEARISH', 'exit_price': 340.0},
+            ]).to_csv(council_file, index=False)
+
+            # 3. Setup Mocking (same as above)
+            original_read_csv = pd.read_csv
+
+            def side_effect_read_csv(filepath, **kwargs):
+                real_path = filepath
+                if "agent_accuracy_structured.csv" in str(filepath):
+                    real_path = struct_file
+                elif "council_history.csv" in str(filepath):
+                    real_path = council_file
+                df = original_read_csv(real_path, **kwargs)
+                if "agent_accuracy_structured.csv" in str(filepath):
+                    original_to_csv = df.to_csv
+                    def custom_to_csv(path_or_buf=None, **csv_kwargs):
+                        target = path_or_buf
+                        if target and "agent_accuracy_structured.csv" in str(target):
+                            target = struct_file
+                        return original_to_csv(target, **csv_kwargs)
+                    df.to_csv = custom_to_csv
+                return df
+
+            with mock.patch('pandas.read_csv', side_effect=side_effect_read_csv):
+                with mock.patch('os.path.exists', return_value=True):
+                    with mock.patch('trading_bot.brier_scoring._append_to_legacy_accuracy'):
+
+                        # Run resolution
+                        resolved_count = brier_scoring.resolve_pending_predictions(council_file)
+
+                        # EXPECTATION: 0 resolved.
+                        # It should match to Cycle A (nearest), see it's unreconciled, and stay PENDING.
+                        # It should NOT match to Cycle B (which is reconciled but wrong cycle).
+                        self.assertEqual(resolved_count, 0)
+
+                        df_new = original_read_csv(struct_file)
+                        self.assertEqual(df_new.iloc[0]['actual'], 'PENDING')
+
+    def test_cycle_aware_legacy_resolution_success(self):
+        """
+        Verify it DOES resolve when the correct cycle IS reconciled.
+        """
+        # Create a temporary directory for test files
+        with tempfile.TemporaryDirectory() as tmpdir:
+            struct_file = os.path.join(tmpdir, "agent_accuracy_structured.csv")
+            council_file = os.path.join(tmpdir, "council_history.csv")
+
+            time_cycle_a = '2026-01-20 10:00:00+00:00'
+            time_council_a = '2026-01-20 10:05:00+00:00'
+
+            # 1. Prediction
+            pd.DataFrame([
+                {'cycle_id': '', 'timestamp': time_cycle_a,
+                 'agent': 'agronomist', 'direction': 'BULLISH', 'confidence': 0.9,
+                 'prob_bullish': 0.9, 'actual': 'PENDING'},
+            ]).to_csv(struct_file, index=False)
+
+            # 2. Council History (Cycle A is now RECONCILED)
+            pd.DataFrame([
+                {'cycle_id': 'KC-cycleA', 'timestamp': time_council_a,
+                 'contract': 'KCH6', 'master_decision': 'BULLISH',
+                 'actual_trend_direction': 'BULLISH', 'exit_price': 360.0},
+            ]).to_csv(council_file, index=False)
+
+            # 3. Setup Mocking
+            original_read_csv = pd.read_csv
+
+            def side_effect_read_csv(filepath, **kwargs):
+                real_path = filepath
+                if "agent_accuracy_structured.csv" in str(filepath):
+                    real_path = struct_file
+                elif "council_history.csv" in str(filepath):
+                    real_path = council_file
+                df = original_read_csv(real_path, **kwargs)
+                if "agent_accuracy_structured.csv" in str(filepath):
+                    original_to_csv = df.to_csv
+                    def custom_to_csv(path_or_buf=None, **csv_kwargs):
+                        target = path_or_buf
+                        if target and "agent_accuracy_structured.csv" in str(target):
+                            target = struct_file
+                        return original_to_csv(target, **csv_kwargs)
+                    df.to_csv = custom_to_csv
+                return df
+
+            with mock.patch('pandas.read_csv', side_effect=side_effect_read_csv):
+                with mock.patch('os.path.exists', return_value=True):
+                    with mock.patch('trading_bot.brier_scoring._append_to_legacy_accuracy'):
+
+                        # Run resolution
+                        resolved_count = brier_scoring.resolve_pending_predictions(council_file)
+
+                        # EXPECTATION: 1 resolved. Matches A (nearest), sees reconciled, resolves.
+                        self.assertEqual(resolved_count, 1)
+
+                        df_new = original_read_csv(struct_file)
+                        self.assertEqual(df_new.iloc[0]['actual'], 'BULLISH')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR implements a robust "cycle-aware" matching algorithm for resolving legacy Brier predictions that lack a `cycle_id`.

**Key Changes:**
1.  **Fixed Cross-Cycle Contamination:** The new algorithm matches predictions to their *own* cycle (nearest council decision in time) regardless of reconciliation status, and then *only* resolves if that specific cycle is reconciled. This prevents the previous issue where predictions were matching to the nearest *reconciled* decision from a completely different cycle (e.g., matching a weather prediction to a macro outcome).
2.  **Updated Migration Script:** `scripts/fix_brier_data.py` now uses this new logic and provides improved diagnostics (Resolved vs. Awaiting Reconciliation vs. Orphaned).
3.  **Updated Production Logic:** `trading_bot/brier_scoring.py` was updated to use the same logic for its fallback strategy.
4.  **New Tests:** Added `tests/test_brier_scoring_new.py` to verify the fix prevents cross-cycle matching and correctly resolves valid cases.

**Verification:**
-   Ran `tests/test_brier_scoring_new.py` and all tests passed.
-   Verified the logic handles the fallback for legacy data while preserving the deterministic `cycle_id` strategy for new data.

---
*PR created automatically by Jules for task [7490691092406776605](https://jules.google.com/task/7490691092406776605) started by @rozavala*