### PR TITLE
📊 Quant: Fix position sizing on negative account value

### DIFF
--- a/tests/test_position_sizer.py
+++ b/tests/test_position_sizer.py
@@ -1,0 +1,47 @@
+import unittest
+import asyncio
+from unittest.mock import MagicMock, AsyncMock
+from trading_bot.position_sizer import DynamicPositionSizer
+
+class TestDynamicPositionSizer(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            'strategy': {'quantity': 1},
+            'risk_management': {'max_heat_pct': 0.25}
+        }
+        self.sizer = DynamicPositionSizer(self.config)
+        self.ib = MagicMock()
+        # Mock reqPositionsAsync to return empty list by default
+        self.ib.reqPositionsAsync = AsyncMock(return_value=[])
+
+    def test_calculate_size_normal(self):
+        async def run():
+            signal = {'confidence': 1.0, 'prediction_type': 'DIRECTIONAL'}
+            size = await self.sizer.calculate_size(
+                self.ib, signal, 'NEUTRAL', account_value=100000.0
+            )
+            self.assertGreater(size, 0)
+        asyncio.run(run())
+
+    def test_calculate_size_negative_account_value(self):
+        async def run():
+            signal = {'confidence': 1.0, 'prediction_type': 'DIRECTIONAL'}
+            # Expecting 0 size when account value is negative
+            size = await self.sizer.calculate_size(
+                self.ib, signal, 'NEUTRAL', account_value=-5000.0
+            )
+            self.assertEqual(size, 0, "Should return 0 size for negative account value")
+        asyncio.run(run())
+
+    def test_calculate_size_zero_account_value(self):
+        async def run():
+            signal = {'confidence': 1.0, 'prediction_type': 'DIRECTIONAL'}
+            # Expecting 0 size when account value is zero
+            size = await self.sizer.calculate_size(
+                self.ib, signal, 'NEUTRAL', account_value=0.0
+            )
+            self.assertEqual(size, 0, "Should return 0 size for zero account value")
+        asyncio.run(run())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/trading_bot/position_sizer.py
+++ b/trading_bot/position_sizer.py
@@ -27,6 +27,10 @@ class DynamicPositionSizer:
                 0.75 = partial alignment
                 0.5 = vote diverges (half size)
         """
+        # Safety check: No trading if account value is non-positive
+        if account_value <= 0:
+            logger.warning(f"Account value is {account_value}. Returning size 0.")
+            return 0
 
         # Base size from confidence
         confidence = signal.get('confidence', 0.5)

--- a/uv.lock
+++ b/uv.lock
@@ -300,6 +300,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "feedparser" },
     { name = "fredapi" },
     { name = "ib-insync" },
     { name = "nasdaq-data-link" },
@@ -323,6 +324,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi" },
+    { name = "feedparser" },
     { name = "fredapi" },
     { name = "ib-insync" },
     { name = "nasdaq-data-link" },
@@ -405,6 +407,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7e/7e/d9788300deaf416178f61fb3c2ceb16b7d0dc9f82a08fdb87a5e64ee3cc7/fastapi-0.117.1.tar.gz", hash = "sha256:fb2d42082d22b185f904ca0ecad2e195b851030bd6c5e4c032d1c981240c631a", size = 307155, upload-time = "2025-09-20T20:16:56.663Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/45/d9d3e8eeefbe93be1c50060a9d9a9f366dba66f288bb518a9566a23a8631/fastapi-0.117.1-py3-none-any.whl", hash = "sha256:33c51a0d21cab2b9722d4e56dbb9316f3687155be6b276191790d8da03507552", size = 95959, upload-time = "2025-09-20T20:16:53.661Z" },
+]
+
+[[package]]
+name = "feedparser"
+version = "6.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sgmllib3k" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/79/db7edb5e77d6dfbc54d7d9df72828be4318275b2e580549ff45a962f6461/feedparser-6.0.12.tar.gz", hash = "sha256:64f76ce90ae3e8ef5d1ede0f8d3b50ce26bcce71dd8ae5e82b1cd2d4a5f94228", size = 286579, upload-time = "2025-09-10T13:33:59.486Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/eb/c96d64137e29ae17d83ad2552470bafe3a7a915e85434d9942077d7fd011/feedparser-6.0.12-py3-none-any.whl", hash = "sha256:6bbff10f5a52662c00a2e3f86a38928c37c48f77b3c511aedcd51de933549324", size = 81480, upload-time = "2025-09-10T13:33:58.022Z" },
 ]
 
 [[package]]
@@ -1348,6 +1362,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/61/82/8d0e39f62764cce5ffd5284131e109f07cf8955aef9ab8ed4e3aa5e30539/scipy-1.16.3-cp314-cp314t-win_amd64.whl", hash = "sha256:d9f48cafc7ce94cf9b15c6bffdc443a81a27bf7075cf2dcd5c8b40f85d10c4e7", size = 39471128, upload-time = "2025-10-28T17:38:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/64/47/a494741db7280eae6dc033510c319e34d42dd41b7ac0c7ead39354d1a2b5/scipy-1.16.3-cp314-cp314t-win_arm64.whl", hash = "sha256:21d9d6b197227a12dcbf9633320a4e34c6b0e51c57268df255a0942983bac562", size = 26464127, upload-time = "2025-10-28T17:38:11.34Z" },
 ]
+
+[[package]]
+name = "sgmllib3k"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
 
 [[package]]
 name = "six"


### PR DESCRIPTION
This PR addresses a critical edge case in `trading_bot/position_sizer.py` where a negative or zero account value would result in a calculated position size (defaulting to 1 due to `max(1, ...)` logic), potentially leading to trading while insolvent.

Changes:
1.  Modified `DynamicPositionSizer.calculate_size` to return `0` immediately if `account_value <= 0`.
2.  Added `tests/test_position_sizer.py` to test:
    *   Negative account value (returns 0).
    *   Zero account value (returns 0).
    *   Normal positive account value (returns > 0).

Verification:
- `uv run pytest tests/test_position_sizer.py` passed.
- `uv run env PYTHONPATH=. pytest tests/test_order_manager.py` passed (regression check).

---
*PR created automatically by Jules for task [4105731773528089834](https://jules.google.com/task/4105731773528089834) started by @rozavala*