### PR TITLE
Relax liquidity filter to 45% for commodity options

### DIFF
--- a/config.json
+++ b/config.json
@@ -52,7 +52,7 @@
     "iron_condor_wing_strikes_apart": 2,
     "slippage_spread_percentage": 0.5,
     "order_type": "LMT",
-    "max_liquidity_spread_percentage": 0.25,
+    "max_liquidity_spread_percentage": 0.45,
     "fixed_slippage_cents": 0.5
   },
   "commodity_profile": {


### PR DESCRIPTION
## Summary
- Coffee options have inherently wider bid-ask spreads than equity options
- Front-month ATM put spread (KCK6) was **39%** during Monday market hours — normal for this market but blocked by the 25% threshold
- Deferred months are still blocked: KCN6 (61%), KCU6 (197%), KCZ6 (no options defined)
- **Change**: `max_liquidity_spread_percentage` from 0.25 → 0.45 in `config.json`

## Test plan
- [ ] Merge and deploy
- [ ] Trigger "Generate and Execute Orders" — front-month should now pass liquidity filter during market hours
- [ ] Monitor that deferred/illiquid contracts are still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)