### PR TITLE
Dashboard Health & Connectivity Fixes

### DIFF
--- a/trading_bot/sentinels.py
+++ b/trading_bot/sentinels.py
@@ -25,6 +25,15 @@ from config.commodity_profiles import get_commodity_profile, GrowingRegion
 
 logger = logging.getLogger(__name__)
 
+# Domain whitelists for prediction market filtering
+DOMAIN_KEYWORD_WHITELISTS = {
+    'coffee': ['coffee', 'arabica', 'robusta', 'kc', 'bean', 'starbucks', 'peet', 'roast', 'harvest', 'crop'],
+    'macro': ['fed', 'rate', 'inflation', 'cpi', 'fomc', 'powell', 'yield', 'treasury', 'dollar', 'dxy', 'recession', 'gdp', 'employment', 'jobs', 'economy', 'market'],
+    'geopolitical': ['war', 'conflict', 'tariff', 'sanction', 'election', 'trade', 'china', 'russia', 'ukraine', 'israel', 'iran', 'houthi', 'suez', 'canal', 'panama', 'trump', 'biden', 'president'],
+    'weather': ['rain', 'drought', 'frost', 'el nino', 'la nina', 'monsoon', 'hurricane', 'cyclone', 'typhoon', 'temp', 'precipitation'],
+    'logistics': ['port', 'shipping', 'container', 'freight', 'strike', 'union', 'rail', 'supply chain']
+}
+
 def with_retry(max_attempts: int = 3, backoff: float = 2.0):
     """Decorator for retrying failed async operations."""
     def decorator(func):


### PR DESCRIPTION
Fixed 6 issues in the Mission Control dashboard:
1. P0 Prediction Markets Radar crash: Switched to `load_state_with_metadata` to handle stale data gracefully.
2. P0 Topic Discovery notifications: Now using human-readable display names instead of opaque hash IDs.
3. P1 Council Page "nan" votes: Added robust NaN handling for agent sentiment display and radar chart.
4. P1 Master Decision fields: Added `safe_display` helper for v7.0 fields (reasoning, catalyst, etc.).
5. P1 Consensus Meter empty: Fixed logic to correctly display `0.0` scores and handle empty strings.
6. P2 Active Position stops: Suppressed "No stop defined" warning for multi-leg strategies (Iron Condor, etc.).

Also fixed a critical latent bug in `trading_bot/sentinels.py` where `DOMAIN_KEYWORD_WHITELISTS` was undefined, causing sentinel crashes (discovered during testing).

---
*PR created automatically by Jules for task [9759233702247484460](https://jules.google.com/task/9759233702247484460) started by @rozavala*