### PR TITLE
Fix Multi-Process Logging Conflict

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -7,6 +7,10 @@ Streamlit's native multi-page support handles routing via the pages/ directory.
 
 import streamlit as st
 from config_loader import load_config
+from trading_bot.logging_config import setup_logging
+
+# Set up dashboard-specific logging
+setup_logging(log_file="logs/dashboard.log")
 
 # Dynamic configuration for commodity-aware branding
 _cfg = load_config()

--- a/deploy.sh
+++ b/deploy.sh
@@ -48,7 +48,8 @@ rollback_and_restart() {
         # Ensure log directory exists and is writable before restarting
         mkdir -p logs
         chmod 755 logs 2>/dev/null || true
-        touch logs/orchestrator.log logs/dashboard.log 2>/dev/null || true
+        touch logs/orchestrator.log logs/dashboard.log logs/manual_test.log logs/performance_analyzer.log logs/equity_logger.log 2>/dev/null || true
+        chmod 664 logs/*.log 2>/dev/null || true
 
         # Restart with old code
         if [ -f "scripts/start_orchestrator.sh" ]; then
@@ -92,6 +93,12 @@ echo "--- 2. Rotating logs... ---"
 mkdir -p logs
 [ -f logs/orchestrator.log ] && mv logs/orchestrator.log logs/orchestrator-$(date --iso=s).log || true
 [ -f logs/dashboard.log ] && mv logs/dashboard.log logs/dashboard-$(date --iso=s).log || true
+
+# Ensure logs directory exists with correct permissions
+chmod 755 logs
+touch logs/orchestrator.log logs/dashboard.log logs/manual_test.log logs/performance_analyzer.log logs/equity_logger.log
+chmod 664 logs/*.log
+chown rodrigo:rodrigo logs/*.log 2>/dev/null || true
 
 # =========================================================================
 # STEP 3: Activate venv + install deps

--- a/equity_logger.py
+++ b/equity_logger.py
@@ -217,7 +217,7 @@ if __name__ == "__main__":
     parser.add_argument('--sync', action='store_true', help='Sync equity from Flex Query')
     args = parser.parse_args()
 
-    setup_logging()
+    setup_logging(log_file="logs/equity_logger.log")
     cfg = load_config()
 
     if cfg:

--- a/manual_test.py
+++ b/manual_test.py
@@ -5,7 +5,7 @@ from trading_bot.logging_config import setup_logging
 from trading_bot.order_manager import generate_and_queue_orders, generate_and_execute_orders
 
 # Initialize logging so you can see the output in your console/file
-setup_logging()
+setup_logging(log_file="logs/manual_test.log")
 logger = logging.getLogger("ManualTest")
 
 async def main():

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -60,7 +60,7 @@ from trading_bot.cycle_id import generate_cycle_id
 from trading_bot.strategy_router import route_strategy, infer_strategy_type
 
 # --- Logging Setup ---
-setup_logging()
+setup_logging(log_file="logs/orchestrator.log")
 logger = logging.getLogger("Orchestrator")
 
 # --- Global Process Handle for the monitor ---

--- a/performance_analyzer.py
+++ b/performance_analyzer.py
@@ -16,8 +16,6 @@ from trading_bot.decision_signals import get_decision_signals_df
 from trading_bot.performance_graphs import generate_performance_charts
 from config_loader import load_config
 
-# --- Logging Setup ---
-setup_logging()
 logger = logging.getLogger("PerformanceAnalyzer")
 
 # --- Constants ---
@@ -512,4 +510,5 @@ async def main(config: dict = None):
         )
 
 if __name__ == "__main__":
+    setup_logging(log_file="logs/performance_analyzer.log")
     asyncio.run(main())

--- a/position_monitor.py
+++ b/position_monitor.py
@@ -22,7 +22,7 @@ from trading_bot.risk_management import monitor_positions_for_risk
 from trading_bot.utils import configure_market_data_type
 
 # --- Logging Setup ---
-setup_logging()
+setup_logging(log_file=None)
 logger = logging.getLogger(__name__)
 
 

--- a/trading_bot/ib_interface.py
+++ b/trading_bot/ib_interface.py
@@ -19,9 +19,6 @@ from trading_bot.utils import (
     get_tick_size, get_contract_multiplier
 )
 
-# --- Logging Setup ---
-setup_logging()
-
 
 async def get_option_market_data(ib: IB, contract: Contract, underlying_future: Contract) -> dict | None:
     """

--- a/trading_bot/risk_management.py
+++ b/trading_bot/risk_management.py
@@ -26,9 +26,6 @@ from trading_bot.ib_interface import place_order, get_active_futures
 from notifications import send_pushover_notification
 from trading_bot.tms import TransactiveMemory
 
-# --- Logging Setup ---
-setup_logging()
-
 
 async def check_iron_condor_theses(ib: IB, config: dict):
     """

--- a/trading_bot/strategy.py
+++ b/trading_bot/strategy.py
@@ -14,9 +14,6 @@ from ib_insync import *
 from trading_bot.logging_config import setup_logging
 from trading_bot.utils import get_expiration_details
 
-# --- Logging Setup ---
-setup_logging()
-
 
 def find_closest_strike(target_strike: float, available_strikes: list[float]) -> float | None:
     """Finds the strike in a list that is closest to a target value.

--- a/trading_bot/utils.py
+++ b/trading_bot/utils.py
@@ -21,9 +21,6 @@ from scipy.stats import norm
 from trading_bot.logging_config import setup_logging
 from trading_bot.timestamps import format_ts
 
-# --- Logging Setup ---
-setup_logging()
-
 # --- COMMODITY PROFILE HELPERS (MECE Phase 0) ---
 CENTS_INDICATORS = ('cent', '¢', 'usc', 'pence', 'pennies')
 


### PR DESCRIPTION
This PR addresses a critical issue where multiple processes (Orchestrator, Dashboard, etc.) were attempting to write to the same log file (`logs/orchestrator.log`), causing permission errors and potential crashes.

Changes:
1.  **Logging Configuration**: `trading_bot/logging_config.py` now accepts an optional `log_file` parameter.
2.  **Process Isolation**:
    *   `orchestrator.py` -> `logs/orchestrator.log`
    *   `dashboard.py` -> `logs/dashboard.log`
    *   `manual_test.py` -> `logs/manual_test.log`
    *   `performance_analyzer.py` -> `logs/performance_analyzer.log`
    *   `equity_logger.py` -> `logs/equity_logger.log`
    *   `position_monitor.py` -> stdout (captured by parent process)
3.  **Library Cleanup**: Removed side-effect `setup_logging()` calls from `utils.py`, `strategy.py`, `ib_interface.py`, and `risk_management.py`.
4.  **Deployment**: Updated `deploy.sh` to ensure all new log files are created with correct permissions.
5.  **Log Collection**: Updated `scripts/collect_logs.sh` to selectively copy active log files, avoiding rotated archives.

This ensures robust, conflict-free logging for the multi-process architecture.

---
*PR created automatically by Jules for task [854092964350518795](https://jules.google.com/task/854092964350518795) started by @rozavala*