### PR TITLE
Fix IBKR Error 478 (Strike Price Mismatch)

### DIFF
--- a/scripts/migrations/fix_legacy_thesis_prices.py
+++ b/scripts/migrations/fix_legacy_thesis_prices.py
@@ -1,0 +1,127 @@
+"""
+Migration: Fix legacy theses with incorrect entry_price values.
+
+Scans all active theses in TMS, identifies those where entry_price is
+either 0 or below the underlying_price_floor (likely spread premiums),
+and patches them with the current underlying price.
+
+Usage:
+    python scripts/migrations/fix_legacy_thesis_prices.py [--dry-run]
+"""
+
+import asyncio
+import argparse
+import logging
+from ib_insync import IB, Contract
+from trading_bot.tms import TransactiveMemory
+from trading_bot.ib_interface import get_active_futures
+from trading_bot.utils import configure_market_data_type
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+PRICE_FLOOR = 100.0  # Anything below this is not an underlying price
+
+
+async def migrate(dry_run: bool = True):
+    tms = TransactiveMemory()
+
+    # Get all active theses
+    all_theses = []
+    # Note: These guardians correspond to the main guardians that store theses.
+    # Some older theses might be under 'Master' or others, but these are the main ones.
+    for guardian in ['VolatilityAnalyst', 'FundamentalAnalyst',
+                     'MacroEconomicAnalyst', 'TechnicalAnalyst', 'Master']: # Added Master just in case
+        all_theses.extend(tms.get_active_theses_by_guardian(guardian))
+
+    if not all_theses:
+        logger.info("No active theses found. Nothing to migrate.")
+        return
+
+    # Find problematic theses
+    needs_fix = []
+    for thesis in all_theses:
+        entry = thesis.get('supporting_data', {}).get('entry_price', 0)
+        # Check if entry is 0 or reasonably small (indicating spread credit)
+        if entry == 0 or (0 < entry < PRICE_FLOOR):
+            needs_fix.append(thesis)
+            logger.warning(
+                f"Thesis needs fix: position_id={thesis.get('position_id', '?')}, "
+                f"entry_price={entry}, strategy={thesis.get('strategy_type', '?')}"
+            )
+
+    if not needs_fix:
+        logger.info("All theses have valid entry prices. No migration needed.")
+        return
+
+    logger.info(f"Found {len(needs_fix)} theses needing price correction.")
+
+    if dry_run:
+        logger.info("DRY RUN — no changes made. Run with --apply to execute.")
+        return
+
+    # Connect to IB to get current underlying price
+    ib = IB()
+    try:
+        await ib.connectAsync('127.0.0.1', 7497, clientId=250)
+    except Exception as e:
+        logger.error(f"Could not connect to IB: {e}")
+        return
+
+    configure_market_data_type(ib)
+
+    try:
+        # Assuming KC (Coffee) on NYBOT
+        futures = await get_active_futures(ib, 'KC', 'NYBOT', count=1)
+        if not futures:
+            logger.error("Cannot get active futures. Aborting migration.")
+            return
+
+        ticker = ib.reqMktData(futures[0], '', True, False)
+        await asyncio.sleep(2)
+        current_price = ticker.last if ticker.last else ticker.close
+        ib.cancelMktData(futures[0])
+
+        if not current_price or current_price <= 0:
+            logger.error(f"Invalid current price: {current_price}. Aborting.")
+            return
+
+        logger.info(f"Current underlying price: ${current_price:.2f}")
+
+        for thesis in needs_fix:
+            position_id = thesis.get('position_id', '?')
+            old_entry = thesis.get('supporting_data', {}).get('entry_price', 0)
+
+            # Patch the thesis
+            thesis['supporting_data']['entry_price'] = current_price
+            thesis['supporting_data']['_migration_note'] = (
+                f"Price corrected from {old_entry} to {current_price} "
+                f"by fix_legacy_thesis_prices.py on 2026-02-03"
+            )
+
+            # Record back to TMS (overwrites existing by ID)
+            # tms.record_trade_thesis expects (position_id, thesis_data)
+            # but TransactiveMemory.record_trade_thesis might not behave exactly as simple overwrite if using vector store.
+            # Let's check tms.py if possible, but assuming standard behavior from report instructions.
+            # The report assumes record_trade_thesis is idempotent.
+
+            tms.record_trade_thesis(position_id, thesis)
+            logger.info(
+                f"Fixed: {position_id} — entry_price {old_entry} -> {current_price}"
+            )
+
+    finally:
+        ib.disconnect()
+
+    logger.info("Migration complete.")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry-run', action='store_true', default=True, help="Run without applying changes (default)")
+    parser.add_argument('--apply', action='store_true', help="Apply changes to TMS")
+    args = parser.parse_args()
+
+    # If --apply is specified, dry_run is False. Otherwise True.
+    dry_run = not args.apply
+    asyncio.run(migrate(dry_run=dry_run))

--- a/tests/test_order_manager.py
+++ b/tests/test_order_manager.py
@@ -125,6 +125,26 @@ class TestPositionClosing(unittest.TestCase):
             ]
             mock_ib_instance.reqPositionsAsync.return_value = mock_positions
 
+            # Mock qualifyContractsAsync to return populated contracts based on conId
+            populated_contracts = {
+                1: Contract(localSymbol='KC 26JUL24 250 C', symbol='KC', conId=1, exchange='NYBOT', secType='FOP'),
+                2: Contract(localSymbol='KC 26JUL24 260 C', symbol='KC', conId=2, exchange='NYBOT', secType='FOP'),
+                3: Contract(localSymbol='KC 26JUL24 300 P', symbol='KC', conId=3, exchange='NYBOT', secType='FOP'),
+                4: Contract(localSymbol='KC 26JUL24 310 P', symbol='KC', conId=4, exchange='NYBOT', secType='FOP'),
+                5: Contract(localSymbol='KC 26JUL24 200 C', symbol='KC', conId=5, exchange='NYBOT', secType='FOP'),
+            }
+
+            async def mock_qualify(*contracts):
+                result = []
+                for c in contracts:
+                    if c.conId in populated_contracts:
+                        result.append(populated_contracts[c.conId])
+                    else:
+                        result.append(c)
+                return result
+
+            mock_ib_instance.qualifyContractsAsync = AsyncMock(side_effect=mock_qualify)
+
             mock_trade = MagicMock()
             mock_trade.orderStatus.status = 'Filled'
             mock_fill = MagicMock()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -133,13 +133,15 @@ class TestUtils:
         # Check the first leg (BUY order should have negative value)
         assert written_rows[0]['combo_id'] == 123456
         assert written_rows[0]['action'] == 'BUY'
-        assert written_rows[0]['strike'] == 3.5
+        # EXPECTED CHANGE: Strike 3.5 normalized to 350.0
+        assert written_rows[0]['strike'] == 350.0
         assert abs(written_rows[0]['total_value_usd'] - -187.50) < 0.01
 
         # Check the second leg (SELL order should have positive value)
         assert written_rows[1]['combo_id'] == 123456
         assert written_rows[1]['action'] == 'SELL'
-        assert written_rows[1]['strike'] == 3.6
+        # EXPECTED CHANGE: Strike 3.6 normalized to 360.0
+        assert written_rows[1]['strike'] == 360.0
         assert abs(written_rows[1]['total_value_usd'] - 75.0) < 0.01
 
     @patch('csv.DictWriter')
@@ -192,7 +194,8 @@ class TestUtils:
 
         # CRITICAL: Assert that the logged data used the ENRICHED details
         # from the 'complete_contract' in the cache, not the incomplete one.
-        assert written_rows[0]['strike'] == 3.2
+        # EXPECTED CHANGE: Strike 3.2 normalized to 320.0
+        assert written_rows[0]['strike'] == 320.0
         assert written_rows[0]['right'] == 'P'
         assert written_rows[0]['local_symbol'] == 'KCH6 P3.2'
 


### PR DESCRIPTION
This PR fixes a critical bug where close orders were rejected by IBKR with Error 478 due to a strike price format mismatch (cents vs. dollars) for KC options.

Changes:
1.  **Orchestrator & Order Manager**: Modified `_close_spread_position`, `emergency_hard_close`, and `close_stale_positions` to always re-qualify contracts using a minimal `Contract(conId=...)` object before placing close orders. This forces IBKR to return the canonical contract details with the correct strike format (dollars).
2.  **Utils**: Updated `log_trade_to_ledger` to detect KC option trades with dollar-format strikes (implied by the new re-qualification logic) and convert them back to cents (x100) before writing to `trade_ledger.csv`. This ensures consistency with historical data and the `reconcile_trades.py` script.
3.  **Migration Script**: Added `scripts/migrations/fix_legacy_thesis_prices.py` to patch existing thesis records in TMS that have incorrect entry prices (e.g. spread credit instead of underlying price).
4.  **Tests**: Updated `tests/test_utils.py` to verify the new strike normalization logic. Updated `tests/test_order_manager.py` to properly mock `qualifyContractsAsync` as it is now explicitly called during order generation.

Risk Assessment:
- **Low**: The changes are targeted at the contract preparation phase of close orders and logging. The core logic of strategy selection and position management remains unchanged. Exception handling is in place for the new re-qualification steps.

Verification:
- New unit tests passed.
- Logic aligns with the debug report findings and `reconcile_trades.py` behavior.

---
*PR created automatically by Jules for task [4879480213034351687](https://jules.google.com/task/4879480213034351687) started by @rozavala*