### PR TITLE
🎨 Palette: Add safety interlock to Refresh All Data button

### DIFF
--- a/pages/1_Cockpit.py
+++ b/pages/1_Cockpit.py
@@ -851,10 +851,12 @@ with ctrl_cols[1]:
             st.error("Config not loaded")
 
 with ctrl_cols[2]:
+    confirm_refresh = st.checkbox("I confirm I want to reload all data", key="confirm_refresh")
     if st.button(
         "🔄 Refresh All Data",
         width="stretch",
-        help="Clears application cache and forces a full data reload from IB/APIs"
+        disabled=not confirm_refresh,
+        help="Clears application cache and forces a full data reload from IB/APIs. Requires confirmation."
     ):
         with st.spinner("Refreshing data..."):
             st.cache_data.clear()


### PR DESCRIPTION
💡 What: Added a confirmation checkbox to the "Refresh All Data" button in the Cockpit page.
🎯 Why: To prevent accidental data refreshes, which can be disruptive and cause data loss or jank, as per the UX Journal (2026-02-08).
📸 Before/After: The button is now disabled by default and requires checking "I confirm I want to reload all data".
♿ Accessibility: The button is clearly labeled and disabled state is visually distinct. Help text explains the requirement.

---
*PR created automatically by Jules for task [13415024069332785116](https://jules.google.com/task/13415024069332785116) started by @rozavala*