### PR TITLE
Fix IB connection leak on connect failure in reconciliation

### DIFF
--- a/trading_bot/reconciliation.py
+++ b/trading_bot/reconciliation.py
@@ -87,6 +87,10 @@ async def reconcile_council_history(config: dict, ib: IB = None):
              await ib.connectAsync(host, port, clientId=client_id)
         except Exception as e:
              logger.error(f"Failed to connect to IB for reconciliation: {e}")
+             try:
+                 ib.disconnect()
+             except Exception:
+                 pass
              return
 
     try:


### PR DESCRIPTION
## Summary
- When `connectAsync()` failed in `reconciliation.py`, the function returned without cleaning up the `IB()` instance — the `finally` block was unreachable because the early return exits before the second `try` block
- Added `ib.disconnect()` in the except handler before returning
- Also investigated `market_data_provider.py` subscription leak (from earlier audit) — confirmed already fixed: all `reqMktData` paths have matching `cancelMktData` calls on every code path

## Test plan
- [x] All 264 tests pass (0 failures)
- [x] Module imports cleanly
- [ ] Verify during next reconciliation run (19:00 UTC daily)

🤖 Generated with [Claude Code](https://claude.com/claude-code)