### PR TITLE
Fix Enhanced Brier Pipeline Gap (50 Stuck Predictions)

### DIFF
--- a/tests/test_brier_bridge.py
+++ b/tests/test_brier_bridge.py
@@ -8,6 +8,7 @@ from trading_bot.brier_bridge import (
     resolve_agent_prediction,
     get_agent_reliability,
     _confidence_to_probs,
+    backfill_enhanced_from_csv,
 )
 
 
@@ -105,6 +106,19 @@ class TestRecordAgentPrediction(unittest.TestCase):
 
         # Verify enhanced was called
         mock_enhanced_tracker.record_prediction.assert_called_once()
+
+
+class TestBackfill(unittest.TestCase):
+    @patch('trading_bot.brier_bridge._get_enhanced_tracker')
+    def test_backfill_calls_tracker(self, mock_get_tracker):
+        mock_tracker = MagicMock()
+        mock_get_tracker.return_value = mock_tracker
+        mock_tracker.backfill_from_resolved_csv.return_value = 5
+
+        result = backfill_enhanced_from_csv()
+
+        self.assertEqual(result, 5)
+        mock_tracker.backfill_from_resolved_csv.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/trading_bot/brier_bridge.py
+++ b/trading_bot/brier_bridge.py
@@ -141,6 +141,28 @@ def resolve_agent_prediction(
         return None
 
 
+def backfill_enhanced_from_csv() -> int:
+    """
+    Catch-up: resolve Enhanced Brier predictions using already-resolved CSV data.
+
+    Called from orchestrator's run_brier_reconciliation to handle the pipeline
+    gap where fix_brier_data.py resolves the CSV without updating the JSON.
+
+    Returns:
+        Number of predictions backfilled
+    """
+    try:
+        tracker = _get_enhanced_tracker()
+        if tracker is None:
+            return 0
+
+        return tracker.backfill_from_resolved_csv()
+
+    except Exception as e:
+        logger.warning(f"Enhanced Brier backfill failed (non-fatal): {e}")
+        return 0
+
+
 def get_agent_reliability(agent_name: str, regime: str = "NORMAL", window: int = 20) -> float:
     """
     Rolling reliability multiplier from Enhanced Brier scores.


### PR DESCRIPTION
Implemented a catch-up mechanism to resolve 50+ stuck pending predictions in `enhanced_brier.json`. The fix introduces a backfill step in the Brier reconciliation process that reads resolved outcomes from `agent_accuracy_structured.csv` and updates the corresponding entries in the Enhanced Brier tracker.

Key changes:
1.  **EnhancedBrierTracker**: Added `backfill_from_resolved_csv` method.
2.  **BrierBridge**: Added `backfill_enhanced_from_csv` wrapper.
3.  **Orchestrator**: Called backfill logic after standard reconciliation.
4.  **Tests**: Added verification test case.

---
*PR created automatically by Jules for task [4244830911092400857](https://jules.google.com/task/4244830911092400857) started by @rozavala*