### PR TITLE
Fix Brier dashboard displaying 1.0 multiplier by normalizing agent names

### DIFF
--- a/pages/7_Brier_Analysis.py
+++ b/pages/7_Brier_Analysis.py
@@ -251,8 +251,8 @@ try:
     from trading_bot.brier_bridge import get_agent_reliability
     from trading_bot.agent_names import AGENT_DISPLAY_NAMES
 
-    agent_names = list(AGENT_DISPLAY_NAMES.values()) if hasattr(AGENT_DISPLAY_NAMES, 'values') else [
-        'agronomist', 'fundamentalist', 'macro', 'sentiment',
+    agent_names = list(AGENT_DISPLAY_NAMES.keys()) if hasattr(AGENT_DISPLAY_NAMES, 'keys') else [
+        'agronomist', 'inventory', 'macro', 'sentiment',
         'technical', 'volatility', 'geopolitical'
     ]
 
@@ -262,7 +262,7 @@ try:
             mult = get_agent_reliability(agent, regime)
             if mult != 1.0 or regime == 'NORMAL':
                 weight_rows.append({
-                    'Agent': agent,
+                    'Agent': AGENT_DISPLAY_NAMES.get(agent, agent),
                     'Regime': regime,
                     'Multiplier': round(mult, 3),
                     'Status': '🟢 Trusted' if mult > 1.2 else '🔴 Distrusted' if mult < 0.8 else '⚪ Baseline',

--- a/trading_bot/brier_bridge.py
+++ b/trading_bot/brier_bridge.py
@@ -157,6 +157,9 @@ def get_agent_reliability(agent_name: str, regime: str = "NORMAL", window: int =
     - Brier ~0.5  → 0.1x (poor calibration)
     """
     try:
+        from trading_bot.agent_names import normalize_agent_name
+        agent_name = normalize_agent_name(agent_name)
+
         tracker = _get_enhanced_tracker()
         if tracker is None:
             return 1.0

--- a/trading_bot/enhanced_brier.py
+++ b/trading_bot/enhanced_brier.py
@@ -274,6 +274,10 @@ class EnhancedBrierTracker:
             - 1.0 = baseline reliability (Brier ~0.25)
             - 2.0 = very reliable (Brier close to 0)
         """
+        # FIX (P1-C, 2026-02-06): Normalize agent name to prevent lookup misses.
+        from trading_bot.agent_names import normalize_agent_name
+        agent = normalize_agent_name(agent)
+
         scores = self.agent_scores.get(agent, {}).get(regime, [])
 
         if len(scores) < 5:


### PR DESCRIPTION
Fixed Brier Analysis dashboard showing all agents at 1.0 multiplier. The issue was caused by using display names (e.g., '🌦️ Meteorologist') for data lookup instead of canonical names (e.g., 'agronomist').

Changes:
- **Dashboard (`pages/7_Brier_Analysis.py`)**: Modified to iterate over `AGENT_DISPLAY_NAMES.keys()` (canonical) instead of values. Updated table display to map canonical names back to display names.
- **Bridge (`trading_bot/brier_bridge.py`)**: Added `normalize_agent_name` call in `get_agent_reliability` to ensure robustness against aliases.
- **Tracker (`trading_bot/enhanced_brier.py`)**: Added `normalize_agent_name` in `get_agent_reliability` as defense-in-depth.

Verified with local reproduction script and Playwright verification of the dashboard.

---
*PR created automatically by Jules for task [3520593541507616952](https://jules.google.com/task/3520593541507616952) started by @rozavala*