### PR TITLE
feat: Implement MANUAL Trigger Type for Dashboard-Forced Cycles

### DIFF
--- a/pages/5_Utilities.py
+++ b/pages/5_Utilities.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from dashboard_utils import get_config
+from trading_bot.weighted_voting import TriggerType
 
 # Load config at module level
 config = get_config()
@@ -227,7 +228,7 @@ with manual_cols[0]:
                     async def run_with_cleanup():
                         """Run order generation with guaranteed connection cleanup."""
                         try:
-                            await generate_and_execute_orders(config, connection_purpose="dashboard_orders")
+                            await generate_and_execute_orders(config, connection_purpose="dashboard_orders", trigger_type=TriggerType.MANUAL)
                         finally:
                             # Ensure pool connections are released before loop closes
                             try:

--- a/tests/test_signal_flow.py
+++ b/tests/test_signal_flow.py
@@ -32,7 +32,7 @@ async def test_neutral_direction_triggers_volatility_signal_low():
     # Mock Active Futures
     future_contract = Future(conId=1, lastTradeDateOrContractMonth='202512', localSymbol='KCZ25')
 
-    with patch('trading_bot.signal_generator.CoffeeCouncil') as council_cls_mock, \
+    with patch('trading_bot.signal_generator.TradingCouncil') as council_cls_mock, \
          patch('trading_bot.signal_generator.ComplianceGuardian'), \
          patch('trading_bot.signal_generator.get_active_futures', new_callable=AsyncMock) as get_futures_mock, \
          patch('trading_bot.signal_generator.build_all_market_contexts', new_callable=AsyncMock) as build_ctx_mock, \
@@ -103,7 +103,7 @@ async def test_neutral_direction_triggers_volatility_signal_high():
 
     future_contract = Future(conId=1, lastTradeDateOrContractMonth='202512', localSymbol='KCZ25')
 
-    with patch('trading_bot.signal_generator.CoffeeCouncil') as council_cls_mock, \
+    with patch('trading_bot.signal_generator.TradingCouncil') as council_cls_mock, \
          patch('trading_bot.signal_generator.ComplianceGuardian'), \
          patch('trading_bot.signal_generator.get_active_futures', new_callable=AsyncMock) as get_futures_mock, \
          patch('trading_bot.signal_generator.build_all_market_contexts', new_callable=AsyncMock) as build_ctx_mock, \

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -30,7 +30,7 @@ async def test_generate_signals():
 
     with patch('trading_bot.signal_generator.get_active_futures', new_callable=AsyncMock) as mock_get_active_futures, \
          patch('trading_bot.signal_generator.build_all_market_contexts', new_callable=AsyncMock) as mock_build, \
-         patch('trading_bot.signal_generator.CoffeeCouncil') as MockCouncil:
+         patch('trading_bot.signal_generator.TradingCouncil') as MockCouncil:
 
         mock_get_active_futures.return_value = mock_futures
         mock_build.return_value = mock_contexts

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -179,7 +179,7 @@ def _describe_bag(contract) -> str:
     return ticker
 
 
-async def generate_and_execute_orders(config: dict, connection_purpose: str = "orchestrator_orders", shutdown_check=None):
+async def generate_and_execute_orders(config: dict, connection_purpose: str = "orchestrator_orders", shutdown_check=None, trigger_type=None):
     """
     Generates, queues, and immediately places orders.
     This ensures that order placement isn't skipped if generation takes
@@ -210,7 +210,7 @@ async def generate_and_execute_orders(config: dict, connection_purpose: str = "o
         return
 
     logger.info(">>> Starting combined task: Generate and Execute Orders <<<")
-    await generate_and_queue_orders(config, connection_purpose=connection_purpose, shutdown_check=shutdown_check)
+    await generate_and_queue_orders(config, connection_purpose=connection_purpose, shutdown_check=shutdown_check, trigger_type=trigger_type)
 
     # Only proceed to placement if orders were actually queued
     if not ORDER_QUEUE.is_empty():
@@ -220,7 +220,7 @@ async def generate_and_execute_orders(config: dict, connection_purpose: str = "o
     logger.info(">>> Combined task 'Generate and Execute Orders' complete <<<")
 
 
-async def generate_and_queue_orders(config: dict, connection_purpose: str = "orchestrator_orders", shutdown_check=None):
+async def generate_and_queue_orders(config: dict, connection_purpose: str = "orchestrator_orders", shutdown_check=None, trigger_type=None):
     """
     Generates trading strategies based on market data and API predictions,
     and queues them for later execution.
@@ -236,7 +236,7 @@ async def generate_and_queue_orders(config: dict, connection_purpose: str = "orc
             logger.info(f"Connected to IB for signal generation (purpose: {connection_purpose}).")
 
             logger.info("Step 1: Generating structured signals via Council...")
-            signals = await generate_signals(ib, config, shutdown_check=shutdown_check)
+            signals = await generate_signals(ib, config, shutdown_check=shutdown_check, trigger_type=trigger_type)
             logger.info(f"Generated {len(signals)} signals: {signals}")
 
             futures = await get_active_futures(ib, config['symbol'], config['exchange'], count=5)


### PR DESCRIPTION
Implemented the "MANUAL Trigger Type for Dashboard-Forced Cycles" feature (v5.4).

Changes:
1.  **Signal Generator**: `generate_signals` now accepts an optional `trigger_type`. If provided (e.g., `TriggerType.MANUAL`), it overrides the internal logic that defaults to `SCHEDULED`.
2.  **Order Manager**: `generate_and_queue_orders` and `generate_and_execute_orders` now accept and pass through `trigger_type`.
3.  **Dashboard**: The "Force Generate & Execute Orders" button in `pages/5_Utilities.py` now explicitly passes `trigger_type=TriggerType.MANUAL`.
4.  **Tests**: Updated unit tests to fix pre-existing `AttributeError` caused by the `CoffeeCouncil` to `TradingCouncil` rename, enabling verification of the new logic.

Verification:
- Grep confirmed `trigger_type` threading through the call stack.
- Existing tests `test_signal_flow.py` and `test_signal_generator.py` pass (after mock fixes), confirming no regression in default behavior.
- Syntax checks passed for all modified files.

---
*PR created automatically by Jules for task [8553728528236053724](https://jules.google.com/task/8553728528236053724) started by @rozavala*