### PR TITLE
Add IB timeouts to all remaining async calls across 8 modules

### DIFF
--- a/trading_bot/drawdown_circuit_breaker.py
+++ b/trading_bot/drawdown_circuit_breaker.py
@@ -97,7 +97,7 @@ class DrawdownGuard:
 
         try:
             # 1. Get Account Summary
-            summary = await ib.accountSummaryAsync()
+            summary = await asyncio.wait_for(ib.accountSummaryAsync(), timeout=10)
             net_liq = 0.0
 
             for item in summary:

--- a/trading_bot/market_data_provider.py
+++ b/trading_bot/market_data_provider.py
@@ -217,14 +217,14 @@ async def _get_technical_indicators(
     volatility_5d = None
 
     try:
-        bars = await ib.reqHistoricalDataAsync(
+        bars = await asyncio.wait_for(ib.reqHistoricalDataAsync(
             contract,
             endDateTime='',
             durationStr=HISTORICAL_DATA_DURATION,
             barSizeSetting='1 day',
             whatToShow='TRADES',
             useRTH=True
-        )
+        ), timeout=10)
 
         if not bars or len(bars) < 5:
             logger.warning(f"Insufficient historical data for {contract.localSymbol}: {len(bars) if bars else 0} bars")

--- a/trading_bot/signal_generator.py
+++ b/trading_bot/signal_generator.py
@@ -334,14 +334,14 @@ async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_ty
 
                 try:
                     # End time = now, Duration = 1 week, Bar size = 1 day
-                    bars = await ib.reqHistoricalDataAsync(
+                    bars = await asyncio.wait_for(ib.reqHistoricalDataAsync(
                         contract,
                         endDateTime='',
                         durationStr='1 W',
                         barSizeSetting='1 day',
                         whatToShow='TRADES',
                         useRTH=True
-                    )
+                    ), timeout=10)
 
                     if bars and len(bars) >= 2:
                         current_close = bars[-1].close

--- a/trading_bot/weighted_voting.py
+++ b/trading_bot/weighted_voting.py
@@ -7,6 +7,7 @@ Domain experts get higher weights on relevant events:
 - Geopolitical Analyst gets 3x weight on logistics events
 """
 
+import asyncio
 import logging
 import re
 import json
@@ -276,9 +277,9 @@ class RegimeDetector:
             return 'UNKNOWN'
 
         try:
-            bars = await ib.reqHistoricalDataAsync(
+            bars = await asyncio.wait_for(ib.reqHistoricalDataAsync(
                 contract, '', '5 D', '1 day', 'TRADES', True
-            )
+            ), timeout=10)
             if not bars or len(bars) < 2:
                 return 'UNKNOWN'
 


### PR DESCRIPTION
## Summary
Completes system-wide IB timeout hardening. After rounds 5 (orchestrator) and 6 (order_manager), this PR covers the remaining 22 unprotected `await ib.*` calls across 8 modules:

- **compliance.py** (4 calls): `reqContractDetailsAsync`, `qualifyContractsAsync`, `reqHistoricalDataAsync` — 8-12s
- **ib_interface.py** (5 calls): `reqSecDefOptParamsAsync`, `reqContractDetailsAsync`, `qualifyContractsAsync`, `reqAllOpenOrdersAsync` — 8-15s
- **risk_management.py** (6 calls): `reqPositionsAsync`, `reqContractDetailsAsync`, `qualifyContractsAsync`, `reqAllOpenOrdersAsync` — 5-15s
- **utils.py** (3 calls): `reqContractDetailsAsync`, `qualifyContractsAsync` — 5s
- **market_data_provider.py** (1): `reqHistoricalDataAsync` — 10s
- **drawdown_circuit_breaker.py** (1): `accountSummaryAsync` — 10s
- **signal_generator.py** (1): `reqHistoricalDataAsync` — 10s
- **weighted_voting.py** (1): `reqHistoricalDataAsync` — 10s

Only `ib.sleepAsync(0.1)` in risk_management.py is intentionally left unprotected (100ms sleep inside a manually bounded 60s deadline loop).

**After this PR, zero unprotected IB async calls remain in the codebase** (excluding connection_pool.py's connectAsync and reconciliation.py's batch operations).

## Test plan
- [x] All 8 modified modules import cleanly
- [x] `pytest tests/test_order_manager.py tests/test_orchestrator.py tests/test_emergency_improvements.py tests/test_position_monitor.py tests/test_weekly_close.py tests/test_sentinel_crash_fixes.py` — 26/26 pass
- [x] Verified zero remaining unprotected `await ib.*` calls (only `ib.sleepAsync` remains, intentionally)
- [ ] Monitor production logs for timeout warnings after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)