### PR TITLE
Fix 7 audit bugs: LLM output validation, NaN guards, markdown stripping

### DIFF
--- a/trading_bot/sentinels.py
+++ b/trading_bot/sentinels.py
@@ -780,7 +780,7 @@ class LogisticsSentinel(Sentinel):
         )
         text = response.text.strip()
         if text.startswith("```json"): text = text[7:]
-        if text.startswith("```"): text = text[:-3]
+        elif text.startswith("```"): text = text[3:]
         if text.endswith("```"): text = text[:-3]
 
         parsed = json.loads(text)
@@ -960,7 +960,7 @@ class NewsSentinel(Sentinel):
         )
         text = response.text.strip()
         if text.startswith("```json"): text = text[7:]
-        if text.startswith("```"): text = text[:-3]
+        elif text.startswith("```"): text = text[3:]
         if text.endswith("```"): text = text[:-3]
 
         parsed = json.loads(text)
@@ -2073,7 +2073,7 @@ class MacroContagionSentinel(Sentinel):
             # Clean JSON
             text = response.text.strip()
             if text.startswith("```json"): text = text[7:]
-            if text.startswith("```"): text = text[:-3]
+            elif text.startswith("```"): text = text[3:]
             if text.endswith("```"): text = text[:-3]
             text = text.strip()
 


### PR DESCRIPTION
## Summary
- **agents.py**: Validate Master Strategist `direction` field — missing/invalid values now default to NEUTRAL instead of propagating `None` through signal generation
- **agents.py**: Coerce DA `proceed` field to strict bool — string `"no"` was truthy in Python, bypassing trade veto
- **compliance.py**: Reject non-boolean `approved` in JSON parse — `bool("maybe")=True` was approving trades
- **order_manager.py**: Guard NaN price reaching compliance (NaN is truthy, passed `if ticker.last` check)
- **order_manager.py**: Guard `MINIMUM_TICK`/`TICK_SIZE` against zero to prevent division-by-zero crash in price rounding
- **sentinels.py**: Fix markdown fence stripping at 3 locations — `"```"` without `json` was removing last 3 chars instead of first 3
- **brier_scoring.py**: Restructure CSV schema migration — avoids closing file handle inside `with` block

## Context
These are the verified findings from a fresh 4-agent audit pass. ~30 false positives were filtered (asyncio "race conditions" that can't happen in single-threaded scheduling, EMERGENCY_LOCK claims verified as correct, etc.).

## Test plan
- [x] `python -c "import orchestrator"` — no import errors
- [x] `pytest tests/ --timeout=120` — 264 passed, 0 failed
- [ ] Monitor next trading cycle for clean LLM parsing (direction, DA proceed, compliance approved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)