### PR TITLE
Fix 5 critical safety issues in trading system

### DIFF
--- a/trading_bot/decision_signals.py
+++ b/trading_bot/decision_signals.py
@@ -131,7 +131,9 @@ def log_decision_signal(
                             full_df[col] = None
                     full_df = full_df[SCHEMA_COLUMNS]
                     combined = pd.concat([full_df, new_row], ignore_index=True)
-                    combined.to_csv(SIGNALS_FILE_PATH, index=False)
+                    temp_path = SIGNALS_FILE_PATH + ".tmp"
+                    combined.to_csv(temp_path, index=False)
+                    os.replace(temp_path, SIGNALS_FILE_PATH)
                 else:
                     new_row.to_csv(SIGNALS_FILE_PATH, mode='a', header=False, index=False)
             except pd.errors.EmptyDataError:

--- a/trading_bot/utils.py
+++ b/trading_bot/utils.py
@@ -613,8 +613,10 @@ def log_council_decision(decision_data):
                 # Reorder columns to match new schema
                 full_df = full_df[fieldnames]
 
-                # Write back migrated data
-                full_df.to_csv(file_path, index=False)
+                # Write back migrated data (atomic: temp file + rename)
+                temp_path = file_path + ".tmp"
+                full_df.to_csv(temp_path, index=False)
+                os.replace(temp_path, file_path)
                 logging.info(f"Schema migration complete. {len(full_df)} records preserved.")
 
         except pd.errors.EmptyDataError:


### PR DESCRIPTION
## Summary

- **Crash cooldown:** Add 30-min cooldown in `_emergency_cycle_done_callback` so a crashing sentinel doesn't immediately re-trigger the same crash in a loop
- **Lock timeout:** Add 300s timeout to `EMERGENCY_LOCK` acquisition so a hung emergency cycle doesn't block all subsequent triggers indefinitely
- **Connection leak guards:** Wrap all 5 short-lived IB connection sites (`cleanup`, `audit`, `orchestrator_orders`, `drawdown_check`, `deferred`) in `try/finally` with `release_connection` to prevent pool exhaustion on errors
- **DA fail-closed:** Change Devil's Advocate parse-failure default from PROCEED to BLOCK — ambiguous or unparseable DA responses now block the trade instead of silently approving it
- **Atomic CSV writes:** Use `temp file + os.replace()` for schema migration rewrites in `decision_signals.py` and `utils.py` to prevent data corruption if the process crashes mid-write

## Test plan

- [x] Full test suite: zero new failures (75 pre-existing failures, identical to `main`)
- [x] Verified crash cooldown: `set_cooldown` present in callback
- [x] Verified lock timeout: `wait_for(EMERGENCY_LOCK.acquire(), timeout=300)` in place
- [x] Verified connection releases: `release_connection` in `finally` block for all 5 functions
- [x] Verified DA fail-closed: `proceed = False` in both ambiguous and total-failure paths
- [x] Verified atomic writes: `os.replace` in both `decision_signals.py` and `utils.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)