### PR TITLE
Friday Lifecycle & Sentinel Hygiene

### DIFF
--- a/config.json
+++ b/config.json
@@ -59,6 +59,7 @@
   },
   "risk_management": {
     "max_holding_days": 2,
+    "min_holding_hours": 6.0,
     "check_interval_seconds": 600,
     "min_confidence_threshold": 0.70,
     "monitoring_grace_period_seconds": 300,

--- a/tests/test_holding_time_gate.py
+++ b/tests/test_holding_time_gate.py
@@ -1,0 +1,92 @@
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch
+import pytz
+
+from trading_bot.utils import hours_until_weekly_close
+
+
+def test_monday_morning():
+    """Monday morning → no forced close → inf."""
+    ny = pytz.timezone('America/New_York')
+    mock_now = datetime(2026, 1, 26, 14, 0, 0, tzinfo=timezone.utc)  # Mon 9 AM ET
+    with patch('trading_bot.utils.datetime') as mock_dt:
+        mock_dt.now.return_value = mock_now
+        result = hours_until_weekly_close()
+    assert result == float('inf')
+
+
+def test_friday_9am():
+    """Friday 9 AM ET → ~3.75h until 12:45."""
+    ny = pytz.timezone('America/New_York')
+    # Friday Jan 30, 2026 at 9:00 AM ET = 14:00 UTC
+    mock_now = datetime(2026, 1, 30, 14, 0, 0, tzinfo=timezone.utc)
+    with patch('trading_bot.utils.datetime') as mock_dt:
+        mock_dt.now.return_value = mock_now
+        result = hours_until_weekly_close()
+    assert 3.5 <= result <= 4.0  # ~3.75h
+
+
+def test_friday_1pm():
+    """Friday 1 PM ET → past close → 0."""
+    mock_now = datetime(2026, 1, 30, 18, 0, 0, tzinfo=timezone.utc)  # Fri 1 PM ET
+    with patch('trading_bot.utils.datetime') as mock_dt:
+        mock_dt.now.return_value = mock_now
+        result = hours_until_weekly_close()
+    assert result == 0.0
+
+
+def test_thursday_before_holiday():
+    """Thursday before Friday holiday → should report hours until Thursday close."""
+    # Dec 31, 2026 is Thursday; Jan 1, 2027 is Friday (New Year's)
+    mock_now = datetime(2026, 12, 31, 14, 0, 0, tzinfo=timezone.utc)  # Thu 9 AM ET
+    with patch('trading_bot.utils.datetime') as mock_dt:
+        mock_dt.now.return_value = mock_now
+        result = hours_until_weekly_close()
+    assert 3.5 <= result <= 4.0  # ~3.75h until 12:45 ET
+
+
+def test_wednesday():
+    """Normal Wednesday → no forced close → inf."""
+    mock_now = datetime(2026, 1, 28, 14, 0, 0, tzinfo=timezone.utc)  # Wed 9 AM ET
+    with patch('trading_bot.utils.datetime') as mock_dt:
+        mock_dt.now.return_value = mock_now
+        result = hours_until_weekly_close()
+    assert result == float('inf')
+
+
+def test_gate_blocks_friday():
+    """Integration: generate_and_execute_orders should skip on Friday."""
+    from unittest.mock import AsyncMock
+    from trading_bot.order_manager import generate_and_execute_orders
+
+    config = {'risk_management': {'min_holding_hours': 6.0}}
+
+    with patch('trading_bot.order_manager.is_market_open', return_value=True), \
+         patch('trading_bot.order_manager.hours_until_weekly_close', return_value=3.75), \
+         patch('trading_bot.order_manager.generate_and_queue_orders') as mock_gen, \
+         patch('trading_bot.order_manager.send_pushover_notification'):
+
+        import asyncio
+        asyncio.run(generate_and_execute_orders(config))
+
+        mock_gen.assert_not_called()  # Should have been skipped
+
+
+def test_gate_allows_thursday():
+    """Integration: generate_and_execute_orders should run on Thursday."""
+    from unittest.mock import AsyncMock
+    from trading_bot.order_manager import generate_and_execute_orders
+
+    config = {'risk_management': {'min_holding_hours': 6.0}}
+
+    with patch('trading_bot.order_manager.is_market_open', return_value=True), \
+         patch('trading_bot.order_manager.hours_until_weekly_close', return_value=float('inf')), \
+         patch('trading_bot.order_manager.generate_and_queue_orders') as mock_gen, \
+         patch('trading_bot.order_manager.place_queued_orders'), \
+         patch('trading_bot.order_manager.send_pushover_notification'):
+
+        import asyncio
+        asyncio.run(generate_and_execute_orders(config))
+
+        mock_gen.assert_called_once()  # Should proceed

--- a/tests/test_prediction_market_sentinel.py
+++ b/tests/test_prediction_market_sentinel.py
@@ -124,7 +124,9 @@ async def test_slug_consistency_check_resets_baseline(mock_config):
         mock_ctx.__aexit__ = AsyncMock(return_value=None)
         mock_get.return_value = mock_ctx
 
-        with patch('trading_bot.sentinels.send_pushover_notification') as mock_notify:
+        with patch('trading_bot.sentinels.send_pushover_notification') as mock_notify, \
+             patch('trading_bot.utils.is_trading_day', return_value=True), \
+             patch('trading_bot.utils.is_market_open', return_value=True):
             trigger = await sentinel.check()
 
     # Should NOT trigger (rollover detected)
@@ -172,7 +174,9 @@ async def test_high_water_mark_prevents_flapping(mock_config):
         mock_ctx.__aexit__ = AsyncMock(return_value=None)
         mock_get.return_value = mock_ctx
 
-        trigger1 = await sentinel.check()
+        with patch('trading_bot.utils.is_trading_day', return_value=True), \
+             patch('trading_bot.utils.is_market_open', return_value=True):
+            trigger1 = await sentinel.check()
 
     assert trigger1 is not None
     assert trigger1.severity == 6
@@ -191,7 +195,9 @@ async def test_high_water_mark_prevents_flapping(mock_config):
         mock_ctx.__aexit__ = AsyncMock(return_value=None)
         mock_get.return_value = mock_ctx
 
-        trigger2 = await sentinel.check()
+        with patch('trading_bot.utils.is_trading_day', return_value=True), \
+             patch('trading_bot.utils.is_market_open', return_value=True):
+            trigger2 = await sentinel.check()
 
     assert trigger2 is not None
     assert trigger2.severity == 7  # Escalation alerts
@@ -210,7 +216,9 @@ async def test_high_water_mark_prevents_flapping(mock_config):
         mock_ctx.__aexit__ = AsyncMock(return_value=None)
         mock_get.return_value = mock_ctx
 
-        trigger3 = await sentinel.check()
+        with patch('trading_bot.utils.is_trading_day', return_value=True), \
+             patch('trading_bot.utils.is_market_open', return_value=True):
+            trigger3 = await sentinel.check()
 
     # Should be SUPPRESSED (severity 6 <= HWM 7)
     assert trigger3 is None
@@ -246,7 +254,9 @@ async def test_hwm_decay_allows_re_alerting(mock_config):
         mock_ctx.__aexit__ = AsyncMock(return_value=None)
         mock_get.return_value = mock_ctx
 
-        trigger = await sentinel.check()
+        with patch('trading_bot.utils.is_trading_day', return_value=True), \
+             patch('trading_bot.utils.is_market_open', return_value=True):
+            trigger = await sentinel.check()
 
     # Should trigger because HWM decayed
     assert trigger is not None
@@ -307,7 +317,9 @@ async def test_no_trigger_on_small_move(mock_config):
         mock_ctx.__aexit__ = AsyncMock(return_value=None)
         mock_get.return_value = mock_ctx
 
-        trigger = await sentinel.check()
+        with patch('trading_bot.utils.is_trading_day', return_value=True), \
+             patch('trading_bot.utils.is_market_open', return_value=True):
+            trigger = await sentinel.check()
 
     assert trigger is None
 


### PR DESCRIPTION
This PR implements a package of improvements to handle the Friday trading lifecycle and reduce log noise.

**Key Changes:**
1.  **Friday Open Gate:** Prevents opening new positions on Friday mornings (or before holidays) if the time remaining until the weekly close is less than `min_holding_hours` (default 6.0). This prevents opening positions that would be closed just 3.75 hours later.
2.  **Friday Close Safety:**
    *   Forces `close_stale_positions` to close "orphaned" positions (those not in the local ledger) during a weekly close to prevent weekend exposure.
    *   Adds a post-close verification step that re-queries IBKR positions and attempts to close any remaining legs.
    *   Adds a guard to `run_emergency_cycle` to prevent emergency sentinels from opening positions during the Friday close window (after 12:30 ET).
3.  **Sentinel Hygiene:**
    *   Reduces `PredictionMarketSentinel` logging noise by moving discovery logs to DEBUG and emitting a single summary line per cycle.
    *   Reduces polling frequency for prediction markets on non-trading days (2h) and off-hours (30m).

**Verification:**
*   Added `tests/test_holding_time_gate.py`.
*   Ran existing tests for weekly close and sentinels (patched to handle new rate limiting).
*   Verified configuration changes in `config.json`.

---
*PR created automatically by Jules for task [15473372393563888187](https://jules.google.com/task/15473372393563888187) started by @rozavala*