### PR TITLE
Make Sentinel Prompts Commodity-Agnostic

### DIFF
--- a/config/commodity_profiles.py
+++ b/config/commodity_profiles.py
@@ -125,6 +125,7 @@ class CommodityProfile:
     weather_apis: List[str] = field(default_factory=list)
     news_keywords: List[str] = field(default_factory=list)
     social_accounts: List[str] = field(default_factory=list)
+    sentiment_search_queries: List[str] = field(default_factory=list)  # Added for XSentimentSentinel
 
     # Risk thresholds
     volatility_high_iv_rank: float = 0.7
@@ -377,6 +378,17 @@ COFFEE_ARABICA_PROFILE = CommodityProfile(
         "zerohedge",          # Macro/markets commentary
         "Barchart",           # Commodity data & charts
         "WSJ"                 # Wall Street Journal markets
+    ],
+
+    sentiment_search_queries=[
+        "coffee futures",
+        "arabica prices",
+        "KC futures",
+        "robusta market",
+        "coffee supply",
+        "Brazil coffee harvest",
+        "coffee supply chain",
+        "US coffee tariffs",
     ],
 
     volatility_high_iv_rank=0.70,
@@ -655,6 +667,7 @@ def _load_profile_from_json(path: str) -> CommodityProfile:
         supply_chain_context=data.get('supply_chain_context', ''),
         # V3 FIX: Load remaining configurable fields (defaults match dataclass)
         social_accounts=data.get('social_accounts', []),
+        sentiment_search_queries=data.get('sentiment_search_queries', []),
         weather_apis=data.get('weather_apis', []),
         volatility_high_iv_rank=data.get('volatility_high_iv_rank', 0.7),
         volatility_low_iv_rank=data.get('volatility_low_iv_rank', 0.3),

--- a/tests/test_sentinel_agnostic.py
+++ b/tests/test_sentinel_agnostic.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from trading_bot.sentinels import NewsSentinel
+from config.commodity_profiles import CommodityProfile, ContractSpec, CommodityType
+
+@pytest.mark.asyncio
+async def test_news_sentinel_uses_commodity_profile():
+    """Verify NewsSentinel prompt uses commodity profile, not hardcoded 'Coffee'."""
+    config = {
+        'sentinels': {'news': {'rss_urls': ['http://test.rss'], 'sentiment_magnitude_threshold': 8, 'model': 'test'}},
+        'gemini': {'api_key': 'TEST'},
+        'commodity': {'ticker': 'CT'}  # Cotton, not coffee
+    }
+
+    mock_profile = CommodityProfile(
+        name="Cotton #2",
+        ticker="CT",
+        commodity_type=CommodityType.SOFT,
+        contract=ContractSpec(
+            symbol="CT",
+            exchange="ICE",
+            contract_months=[],
+            tick_size=0.01,
+            tick_value=500,
+            contract_size=50000,
+            unit="lbs",
+            trading_hours_utc=""
+        ),
+        sentiment_search_queries=["cotton futures"]
+    )
+
+    with patch('trading_bot.sentinels.get_commodity_profile', return_value=mock_profile), \
+         patch.object(NewsSentinel, '_fetch_rss_safe', new_callable=AsyncMock) as mock_rss, \
+         patch('google.genai.Client'):
+
+        mock_rss.return_value = ["Cotton prices surge on drought"]
+        sentinel = NewsSentinel(config)
+
+        # Verify profile loaded correctly
+        assert sentinel.profile.ticker == 'CT'
+        assert 'Coffee' not in sentinel.profile.name
+
+        # Capture the prompt sent to AI
+        prompts_sent = []
+        async def capture_prompt(prompt):
+            prompts_sent.append(prompt)
+            return {"score": 7, "summary": "Cotton surge"}
+
+        sentinel._analyze_with_ai = capture_prompt
+        await sentinel.check()
+
+        # Verify prompt uses Cotton, not Coffee
+        assert len(prompts_sent) == 1
+        assert 'Coffee' not in prompts_sent[0]
+        assert sentinel.profile.name in prompts_sent[0]
+        assert "Cotton #2" in prompts_sent[0]

--- a/tests/test_sentinel_crash_fixes.py
+++ b/tests/test_sentinel_crash_fixes.py
@@ -281,7 +281,7 @@ async def test_commodity_impact_field_in_trigger():
 
     # Mock a 20% swing (big enough to trigger)
     mock_response = [
-        {'slug': 'test-market', 'title': 'Test Market', 'markets': [
+        {'slug': 'test-market', 'title': 'Test Coffee Market', 'markets': [
             {'outcomePrices': ['0.70'], 'volume': '100000', 'liquidity': '50000'}
         ]}
     ]

--- a/tests/test_sentinels.py
+++ b/tests/test_sentinels.py
@@ -99,10 +99,11 @@ async def test_weather_sentinel_frost():
     # Mock requests.get
     with patch('requests.get') as mock_get:
         mock_response = MagicMock()
-        # Mock API response: 3.0 degrees (Frost)
+        # Mock API response: 1.0 degrees (Frost < 2.0)
         mock_response.json.return_value = {
             'daily': {
-                'temperature_2m_min': [10.0, 3.0, 12.0],
+                'time': ['2023-01-01', '2023-01-02', '2023-01-03'],
+                'temperature_2m_min': [10.0, 1.0, 12.0],
                 'precipitation_sum': [0.0, 0.0, 0.0]
             }
         }
@@ -114,7 +115,7 @@ async def test_weather_sentinel_frost():
         assert trigger is not None
         assert trigger.source == "WeatherSentinel"
         assert trigger.payload['type'] == "FROST"
-        assert trigger.payload['value'] == 3.0
+        assert trigger.payload['min_temp_c'] == 1.0
         # Check if URL was used
         assert 'http://test-weather.com' in mock_get.call_args[0][0]
 


### PR DESCRIPTION
This PR addresses the issue of hardcoded "Coffee" references in sentinel prompts, making them commodity-agnostic as per the V4.1 Addendum.

Changes:
1.  **Config**: Updated `CommodityProfile` to include `sentiment_search_queries` for configuring X search terms.
2.  **Sentinels**:
    *   `NewsSentinel`: Uses `profile.name` in prompts and adds an escape hatch for unrelated headlines.
    *   `XSentimentSentinel`: Uses `profile.name` in system prompt and `profile.sentiment_search_queries` for searching.
    *   `LogisticsSentinel`: Uses `profile.name` in prompt.
    *   `MacroContagionSentinel`: Uses `profile.name` in interpretation string.
3.  **Tests**:
    *   Added `tests/test_sentinel_agnostic.py`.
    *   Updated `tests/test_sentinel_crash_fixes.py` to include coffee keywords in mock data for PredictionMarketSentinel test (fixing a pre-existing or side-effect failure).
    *   Updated `tests/test_sentinels.py` to correct WeatherSentinel test mock data (fixing a pre-existing or side-effect failure).

---
*PR created automatically by Jules for task [14728140336433108012](https://jules.google.com/task/14728140336433108012) started by @rozavala*