### PR TITLE
v5.3.1 Consolidated Confidence Parsing Fix

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -49,6 +49,7 @@ from trading_bot.ib_interface import (
 )
 from trading_bot.strategy import define_directional_strategy, define_volatility_strategy
 from trading_bot.state_manager import StateManager
+from trading_bot.confidence_utils import parse_confidence
 from trading_bot.connection_pool import IBConnectionPool
 from trading_bot.compliance import ComplianceGuardian
 from trading_bot.position_sizer import DynamicPositionSizer
@@ -208,7 +209,8 @@ def _extract_agent_prediction(report) -> tuple:
 
     if isinstance(report, dict):
         direction = report.get('sentiment', 'NEUTRAL')
-        confidence = report.get('confidence', 0.5)
+        # v5.3.1 FIX: Parse band strings to float at the source
+        confidence = parse_confidence(report.get('confidence', 0.5))
 
         # Fallback parsing if sentiment missing
         if not direction or direction in ('N/A', ''):
@@ -2500,7 +2502,7 @@ async def run_emergency_cycle(trigger: SentinelTrigger, config: dict, ib: IB):
                         record_agent_prediction(
                             agent=agent_name,
                             predicted_direction=direction,
-                            predicted_confidence=float(confidence),
+                            predicted_confidence=parse_confidence(confidence),
                             cycle_id=cycle_id,
                             regime=current_regime,
                             contract=target_contract.lastTradeDateOrContractMonth[:6] if target_contract else "",

--- a/trading_bot/agents.py
+++ b/trading_bot/agents.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass, field
 from google import genai
 from google.genai import types
+from trading_bot.confidence_utils import parse_confidence
 from trading_bot.state_manager import StateManager
 from trading_bot.sentinels import SentinelTrigger
 from trading_bot.semantic_router import SemanticRouter
@@ -736,7 +737,7 @@ OUTPUT FORMAT (JSON):
                 data = json.loads(self._clean_json_text(result_raw))
                 # Apply Confidence Correction (use min to never inflate)
                 if conf_adj is not None:
-                    original_conf = float(data.get('confidence', 0.5))
+                    original_conf = parse_confidence(data.get('confidence', 0.5))
                     adjusted_conf = min(original_conf, conf_adj)
                     logger.info(
                         f"[{persona_key}] Confidence clamped: "
@@ -763,7 +764,7 @@ OUTPUT FORMAT (JSON):
 
             structured_result = {
                 'data': formatted_text,
-                'confidence': float(data.get('confidence', 0.5)),
+                'confidence': parse_confidence(data.get('confidence', 0.5)),
                 'sentiment': data.get('sentiment', 'NEUTRAL'),
                 'data_freshness_hours': grounded_data.data_freshness_hours
             }
@@ -779,7 +780,7 @@ OUTPUT FORMAT (JSON):
                         grounded_data=grounded_data.raw_findings, # Fix B3: Populate grounded data
                         output_text=formatted_text,
                         sentiment=data.get('sentiment', 'NEUTRAL'),
-                        confidence=float(data.get('confidence', 0.5)),
+                        confidence=parse_confidence(data.get('confidence', 0.5)),
                         model_name=self.agent_model_name # Approximation, router might differ
                     )
                     self.observability.record_trace(trace)
@@ -854,7 +855,7 @@ OUTPUT FORMAT (JSON ONLY):
 
         return {
             'data': formatted_text,
-            'confidence': float(data.get('confidence', 0.5)),
+            'confidence': parse_confidence(data.get('confidence', 0.5)),
             'sentiment': data.get('sentiment', 'NEUTRAL')
         }
 

--- a/trading_bot/confidence_utils.py
+++ b/trading_bot/confidence_utils.py
@@ -1,0 +1,71 @@
+"""
+Shared confidence parsing utilities.
+
+v5.3.1: Canonical source of truth for confidence band mappings.
+All modules that need to convert LLM confidence output (band strings
+or numeric values) to floats should import from here.
+
+Commodity-agnostic: No commodity-specific logic.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# === CONFIDENCE BAND MAPPING ===
+# v7.0 philosophy: LLMs reason in categories, Python translates to numbers.
+# These values represent the midpoint of each band's semantic range.
+# If adding new bands, update ONLY this dict — all consumers import it.
+CONFIDENCE_BANDS = {
+    'LOW': 0.55,
+    'MODERATE': 0.65,
+    'HIGH': 0.80,
+    'EXTREME': 0.90,
+}
+
+
+def parse_confidence(raw_value, default: float = 0.5) -> float:
+    """
+    Parse confidence from LLM output — handles bands, numbers, and edge cases.
+
+    Supports:
+        - Band strings: 'HIGH', 'moderate', ' Low ' (case/whitespace insensitive)
+        - Numeric strings: '0.73', '0.5'
+        - Actual numbers: 0.73, 1
+        - Graceful fallback to `default` for anything unparseable
+
+    Args:
+        raw_value: The raw confidence value from LLM output or report dict.
+        default: Fallback value if parsing fails. Default 0.5 (neutral).
+
+    Returns:
+        float: Parsed confidence value, clamped to [0.0, 1.0].
+
+    Examples:
+        >>> parse_confidence('HIGH')
+        0.80
+        >>> parse_confidence(0.73)
+        0.73
+        >>> parse_confidence('GARBAGE')
+        0.5
+    """
+    if isinstance(raw_value, (int, float)):
+        return max(0.0, min(1.0, float(raw_value)))
+    if isinstance(raw_value, str):
+        upper = raw_value.strip().upper()
+        if upper in CONFIDENCE_BANDS:
+            return CONFIDENCE_BANDS[upper]
+        try:
+            return max(0.0, min(1.0, float(raw_value)))
+        except ValueError:
+            logger.warning(
+                f"Unparseable confidence value: '{raw_value}'. Using default {default}."
+            )
+            return default
+    # None, list, dict, or other unexpected types
+    if raw_value is not None:
+        logger.warning(
+            f"Unexpected confidence type: {type(raw_value).__name__} = {raw_value!r}. "
+            f"Using default {default}."
+        )
+    return default

--- a/trading_bot/signal_generator.py
+++ b/trading_bot/signal_generator.py
@@ -19,6 +19,7 @@ from trading_bot.state_manager import StateManager # Import StateManager
 from trading_bot.compliance import ComplianceGuardian
 from trading_bot.weighted_voting import calculate_weighted_decision, determine_trigger_type, TriggerType, detect_market_regime_simple
 from trading_bot.heterogeneous_router import CriticalRPCError
+from trading_bot.confidence_utils import parse_confidence
 from trading_bot.cycle_id import generate_cycle_id
 from trading_bot.brier_bridge import record_agent_prediction
 from trading_bot.strategy_router import (
@@ -706,7 +707,7 @@ async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_ty
                             record_agent_prediction(
                                 agent=agent_name,
                                 predicted_direction=direction,
-                                predicted_confidence=float(confidence),
+                                predicted_confidence=parse_confidence(confidence),
                                 cycle_id=cycle_id,
                                 regime=regime_log,
                                 contract=contract_name,
@@ -717,7 +718,7 @@ async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_ty
                         record_agent_prediction(
                             agent='master',
                             predicted_direction=decision.get('direction', 'NEUTRAL'),
-                            predicted_confidence=float(decision.get('confidence', 0.5)),
+                            predicted_confidence=parse_confidence(decision.get('confidence', 0.5)),
                             cycle_id=cycle_id,
                             regime=regime_log,
                             contract=contract_name,

--- a/trading_bot/weighted_voting.py
+++ b/trading_bot/weighted_voting.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from typing import Optional, Any
 from trading_bot.brier_bridge import get_agent_reliability
 from trading_bot.strategy_router import extract_agent_prediction
+from trading_bot.confidence_utils import CONFIDENCE_BANDS
 
 logger = logging.getLogger(__name__)
 
@@ -429,12 +430,6 @@ async def calculate_weighted_decision(
                 # v7.0 philosophy: LLMs output bands, not precise numbers.
                 # Map categorical confidence to fixed values. Fall back to
                 # numeric parsing for backward compatibility with cached reports.
-                CONFIDENCE_BANDS = {
-                    'LOW': 0.55,
-                    'MODERATE': 0.65,
-                    'HIGH': 0.80,
-                    'EXTREME': 0.90,
-                }
                 raw_conf = report.get('confidence', 0.5)
                 if isinstance(raw_conf, str) and raw_conf.upper() in CONFIDENCE_BANDS:
                     confidence = CONFIDENCE_BANDS[raw_conf.upper()]


### PR DESCRIPTION
Implemented v5.3.1 fix to consolidate confidence parsing and resolve crash caused by band strings (e.g. 'HIGH') being passed to `float()`. 

Changes:
1. Created `trading_bot/confidence_utils.py` with `parse_confidence` and `CONFIDENCE_BANDS`.
2. Updated `trading_bot/agents.py` to use `parse_confidence` (fixing 4 crash sites).
3. Updated `trading_bot/weighted_voting.py` to import `CONFIDENCE_BANDS` (DRY fix).
4. Updated `orchestrator.py` `_extract_agent_prediction` to return float confidence (Source fix).
5. Updated `trading_bot/signal_generator.py` and `orchestrator.py` Brier recording to use `parse_confidence`.

Verified via `verify_changes_v531.py` with mocked dependencies.

---
*PR created automatically by Jules for task [14837918214026713031](https://jules.google.com/task/14837918214026713031) started by @rozavala*