### PR TITLE
Fix dashboard P&L NaN, prediction market relevance, and signal overlay contract alignment

### DIFF
--- a/config.json
+++ b/config.json
@@ -254,6 +254,11 @@
       "min_volume_usd": 10000,
       "min_relevance_score": 1,
       "hwm_decay_hours": 24,
+      "global_exclude_keywords": [
+        "crypto", "bitcoin", "ethereum", "nft", "defi",
+        "nba", "nfl", "mlb", "sports", "football", "soccer",
+        "oscars", "grammy", "reality tv", "celebrity"
+      ],
       "providers": {
         "polymarket": {
           "api_url": "https://gamma-api.polymarket.com/events",
@@ -358,23 +363,28 @@
         {
           "name": "LatAm Geopolitics",
           "enabled": true,
+          "llm_validation_required": true,
           "discovery_methods": [
             {"type": "tag_scan", "tag_id": 100265, "limit": 15},
             {"type": "query", "q": "Colombia"},
-            {"type": "query", "q": "Latin America military"},
+            {"type": "query", "q": "Latin America"},
             {"type": "query", "q": "Venezuela"}
           ],
           "relevance_keywords": [
-            "colombia", "latin", "america", "venezuela", "brazil",
-            "mexico", "invade", "invasion", "military", "embargo",
-            "supply chain", "port", "blockade"
+            "colombia", "latin america", "venezuela", "brazil",
+            "mexico", "central america", "costa rica", "guatemala",
+            "honduras", "peru", "ecuador", "embargo",
+            "supply chain", "port strike", "blockade", "cartel"
           ],
-          "exclude_keywords": ["sports", "football", "soccer", "crypto"],
-          "min_relevance_score": 1,
+          "exclude_keywords": [
+            "russia", "nato", "ukraine", "china", "taiwan",
+            "middle east", "iran", "israel", "north korea"
+          ],
+          "min_relevance_score": 2,
           "max_topics": 2,
           "default_threshold_pct": 5.0,
           "importance": "supply_chain",
-          "commodity_impact_template": "LatAm geopolitical instability threatens coffee supply chains from origin countries"
+          "commodity_impact_template": "LatAm geopolitical instability threatens commodity supply chains from origin countries"
         },
         {
           "name": "Fed Leadership",

--- a/dashboard_utils.py
+++ b/dashboard_utils.py
@@ -629,7 +629,11 @@ def fetch_all_live_data(_config: dict) -> dict:
             ib.sleep(1)
             pnl_data = ib.pnl()
             if pnl_data:
-                result['daily_pnl'] = pnl_data[0].dailyPnL or 0.0
+                raw_pnl = pnl_data[0].dailyPnL
+                # NaN is truthy in Python, so `or 0.0` doesn't catch it.
+                # Must use explicit math.isnan() check.
+                import math
+                result['daily_pnl'] = 0.0 if (raw_pnl is None or math.isnan(raw_pnl)) else raw_pnl
 
         # Positions & Portfolio
         result['open_positions'] = ib.positions()

--- a/pages/1_Cockpit.py
+++ b/pages/1_Cockpit.py
@@ -213,7 +213,11 @@ def render_portfolio_risk_summary(live_data: dict):
             st.metric("Margin Util", "N/A")
 
     with cols[2]:
-        st.metric("Daily P&L", f"${daily_pnl:+,.0f}")
+        import math
+        if daily_pnl is None or (isinstance(daily_pnl, float) and math.isnan(daily_pnl)):
+            st.metric("Daily P&L", "$0", delta="No data", delta_color="off")
+        else:
+            st.metric("Daily P&L", f"${daily_pnl:+,.0f}")
 
     with cols[3]:
         pos_count = len([p for p in live_data.get('open_positions', []) if p.position != 0])


### PR DESCRIPTION
Implemented fixes for three high-priority dashboard bugs:
1.  **Daily P&L "$+nan":** Added robust `math.isnan` checks in `dashboard_utils.py` and `pages/1_Cockpit.py` to handle missing IBKR data gracefully.
2.  **Irrelevant Prediction Markets:** Enhanced `TopicDiscoveryAgent` with regex-based word boundary matching, a mandatory LLM validation gate for broad interest areas, and global exclude keywords. Updated `config.json` to refine the "LatAm Geopolitics" area and block crypto/sports topics globally.
3.  **Signal Overlay Misalignment:** Implemented `resolve_front_month_ticker` in `pages/6_Signal_Overlay.py` to dynamically select the correct front month based on DTE config, matching the trading engine's logic. Also fixed the contract dropdown sort order.

Verified with existing tests and frontend verification script (screenshots captured).

---
*PR created automatically by Jules for task [1585220830830746217](https://jules.google.com/task/1585220830830746217) started by @rozavala*