### PR TITLE
Harden thesis monitoring: fix 6 gaps in _validate_thesis

### DIFF
--- a/tests/test_exit_integration.py
+++ b/tests/test_exit_integration.py
@@ -154,9 +154,9 @@ class TestThesisLifecycleIntegration(unittest.IsolatedAsyncioTestCase):
         mock_council = MagicMock()
 
         # Test with RANGE_BOUND regime (should HOLD)
-        with patch('orchestrator._get_current_regime', new_callable=AsyncMock) as mock_regime, \
+        with patch('orchestrator._get_current_regime_and_iv', new_callable=AsyncMock) as mock_regime, \
              patch('orchestrator._get_current_price', new_callable=AsyncMock) as mock_price:
-            mock_regime.return_value = 'RANGE_BOUND'
+            mock_regime.return_value = ('RANGE_BOUND', 25.0)
             mock_price.return_value = 345.0
 
             result = await _validate_thesis(
@@ -166,9 +166,9 @@ class TestThesisLifecycleIntegration(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(result['action'], 'HOLD', "Should HOLD when regime unchanged")
 
         # Test with HIGH_VOLATILITY regime (should CLOSE)
-        with patch('orchestrator._get_current_regime', new_callable=AsyncMock) as mock_regime, \
+        with patch('orchestrator._get_current_regime_and_iv', new_callable=AsyncMock) as mock_regime, \
              patch('orchestrator._get_current_price', new_callable=AsyncMock) as mock_price:
-            mock_regime.return_value = 'HIGH_VOLATILITY'
+            mock_regime.return_value = ('HIGH_VOLATILITY', 75.0)
             mock_price.return_value = 345.0
 
             result = await _validate_thesis(

--- a/tests/test_exit_logic.py
+++ b/tests/test_exit_logic.py
@@ -78,9 +78,9 @@ class TestExitLogic(unittest.IsolatedAsyncioTestCase):
         mock_council = MagicMock()
         mock_position = MagicMock()
 
-        # Mock _get_current_regime to return HIGH_VOLATILITY
-        with patch('orchestrator._get_current_regime', new_callable=AsyncMock) as mock_regime:
-            mock_regime.return_value = 'HIGH_VOLATILITY'
+        # Mock _get_current_regime_and_iv to return HIGH_VOLATILITY with high IV rank
+        with patch('orchestrator._get_current_regime_and_iv', new_callable=AsyncMock) as mock_regime:
+            mock_regime.return_value = ('HIGH_VOLATILITY', 75.0)
 
             result = await _validate_thesis(thesis, mock_position, mock_council, mock_config, mock_ib)
 


### PR DESCRIPTION
## Summary

- **Budget gate split**: IC/straddle data-driven checks now run even when LLM budget is exhausted; only narrative (LLM) checks are skipped
- **Config-driven thresholds**: Replaced 5 hardcoded values (`2.0`, `70`, `4`, `1.0`, `0.6`) with reads from `config['exit_logic']`
- **Feature flags respected**: `enable_regime_breach_exits`, `enable_theta_hurdle_check`, `enable_narrative_exits` now gate their respective validation branches
- **Standalone IV rank check**: Iron condors are now closed when IV rank exceeds threshold regardless of entry regime (previously only caught RANGE_BOUND → HIGH_VOLATILITY transitions)
- **Straddle price fix**: Theta burn check now resolves the underlying future instead of using the option/combo contract price
- **Guardian context enriched**: `_get_context_for_guardian` now provides sentinel event history + guardian reports from StateManager (was a near-empty stub)

## Test plan

- [x] `python -c "import orchestrator"` — no import errors
- [x] `pytest tests/test_orchestrator.py tests/test_emergency_improvements.py tests/test_position_monitor.py tests/test_exit_integration.py tests/test_exit_logic.py` — 27/27 pass
- [ ] Manual review: confirm config values in `config.json` `exit_logic` section match expected defaults
- [ ] Production dry-run: verify position audit logs show config reads and feature flag status

🤖 Generated with [Claude Code](https://claude.com/claude-code)