### PR TITLE
Fix backfill early return blocking CSV-to-JSON sync

### DIFF
--- a/trading_bot/enhanced_brier.py
+++ b/trading_bot/enhanced_brier.py
@@ -355,9 +355,6 @@ class EnhancedBrierTracker:
             if cycle_id and agent:
                 csv_resolved[(cycle_id, agent)] = actual
 
-        if not csv_resolved:
-            return 0
-
         # Find unresolved Enhanced Brier predictions that have CSV resolutions
         backfilled = 0
         for pred in self.predictions:


### PR DESCRIPTION
## Summary
- Removes premature `if not csv_resolved: return 0` guard in `backfill_from_resolved_csv()` that prevented pass 2 (create missing JSON entries from CSV) from ever running
- This was the reason the 21-prediction gap between Enhanced JSON and CSV stores wasn't converging after #744

## Context
The early return was intended to skip pass 1 (resolve existing JSON predictions) when no CSV rows were resolved. But it also skipped pass 2 (create JSON entries for CSV-only rows), which is the pass that closes the count gap.

## Test plan
- [x] `python -c "import orchestrator"` — no import errors
- [x] `pytest tests/test_brier_scoring_new.py tests/test_brier_bridge.py tests/test_brier_integration.py` — 17/17 pass
- [x] Local verification: backfill now creates 15 missing entries (was 0 before fix)
- [ ] After deploy: dashboard sync indicator should turn green after next reconciliation cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)