### PR TITLE
🌿 Gardener: Refactor run_sentinels in orchestrator

### DIFF
--- a/tests/test_sentinel_loop.py
+++ b/tests/test_sentinel_loop.py
@@ -11,6 +11,8 @@ class TestSentinelLoop(unittest.IsolatedAsyncioTestCase):
     @patch('orchestrator.LogisticsSentinel')
     @patch('orchestrator.NewsSentinel')
     @patch('orchestrator.XSentimentSentinel')
+    @patch('orchestrator.PredictionMarketSentinel')
+    @patch('orchestrator.MacroContagionSentinel')
     @patch('orchestrator.MicrostructureSentinel')
     @patch('orchestrator.is_market_open')
     @patch('orchestrator.is_trading_day')
@@ -19,7 +21,7 @@ class TestSentinelLoop(unittest.IsolatedAsyncioTestCase):
     @patch('orchestrator.get_active_futures', new_callable=AsyncMock)
     async def test_run_sentinels_lazy_init_and_market_hours(
         self, mock_get_futures, mock_dedup, mock_configure, mock_is_trading, mock_is_market_open,
-        mock_micro_class, mock_x_class, mock_news_class, mock_logistics_class,
+        mock_micro_class, mock_macro_class, mock_prediction_class, mock_x_class, mock_news_class, mock_logistics_class,
         mock_weather_class, mock_price_class, mock_ib_pool
     ):
         # Setup mocks


### PR DESCRIPTION
Extracted `_run_periodic_sentinel` helper function in `orchestrator.py` to reduce code duplication in `run_sentinels`. This simplifies the main sentinel loop by encapsulating the common pattern of checking time interval, executing the check, validating the trigger, handling the emergency cycle, and recording health/stats.

Also patched `tests/test_sentinel_loop.py` to include mocks for `PredictionMarketSentinel` and `MacroContagionSentinel`, fixing a test failure caused by missing API keys in the test environment.

---
*PR created automatically by Jules for task [14291166943139641218](https://jules.google.com/task/14291166943139641218) started by @rozavala*