### PR TITLE
Commodity-agnostic refactor + dead code cleanup

### DIFF
--- a/config.json
+++ b/config.json
@@ -55,14 +55,6 @@
     "max_liquidity_spread_percentage": 0.45,
     "fixed_slippage_cents": 0.5
   },
-  "commodity_profile": {
-    "KC": {
-      "name": "Coffee C Arabica",
-      "price_unit": "cents/lb",
-      "stop_parse_range": [80, 800],
-      "typical_price_range": [100, 600]
-    }
-  },
   "risk_management": {
     "max_holding_days": 2,
     "min_holding_hours": 6.0,
@@ -88,41 +80,7 @@
   },
   "fred_api_key": "LOADED_FROM_ENV",
   "nasdaq_api_key": "LOADED_FROM_ENV",
-  "weather_stations": {
-    "brazil_minas_gerais": [
-      "-19.9245",
-      "-43.9353"
-    ],
-    "vietnam_ho_chi_minh": [
-      "10.8231",
-      "106.6297"
-    ],
-    "colombia_antioquia": [
-      "6.2442",
-      "-75.5812"
-    ],
-    "indonesia_sumatra": [
-      "3.5952",
-      "98.6722"
-    ]
-  },
-  "fred_series": {
-    "brl_usd_exchange_rate": "DEXBZUS",
-    "oil_price_wti": "DCOILWTICO",
-    "indonesia_idr_usd": "DEXINUS",
-    "mexico_mxn_usd": "DEXMXUS",
-    "dgs10_yield": "DGS10"
-  },
-  "yf_series_map": {
-    "SB=F": "sugar_price",
-    "^GSPC": "sp500_price",
-    "NSRGY": "nestle_stock",
-    "DX-Y.NYB": "us_dollar_index",
-    "^VIX": "volatility_index",
-    "MAERSK-B.CO": "shipping_proxy"
-  },
   "validation_thresholds": {
-    "price_spike_pct": 0.15,
     "prediction_sanity_check_pct": 0.20
   },
   "validation": {
@@ -202,43 +160,14 @@
       }
     },
     "logistics": {
-      "model": "gemini-3-flash-preview",
-      "rss_urls_override": [
-        "https://news.google.com/rss/search?q=Port+of+Santos+logistics+coffee",
-        "https://news.google.com/rss/search?q=Red+Sea+Suez+coffee+shipping+delays",
-        "https://news.google.com/rss/search?q=coffee+supply+chain+bottlenecks"
-      ]
+      "model": "gemini-3-flash-preview"
     },
     "news": {
       "model": "gemini-3-flash-preview",
-      "rss_urls_override": [
-        "https://news.google.com/rss/search?q=coffee+markets+site:reuters.com",
-        "https://news.google.com/rss/search?q=coffee+futures+site:bloomberg.com",
-        "https://news.google.com/rss/search?q=Minas+Gerais+weather+coffee+crop",
-        "https://news.google.com/rss/search?q=Vietnam+coffee+harvest+robusta",
-        "https://news.google.com/rss/search?q=Cooxupé+coffee+report",
-        "https://news.google.com/rss/search?q=coffee+futures+market+sentiment"
-      ],
       "sentiment_magnitude_threshold": 8
     },
     "x_sentiment": {
       "model": "grok-4-1-fast-reasoning",
-      "search_queries": [
-        "coffee futures",
-        "arabica prices",
-        "Brazil coffee harvest",
-        "Colombia coffee",
-        "US coffee tariffs"
-      ],
-      "from_handles": [
-        "SpillingTheBean",
-        "optima_t",
-        "Reuters",
-        "ICOcoffeeorg",
-        "zerohedge",
-        "Barchart",
-        "WSJ"
-      ],
       "exclude_keywords": ["meme", "joke", "spam", "giveaway", "airdrop", "nft", "crypto"],
       "sentiment_threshold": 6.5,
       "min_engagement": 10,

--- a/dashboard_utils.py
+++ b/dashboard_utils.py
@@ -671,13 +671,14 @@ def fetch_live_dashboard_data(_config):
     Uses underscore prefix for config to prevent Streamlit from hashing it.
     """
     ib = IB()
+    ticker = _config.get('commodity', {}).get('ticker', _config.get('symbol', 'KC'))
     data = {
         "NetLiquidation": 0.0,
         "MaintMarginReq": 0.0,
         "DailyPnL": 0.0,
         "DailyPnLPct": 0.0,
-        "KC_DailyChange": 0.0,
-        "KC_Price": 0.0,
+        f"{ticker}_DailyChange": 0.0,
+        f"{ticker}_Price": 0.0,
         "MarketData": pd.DataFrame()
     }
 

--- a/pages/2_The_Scorecard.py
+++ b/pages/2_The_Scorecard.py
@@ -118,7 +118,8 @@ strategy_filter = st.sidebar.multiselect(
 live_price = None
 if config:
     live_data = fetch_live_dashboard_data(config)
-    live_price = live_data.get('KC_Price')
+    ticker = config.get('commodity', {}).get('ticker', config.get('symbol', 'KC'))
+    live_price = live_data.get(f'{ticker}_Price')
 
 # Grade decisions
 graded_df = grade_decision_quality(council_df)

--- a/pages/5_Utilities.py
+++ b/pages/5_Utilities.py
@@ -31,9 +31,9 @@ st.caption("System maintenance and operational tools")
 def get_current_environment():
     """Detect current environment from hostname or config."""
     hostname = socket.gethostname()
-    if 'prod' in hostname.lower() or hostname == 'coffee-bot-prod':
+    if 'prod' in hostname.lower():
         return 'prod'
-    if os.getenv("COFFEE_BOT_ENV") == "prod":
+    if os.getenv("TRADING_BOT_ENV") == "prod" or os.getenv("COFFEE_BOT_ENV") == "prod":
         return "prod"
     return 'dev'
 

--- a/pages/7_Brier_Analysis.py
+++ b/pages/7_Brier_Analysis.py
@@ -393,4 +393,4 @@ st.caption(
 
 
 st.markdown("---")
-st.caption("Brier Analysis | Coffee Bot Real Options v6.4")
+st.caption("Brier Analysis | Real Options v6.4")

--- a/trading_bot/agents.py
+++ b/trading_bot/agents.py
@@ -133,7 +133,7 @@ class TradingCouncil:
 
     def __init__(self, config: dict):
         """
-        Initializes the Coffee Council with configuration.
+        Initializes the Trading Council with configuration.
 
         Args:
             config: The full application configuration dictionary.

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -8,7 +8,6 @@ strategy definition from the execution timing.
 import asyncio
 import logging
 import os
-import random
 import time
 import traceback
 from collections import defaultdict

--- a/trading_bot/topic_discovery.py
+++ b/trading_bot/topic_discovery.py
@@ -401,10 +401,11 @@ class TopicDiscoveryAgent:
 
         self._llm_calls_this_scan += 1
 
-        # Commodity-agnostic: Pull active commodity from profile config
-        commodity_profile = self.config.get('commodity_profile', {})
-        commodity_name = commodity_profile.get('name', 'commodities')
-        commodity_description = commodity_profile.get('description', 'commodity futures')
+        # Commodity-agnostic: Pull active commodity from CommodityProfile
+        from config.commodity_profiles import get_active_profile
+        _profile = get_active_profile(self.config)
+        commodity_name = _profile.name
+        commodity_description = f"{_profile.name} futures"
         impact_template = area.get('commodity_impact_template', '')
 
         prompt = f"""You are a relevance filter for an algorithmic {commodity_description} trading system.


### PR DESCRIPTION
## Summary

- **Replace all hardcoded KC/Coffee references** across 15 files with profile-driven values from `CommodityProfile`, enabling the system to trade any configured commodity (KC remains the default fallback)
- **Add 4 new fields** to `CommodityProfile`: `research_prompts`, `concentration_proxies`, `concentration_label`, `cross_commodity_basket` — populated for both KC and CC profiles
- **Signal generator** now uses profile-driven research prompts instead of hardcoded coffee-specific queries
- **Compliance** concentration check uses profile proxies/labels (not hardcoded "Brazil")
- **Sentinels** (FundamentalRegime, MacroContagion, PredictionMarket) use dynamic commodity names, tickers, and correlation baskets
- **Dashboard pages** use dynamic ticker for price keys, regex patterns, fallback fetches, and export filenames
- **Remove dead config.json entries**: `weather_stations`, `fred_series`, `yf_series_map`, `commodity_profile` dict, sentinel RSS overrides, x_sentiment `search_queries`/`from_handles`
- **Dead code removal**: unused `import random` in order_manager.py, rename `check_coffee_council` → `check_trading_council`

## Test plan

- [x] All 261 tests pass (`pytest tests/ --timeout=120`)
- [x] `python -c "import orchestrator"` — no import errors
- [x] KC profile: `concentration_label == 'Brazil'`, 8 research prompts
- [x] CC profile: `concentration_label == 'West Africa'`, 8 research prompts
- [x] Dead config entries confirmed removed from config.json
- [x] Remaining `'KC'` references are only fallback defaults and comments
- [ ] Manual: Deploy to DEV and run a scheduled cycle to verify profile-driven prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)