### PR TITLE
Fix TypeError in trading_bot/calendars.py by importing Easter from pandas.tseries.offsets

### DIFF
--- a/trading_bot/calendars.py
+++ b/trading_bot/calendars.py
@@ -4,8 +4,7 @@ from pandas.tseries.holiday import (
     AbstractHolidayCalendar, Holiday, nearest_workday,
     USMemorialDay, USLaborDay, USThanksgivingDay, USFederalHolidayCalendar
 )
-from pandas.tseries.offsets import DateOffset
-from dateutil.easter import easter as Easter
+from pandas.tseries.offsets import DateOffset, Easter
 from datetime import date, timedelta
 import pandas as pd
 


### PR DESCRIPTION
The `ICEHolidayCalendar` class in `trading_bot/calendars.py` was failing to instantiate because it used `dateutil.easter.easter` in a `Holiday` definition. The `Holiday` class expects an offset, but `dateutil.easter.easter` is a function requiring a year argument.

This change updates the import to use `pandas.tseries.offsets.Easter`, which provides the correct offset behavior expected by pandas' `Holiday` class.

Verification:
- Created a reproduction script `reproduce_issue.py` which failed with `TypeError` before the fix and passed after.
- Ran `tests/test_order_manager.py` to ensure no regressions in dependent modules.


---
*PR created automatically by Jules for task [4778484959225997751](https://jules.google.com/task/4778484959225997751) started by @rozavala*