### PR TITLE
Fix deploy: remove scripts/migrations from verify check

### DIFF
--- a/scripts/verify_deploy.sh
+++ b/scripts/verify_deploy.sh
@@ -42,7 +42,6 @@ REQUIRED_DIRS=(
     "data"
     "data/surrogate_models"
     # "logs" # logs might not exist in fresh clone? but good to check
-    "scripts/migrations"
 )
 for dir in "${REQUIRED_DIRS[@]}"; do
     if [ ! -d "$dir" ]; then


### PR DESCRIPTION
## Summary
- Removes `scripts/migrations` from the `REQUIRED_DIRS` array in `scripts/verify_deploy.sh`
- The migration scripts were deleted in PR #775, but the deploy verification gate still checked for the directory, causing automatic rollback

## Test plan
- [ ] Merge and verify deploy completes past check [1/5] without rolling back

🤖 Generated with [Claude Code](https://claude.com/claude-code)