### PR TITLE
Fix Brier Test & Dashboard Regime Display

### DIFF
--- a/pages/7_Brier_Analysis.py
+++ b/pages/7_Brier_Analysis.py
@@ -258,7 +258,7 @@ try:
 
     weight_rows = []
     for agent in agent_names:
-        for regime in ['NORMAL', 'HIGH_VOL', 'WEATHER_EVENT', 'MACRO_SHIFT']:
+        for regime in ['NORMAL', 'HIGH_VOL', 'RANGE_BOUND', 'WEATHER_EVENT', 'MACRO_SHIFT']:
             mult = get_agent_reliability(agent, regime)
             if mult != 1.0 or regime == 'NORMAL':
                 weight_rows.append({

--- a/tests/test_brier_bridge.py
+++ b/tests/test_brier_bridge.py
@@ -61,7 +61,7 @@ class TestGetAgentReliability(unittest.TestCase):
 
         # Setup: HIGH_VOLATILITY returns 1.0 (no data), NORMAL returns 1.5
         def side_effect(agent, regime):
-            if regime == "HIGH_VOLATILITY":
+            if regime == "HIGH_VOL":
                 return 1.0
             if regime == "NORMAL":
                 return 1.5
@@ -77,7 +77,7 @@ class TestGetAgentReliability(unittest.TestCase):
 
         # Verify both calls were made
         expected_calls = [
-            unittest.mock.call('agronomist', 'HIGH_VOLATILITY'),
+            unittest.mock.call('agronomist', 'HIGH_VOL'),
             unittest.mock.call('agronomist', 'NORMAL')
         ]
         mock_tracker.get_agent_reliability.assert_has_calls(expected_calls)


### PR DESCRIPTION
This PR addresses two "quick fix" items resulting from post-harmonization cleanup:

1.  **Test Fix (`tests/test_brier_bridge.py`):**
    -   The `test_regime_fallback_to_normal` test was failing `assert_has_calls` because the code now normalizes "HIGH_VOLATILITY" to "HIGH_VOL" before calling the tracker.
    -   The test mock was updated to handle "HIGH_VOL" instead of "HIGH_VOLATILITY" in both the side effect and the expected calls list.
    -   This aligns the test with the actual implementation where `normalize_regime` is called.

2.  **Dashboard Update (`pages/7_Brier_Analysis.py`):**
    -   Added `RANGE_BOUND` to the list of regimes iterated over in the "Current Reliability Multipliers" section.
    -   This ensures that as data accumulates for this new regime, it will be visible in the Mission Control dashboard.

Verified by running the unit test `tests/test_brier_bridge.py` (passed). Dashboard change is a static list update safe for display-only verification.

---
*PR created automatically by Jules for task [9178016070309529343](https://jules.google.com/task/9178016070309529343) started by @rozavala*