### PR TITLE
Fix log collection crash: cleanup trap + deploy race guard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,27 @@ jobs:
             # Navigate to the repo
             cd ~/real_options &&
 
+            # Wait for log collection to finish (if running)
+            COLLECT_LOCK=/tmp/trading-bot-collect.lock
+            for i in 1 2 3 4 5 6; do
+              if [ -f \"\$COLLECT_LOCK\" ]; then
+                echo \"Log collection in progress, waiting 10s (\$i/6)...\"
+                sleep 10
+              else
+                break
+              fi
+            done
+            # Remove stale lock if still present after 60s
+            rm -f \"\$COLLECT_LOCK\"
+
+            # Ensure we are on the correct branch (self-heal from stuck logs branch)
+            CURRENT=\$(git branch --show-current)
+            if [ \"\$CURRENT\" != \"${{ github.ref_name }}\" ]; then
+              echo \"WARNING: On branch \$CURRENT, expected ${{ github.ref_name }}. Cleaning up...\"
+              git checkout -- . 2>/dev/null || true
+              git clean -fd 2>/dev/null || true
+            fi
+
             # Fetch and Switch
             git fetch &&
             git checkout ${{ github.ref_name }} &&

--- a/scripts/collect_logs.sh
+++ b/scripts/collect_logs.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-set -e
-
 # === Coffee Bot Real Options - Log Collection (Environment Configurable) ===
-# This script collects logs and output files for the specified environment
+# This script collects logs and output files for the specified environment.
+#
+# Safety: Uses a cleanup trap to ALWAYS switch back to the original branch,
+# even if the script fails mid-execution.
 
 # Load environment variables from .env if present
 if [ -f .env ]; then
@@ -14,12 +15,29 @@ ENV_NAME="${LOG_ENV_NAME:-dev}"
 REPO_DIR="${COFFEE_BOT_PATH:-$(pwd)}"
 DEST_DIR="$REPO_DIR/$ENV_NAME"
 BRANCH="${LOG_BRANCH:-logs}"
+ORIGINAL_BRANCH=""
+SWITCHED_BRANCH=false
 
-echo "🚀 Coffee Bot Log Collection"
+echo "Coffee Bot Log Collection"
 echo "Environment: $ENV_NAME"
 echo "Repository: $REPO_DIR"
 echo "Branch: $BRANCH"
 echo "=========================="
+
+# === CLEANUP TRAP: Always switch back to original branch ===
+cleanup() {
+    local exit_code=$?
+    if [ "$SWITCHED_BRANCH" = true ] && [ -n "$ORIGINAL_BRANCH" ]; then
+        echo "Cleanup: switching back to $ORIGINAL_BRANCH..."
+        cd "$REPO_DIR" 2>/dev/null || true
+        # Discard any uncommitted changes from the copy phase
+        git checkout -- . 2>/dev/null || true
+        git clean -fd "$DEST_DIR" 2>/dev/null || true
+        git checkout "$ORIGINAL_BRANCH" 2>/dev/null || git checkout main 2>/dev/null || true
+    fi
+    exit $exit_code
+}
+trap cleanup EXIT
 
 # Skip if deploy is in progress
 DEPLOY_LOCK="/tmp/trading-bot-deploy.lock"
@@ -27,40 +45,53 @@ if [ -f "$DEPLOY_LOCK" ]; then
     LOCK_AGE=$(( $(date +%s) - $(stat -c %Y "$DEPLOY_LOCK") ))
     LOCK_PID=$(cat "$DEPLOY_LOCK" 2>/dev/null)
     if [ "$LOCK_AGE" -gt 1800 ]; then
-        echo "🧹 Deploy lock is ${LOCK_AGE}s old (>30min), treating as stale"
+        echo "Deploy lock is ${LOCK_AGE}s old (>30min), treating as stale"
         rm -f "$DEPLOY_LOCK"
     elif kill -0 "$LOCK_PID" 2>/dev/null; then
-        echo "⏭️  Deploy in progress (PID $LOCK_PID, age ${LOCK_AGE}s), skipping"
+        echo "Deploy in progress (PID $LOCK_PID, age ${LOCK_AGE}s), skipping"
         exit 0
     else
-        echo "🧹 Stale deploy lock found (process gone), removing"
+        echo "Stale deploy lock found (process gone), removing"
         rm -f "$DEPLOY_LOCK"
     fi
 fi
 
-# 1. CAPTURE ORIGINAL BRANCH (Fix for Bug #1)
-# We must do this BEFORE we switch branches
-cd "$REPO_DIR" || exit
+# Create our own lock to prevent deploy from running git checkout mid-collection
+COLLECT_LOCK="/tmp/trading-bot-collect.lock"
+echo "$$" > "$COLLECT_LOCK"
+# Remove collect lock on exit (in addition to branch cleanup above)
+original_cleanup=$(trap -p EXIT | sed "s/trap -- '\(.*\)' EXIT/\1/")
+trap "$original_cleanup; rm -f '$COLLECT_LOCK'" EXIT
+
+cd "$REPO_DIR" || exit 1
 ORIGINAL_BRANCH=$(git branch --show-current)
 
 if [ -z "$ORIGINAL_BRANCH" ]; then
-    echo "⚠️  Could not detect current branch, defaulting to 'main'"
+    echo "WARNING: Could not detect current branch, defaulting to 'main'"
     ORIGINAL_BRANCH="main"
 fi
-echo "📍 Starting from branch: $ORIGINAL_BRANCH"
+echo "Starting from branch: $ORIGINAL_BRANCH"
 
-# 2. MEMORY SAFETY (Fix for Bug #2)
-# Prevent Git from using too much RAM during operations on the 4GB droplet
+# Self-heal: if we're already on the logs branch (from a previous failed run),
+# discard any dirty state before proceeding
+if [ "$ORIGINAL_BRANCH" = "$BRANCH" ]; then
+    echo "WARNING: Already on '$BRANCH' branch (previous run may have failed). Self-healing..."
+    git checkout -- . 2>/dev/null || true
+    git clean -fd 2>/dev/null || true
+    ORIGINAL_BRANCH="main"
+fi
+
+# Prevent Git from using too much RAM on the 4GB droplet
 git config pack.windowMemory 512m
 git config pack.threads 1
 
-# 1. Go to repo and get the latest logs branch state
-cd "$REPO_DIR" || exit
-git fetch origin $BRANCH 2>/dev/null || echo "Creating new logs branch..."
-git checkout $BRANCH 2>/dev/null || git checkout --orphan $BRANCH
-git reset --hard origin/$BRANCH 2>/dev/null || echo "New branch setup..."
+# Fetch and switch to the logs branch
+git fetch origin "$BRANCH" 2>/dev/null || echo "Creating new logs branch..."
+git checkout "$BRANCH" 2>/dev/null || git checkout --orphan "$BRANCH"
+SWITCHED_BRANCH=true
+git reset --hard "origin/$BRANCH" 2>/dev/null || echo "New branch setup..."
 
-# 2. CLEAR & GATHER
+# CLEAR & GATHER
 # Wipe the old logs in the env folder so we don't keep junk
 rm -rf "$DEST_DIR"
 mkdir -p "$DEST_DIR"
@@ -68,12 +99,10 @@ mkdir -p "$DEST_DIR"
 echo "Gathering logs for $ENV_NAME..."
 
 # === LOG FILES ===
-# Specific log files only (not timestamped versions)
 if [ -d "$REPO_DIR/logs" ]; then
     echo "Copying specific log files..."
     mkdir -p "$DEST_DIR/logs"
-    
-    # Copy explicitly known active log files to avoid copying rotated/timestamped logs
+
     for logfile in "orchestrator.log" "dashboard.log" "manual_test.log" "performance_analyzer.log" "equity_logger.log"; do
         if [ -f "$REPO_DIR/logs/$logfile" ]; then
             cp "$REPO_DIR/logs/$logfile" "$DEST_DIR/logs/"
@@ -82,69 +111,54 @@ if [ -d "$REPO_DIR/logs" ]; then
 fi
 
 # === DATA FILES ===
-# Main data directory check - prevents errors if data folder is missing
 if [ -d "$REPO_DIR/data" ]; then
     echo "Copying specific data files..."
     mkdir -p "$DEST_DIR/data"
 
-    # 1. Copy SAFE text-based files (CSV, JSON, LOG)
-    # We use simple wildcards to grab relevant files while avoiding heavy binaries
-    # 2>/dev/null ensures it doesn't complain if no files of that specific type exist
-    cp "$REPO_DIR/data/"*.csv "$DEST_DIR/data/" 2>/dev/null
-    cp "$REPO_DIR/data/"*.json "$DEST_DIR/data/" 2>/dev/null
+    cp "$REPO_DIR/data/"*.csv "$DEST_DIR/data/" 2>/dev/null || true
+    cp "$REPO_DIR/data/"*.json "$DEST_DIR/data/" 2>/dev/null || true
 
-    # Copy .log files but try to exclude obvious timestamped ones if any exist
-    # Standard globbing doesn't support exclusions easily, so we use a loop
     for f in "$REPO_DIR/data/"*.log; do
         if [ -f "$f" ]; then
             filename=$(basename "$f")
-            # Simple check: if filename contains a 4-digit year pattern like -202X-, skip it
             if [[ ! "$filename" =~ -202[0-9]- ]]; then
                 cp "$f" "$DEST_DIR/data/"
             fi
         fi
     done
 
-    # 2. EXPLICITLY SKIP HEAVY BINARIES
-    # We do NOT copy the 'tms' folder or .sqlite3 files here
     echo "Skipping .sqlite3 and TMS binaries to prevent repo bloat."
 fi
 
 # === TRADE FILES ===
-# Main trade ledger
 if [ -f "$REPO_DIR/trade_ledger.csv" ]; then
     echo "Copying trade_ledger.csv..."
     cp "$REPO_DIR/trade_ledger.csv" "$DEST_DIR/"
 fi
 
-# Decision signals (Council output summary — replaces old model_signals.csv)
 if [ -f "$REPO_DIR/decision_signals.csv" ]; then
     echo "Copying decision_signals.csv..."
     cp "$REPO_DIR/decision_signals.csv" "$DEST_DIR/"
 fi
 
-# Archive ledger directory
 if [ -d "$REPO_DIR/archive_ledger" ]; then
     echo "Copying archive_ledger directory..."
     cp -r "$REPO_DIR/archive_ledger" "$DEST_DIR/"
 fi
 
 # === CONFIGURATION FILES ===
-# Config file (sanitized - excludes .env for security)
 if [ -f "$REPO_DIR/config.json" ]; then
     echo "Copying config.json..."
     cp "$REPO_DIR/config.json" "$DEST_DIR/"
 fi
 
 # === STATE FILES ===
-# Root state file
 if [ -f "$REPO_DIR/state.json" ]; then
     echo "Copying state.json..."
     cp "$REPO_DIR/state.json" "$DEST_DIR/"
 fi
 
 # === PERFORMANCE FILES ===
-# Daily performance chart
 if [ -f "$REPO_DIR/daily_performance.png" ]; then
     echo "Copying daily_performance.png..."
     cp "$REPO_DIR/daily_performance.png" "$DEST_DIR/"
@@ -152,7 +166,6 @@ fi
 
 # === ENVIRONMENT-SPECIFIC REPORTS ===
 if [ "$ENV_NAME" = "prod" ]; then
-    # === PRODUCTION HEALTH REPORT ===
     echo "Creating production health report..."
     {
         echo "=== PRODUCTION HEALTH REPORT ==="
@@ -161,71 +174,66 @@ if [ "$ENV_NAME" = "prod" ]; then
         echo "Hostname: $(hostname)"
         echo "Uptime: $(uptime)"
         echo ""
-        
+
         echo "=== DISK USAGE ==="
         df -h
         echo ""
-        
+
         echo "=== MEMORY USAGE ==="
         free -h
         echo ""
-        
+
         echo "=== LOAD AVERAGE ==="
         cat /proc/loadavg
         echo ""
-        
+
         echo "=== PROCESS STATUS ==="
         echo "Trading processes:"
-        ps aux | grep -E "(orchestrator|position_monitor)" | grep -v grep
+        ps aux | grep -E "(orchestrator|position_monitor)" | grep -v grep || true
         echo ""
         echo "Dashboard processes:"
-        ps aux | grep streamlit | grep -v grep
+        ps aux | grep streamlit | grep -v grep || true
         echo ""
-        
+
         echo "=== NETWORK STATUS ==="
         echo "Open ports (Trading & Dashboard):"
         netstat -tlnp 2>/dev/null | grep -E ":(8501|7497|7496)" || echo "netstat not available"
         echo ""
-        
+
         echo "=== RECENT ERRORS (if any) ==="
         if [ -f "$REPO_DIR/logs/orchestrator.log" ]; then
             echo "Recent orchestrator errors:"
-            grep -i "error\|critical\|exception" "$REPO_DIR/logs/orchestrator.log" | tail -10
+            grep -i "error\|critical\|exception" "$REPO_DIR/logs/orchestrator.log" | tail -10 || true
         fi
-        
+
     } > "$DEST_DIR/production_health_report.txt"
-    
-    # === TRADING PERFORMANCE SNAPSHOT ===
+
     echo "Creating trading performance snapshot..."
     {
         echo "=== TRADING PERFORMANCE SNAPSHOT ==="
         echo "Generated: $(date)"
         echo ""
-        
-        # Council decisions summary
+
         if [ -f "$REPO_DIR/data/council_history.csv" ]; then
             echo "=== RECENT COUNCIL DECISIONS (Last 10) ==="
             tail -10 "$REPO_DIR/data/council_history.csv"
             echo ""
         fi
-        
-        # Equity curve summary
+
         if [ -f "$REPO_DIR/data/daily_equity.csv" ]; then
             echo "=== RECENT EQUITY DATA (Last 10 days) ==="
             tail -10 "$REPO_DIR/data/daily_equity.csv"
             echo ""
         fi
-        
-        # Trade ledger summary
+
         if [ -f "$REPO_DIR/trade_ledger.csv" ]; then
             echo "=== RECENT TRADES (Last 10) ==="
             tail -10 "$REPO_DIR/trade_ledger.csv"
             echo ""
         fi
-        
+
     } > "$DEST_DIR/trading_performance_snapshot.txt"
 else
-    # === DEVELOPMENT SYSTEM INFO ===
     echo "Creating system snapshot..."
     {
         echo "=== SYSTEM SNAPSHOT FOR $ENV_NAME ==="
@@ -241,37 +249,31 @@ else
         echo ""
         echo "=== PROCESS STATUS ==="
         echo "Python processes:"
-        ps aux | grep python | grep -v grep
+        ps aux | grep python | grep -v grep || true
         echo ""
         echo "Streamlit processes:"
-        ps aux | grep streamlit | grep -v grep
-        
+        ps aux | grep streamlit | grep -v grep || true
+
     } > "$DEST_DIR/system_snapshot.txt"
 fi
 
-# Keep the placeholder so the folder exists even if empty
 touch "$DEST_DIR/.keep"
 
-# 3. PUSH
+# === COMMIT & PUSH ===
 git add "$DEST_DIR"
-git commit -m "Snapshot $ENV_NAME: $(date +'%Y-%m-%d %H:%M')"
-git push origin $BRANCH
 
-# 4. CRITICAL: SWITCH BACK TO ORIGINAL BRANCH
+# Only commit if there are staged changes (prevents "nothing to commit" failure)
+if git diff --cached --quiet; then
+    echo "No changes since last snapshot, skipping commit."
+else
+    git commit -m "Snapshot $ENV_NAME: $(date +'%Y-%m-%d %H:%M')"
+    git push origin "$BRANCH"
+    echo "Snapshot pushed to $BRANCH branch."
+fi
+
+# Switch back (also handled by trap, but do it explicitly for clean exit message)
+SWITCHED_BRANCH=false
 echo "Switching back to original branch: $ORIGINAL_BRANCH"
 git checkout "$ORIGINAL_BRANCH"
 
-echo "✅ Successfully collected and pushed logs for $ENV_NAME"
-echo "📁 Files included in snapshot:"
-echo "   - logs/orchestrator.log and logs/dashboard.log (current only)"
-echo "   - data/ directory (council_history.csv, daily_equity.csv, state.json, etc.)"
-echo "   - data/tms/ directory (chroma.sqlite3 and TMS files)"
-echo "   - trade_ledger.csv (model_signals.csv removed)"
-echo "   - archive_ledger/ directory (if exists)"
-echo "   - config.json and state.json"
-if [ "$ENV_NAME" = "prod" ]; then
-    echo "   - production_health_report.txt and trading_performance_snapshot.txt"
-else
-    echo "   - system_snapshot.txt"
-fi
-echo "   - log_summary.txt (generated report)"
+echo "Successfully collected $ENV_NAME logs!"


### PR DESCRIPTION
## Summary
- **Root cause**: `collect_logs.sh` had no cleanup handler — when `git commit` failed (nothing changed since last snapshot), `set -e` killed the script while on the `logs` branch, leaving the repo stranded with uncommitted changes. This blocked both future cron collections and deploys (two deploy failures on Feb 8 at 22:29 and 23:07).
- **collect_logs.sh**: Added EXIT trap that always restores original branch, self-healing for stuck state, `git diff --cached` check before commit, and collection lock file
- **deploy.yml**: Wait for active collection, self-heal if repo on wrong branch

## Test plan
- [ ] Merge and deploy — the deploy itself exercises the new deploy.yml guards
- [ ] Trigger log collection from dashboard Utilities page — should succeed
- [ ] Verify logs branch gets new snapshots every 30 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)