### PR TITLE
Rotate equity_logger.log on deploy, auto-delete old logs

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -144,6 +144,10 @@ echo "--- 2. Rotating logs... ---"
 mkdir -p logs
 [ -f logs/orchestrator.log ] && mv logs/orchestrator.log logs/orchestrator-$(date --iso=s).log || true
 [ -f logs/dashboard.log ] && mv logs/dashboard.log logs/dashboard-$(date --iso=s).log || true
+[ -f logs/equity_logger.log ] && mv logs/equity_logger.log logs/equity_logger-$(date --iso=s).log || true
+
+# Clean up rotated logs older than 7 days
+find logs/ -name "*-20*.log" -mtime +7 -delete 2>/dev/null || true
 
 # Ensure logs directory exists with correct permissions
 chmod 755 logs


### PR DESCRIPTION
## Summary
- Add `equity_logger.log` to the deploy-time timestamp rotation (was only `touch`ed, never archived — unlike orchestrator.log and dashboard.log)
- Add `find -mtime +7 -delete` to clean up rotated log files older than 7 days (currently 579 files / 19MB accumulating on the droplet)

## Test plan
- [ ] Deploy and verify equity_logger gets timestamped rename in step 2
- [ ] Verify old `*-20*.log` files older than 7 days are deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)