### PR TITLE
Fix IB API Error 10314 in reconciliation via format_ib_datetime

### DIFF
--- a/trading_bot/reconciliation.py
+++ b/trading_bot/reconciliation.py
@@ -11,7 +11,7 @@ import pytz
 import pandas as pd
 from ib_insync import IB, Contract, util
 from trading_bot.brier_scoring import get_brier_tracker
-from trading_bot.timestamps import parse_ts_column, parse_ts_single
+from trading_bot.timestamps import parse_ts_column, parse_ts_single, format_ib_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -304,7 +304,7 @@ async def _process_reconciliation(ib: IB, df: pd.DataFrame, config: dict, file_p
 
                 # Fetch Historical Data
                 # Use IB's preferred UTC format to suppress Warning 2174
-                end_str = (target_exit_time + timedelta(days=2)).strftime('%Y%m%d-%H:%M:%S') + ' UTC'
+                end_str = format_ib_datetime(target_exit_time + timedelta(days=2))
                 bars = await ib.reqHistoricalDataAsync(
                     qualified_contract,
                     endDateTime=end_str,


### PR DESCRIPTION
Introduced trading_bot.timestamps.format_ib_datetime utility to correctly format datetimes for IB API (dash format without suffix). Updated trading_bot/reconciliation.py to use this utility, fixing the invalid 'YYYYMMDD-HH:MM:SS UTC' format that caused Error 10314. Added comprehensive tests in tests/test_timestamps.py.

---
*PR created automatically by Jules for task [1141077896489257944](https://jules.google.com/task/1141077896489257944) started by @rozavala*