### PR TITLE
Auto-backfill on tracker init for immediate store convergence

### DIFF
--- a/trading_bot/enhanced_brier.py
+++ b/trading_bot/enhanced_brier.py
@@ -201,8 +201,14 @@ class EnhancedBrierTracker:
         # Per-agent, per-regime Brier scores
         self.agent_scores: Dict[str, Dict[str, List[float]]] = {}
 
-        # Load existing data
+        # Load existing data and sync with CSV
         self._load()
+        # Auto-backfill only for the default production data path
+        if os.path.abspath(data_path) == os.path.abspath("./data/enhanced_brier.json"):
+            try:
+                self.backfill_from_resolved_csv()
+            except Exception as e:
+                logger.warning(f"Auto-backfill on init failed (non-fatal): {e}")
 
     def record_prediction(
         self,
@@ -644,6 +650,7 @@ class EnhancedBrierTracker:
 
             if dupes_removed > 0:
                 logger.info(f"Removed {dupes_removed} duplicate predictions on load")
+                self._save()  # Persist deduped state to disk
 
             # Load agent scores
             self.agent_scores = data.get('agent_scores', {})


### PR DESCRIPTION
## Summary
- `_load()` now persists to disk after removing duplicates (previously only cleaned in-memory)
- `__init__()` now auto-runs `backfill_from_resolved_csv()` on the production data path
- This means the JSON file converges with CSV on the **first tracker initialization** after deploy, not on the next reconciliation cycle

## Why the previous PRs weren't enough
The dedup-on-load (#744) and early-return fix (#745) were correct but passive — they only took effect when explicitly triggered. The dashboard reads the raw JSON file directly, so it never saw the in-memory improvements. The stores will now converge as soon as the orchestrator starts (or any code path initializes the tracker singleton).

## Test plan
- [x] `python -c "import orchestrator"` — no import errors
- [x] 17/17 Brier tests pass (auto-backfill skipped for non-default data paths to avoid polluting test trackers)
- [ ] After deploy: dashboard should show matching counts immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)