### PR TITLE
Fix SentinelStats missing methods (record_error, get_all)

### DIFF
--- a/tests/test_ws_changes.py
+++ b/tests/test_ws_changes.py
@@ -36,5 +36,63 @@ class TestWSChanges(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(dashboard["TestSentinel"]["trades_triggered"], 1)
         self.assertEqual(dashboard["TestSentinel"]["conversion_rate"], 1.0)
 
+    def test_sentinel_stats_record_error(self):
+        """Test record_error method exists and works."""
+        if STATS_FILE.exists():
+            os.remove(STATS_FILE)
+
+        stats = SentinelStats()
+        stats.record_error("TestSentinel", "TIMEOUT")
+        stats.record_error("TestSentinel", "TIMEOUT")
+
+        raw = stats.get_all()
+        self.assertIn("TestSentinel", raw)
+        from datetime import datetime, timezone
+        today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+        self.assertEqual(raw["TestSentinel"]["errors"][today], 2)
+        self.assertEqual(raw["TestSentinel"]["total_alerts"], 0)  # Errors != alerts
+
+        # Check dashboard stats
+        dashboard = stats.get_dashboard_stats()
+        self.assertEqual(dashboard["TestSentinel"]["errors_today"], 2)
+
+    def test_sentinel_stats_get_all(self):
+        """Test get_all returns raw sentinel dict."""
+        if STATS_FILE.exists():
+            os.remove(STATS_FILE)
+
+        stats = SentinelStats()
+        stats.record_alert("Alpha", True)
+        stats.record_alert("Beta", False)
+
+        raw = stats.get_all()
+        self.assertIn("Alpha", raw)
+        self.assertIn("Beta", raw)
+        self.assertEqual(raw["Alpha"]["trades_triggered"], 1)
+        self.assertEqual(raw["Beta"]["trades_triggered"], 0)
+
+    def test_sentinel_stats_backward_compat(self):
+        """Test that record_error works on entries created by record_alert (no 'errors' key)."""
+        if STATS_FILE.exists():
+            os.remove(STATS_FILE)
+
+        stats = SentinelStats()
+        stats.record_alert("Legacy", True)  # Creates entry without 'errors' key
+
+        # Remove 'errors' key to simulate pre-existing data
+        # Note: In the new implementation record_alert doesn't add 'errors' key,
+        # but let's be explicit about removing it if it was added implicitly
+        if 'errors' in stats.stats['sentinels']['Legacy']:
+            del stats.stats['sentinels']['Legacy']['errors']
+        stats._save_stats()
+
+        # Reload and record error — should not crash
+        stats2 = SentinelStats()
+        stats2.record_error("Legacy", "TIMEOUT")
+
+        from datetime import datetime, timezone
+        today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+        self.assertEqual(stats2.stats['sentinels']['Legacy']['errors'][today], 1)
+
 if __name__ == "__main__":
     unittest.main()

--- a/trading_bot/sentinel_stats.py
+++ b/trading_bot/sentinel_stats.py
@@ -63,9 +63,55 @@ class SentinelStats:
 
         self._save_stats()
 
+    def record_error(self, sentinel_name: str, error_type: str):
+        """
+        Record a sentinel error (timeout, crash, API failure, etc.).
+
+        Called by:
+        - All 8 sentinel timeout handlers in run_sentinels() (Fix 0)
+        - _emergency_cycle_done_callback() crash handler (Fix 8)
+
+        Args:
+            sentinel_name: Name of the sentinel (e.g., 'WeatherSentinel')
+            error_type: Type of error (e.g., 'TIMEOUT', 'CRASH: ValueError')
+        """
+        if sentinel_name not in self.stats['sentinels']:
+            self.stats['sentinels'][sentinel_name] = {
+                'total_alerts': 0,
+                'trades_triggered': 0,
+                'last_alert': None,
+                'daily_counts': {},
+                'errors': {}
+            }
+
+        s = self.stats['sentinels'][sentinel_name]
+
+        # Ensure 'errors' key exists (backward compat with pre-existing stats)
+        if 'errors' not in s:
+            s['errors'] = {}
+
+        today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+        s['errors'][today] = s['errors'].get(today, 0) + 1
+
+        self._save_stats()
+
+    def get_all(self) -> dict:
+        """
+        Get raw stats dict for all sentinels.
+
+        Called by sentinel_effectiveness_check() (Fix 7) which reads:
+        - s.get('total_alerts', 0)
+        - s.get('trades_triggered', 0)
+
+        Returns:
+            Dict of {sentinel_name: stats_dict}
+        """
+        return self.stats.get('sentinels', {})
+
     def get_dashboard_stats(self) -> dict:
         """Get stats formatted for dashboard display."""
         result = {}
+        today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
 
         for name, data in self.stats.get('sentinels', {}).items():
             total = data['total_alerts']
@@ -76,9 +122,8 @@ class SentinelStats:
                 'trades_triggered': trades,
                 'conversion_rate': trades / total if total > 0 else 0,
                 'last_alert': data['last_alert'],
-                'alerts_today': data['daily_counts'].get(
-                    datetime.now(timezone.utc).strftime('%Y-%m-%d'), 0
-                )
+                'alerts_today': data['daily_counts'].get(today, 0),
+                'errors_today': data.get('errors', {}).get(today, 0)
             }
 
         return result


### PR DESCRIPTION
Added missing methods record_error and get_all to SentinelStats to fix AttributeError in orchestrator loop. Also updated dashboard stats and added tests.

---
*PR created automatically by Jules for task [14850606381273582492](https://jules.google.com/task/14850606381273582492) started by @rozavala*