### PR TITLE
Fix .dt accessor crash on empty decision_signals DataFrame

### DIFF
--- a/performance_analyzer.py
+++ b/performance_analyzer.py
@@ -172,7 +172,8 @@ def generate_executive_summary(
 
     # --- Calculate metrics ---
     signal_col = 'signal' if 'signal' in signals_df.columns else 'master_decision'
-    today_signals = signals_df[signals_df['timestamp'].dt.date == today_date] if 'timestamp' in signals_df.columns else signals_df
+    has_ts = 'timestamp' in signals_df.columns and not signals_df.empty and pd.api.types.is_datetime64_any_dtype(signals_df['timestamp'])
+    today_signals = signals_df[signals_df['timestamp'].dt.date == today_date] if has_ts else signals_df
     signals_fired_today = len(today_signals[today_signals[signal_col] != 'NEUTRAL']) if signal_col in today_signals.columns else 0
     signals_fired_ltd = len(signals_df[signals_df[signal_col] != 'NEUTRAL']) if signal_col in signals_df.columns else 0
 
@@ -243,7 +244,8 @@ def generate_morning_signals_report(signals_df: pd.DataFrame, today_date: dateti
     if signals_df.empty:
         return "No decision signals recorded yet today.\n"
 
-    today_signals = signals_df[signals_df['timestamp'].dt.date == today_date] if 'timestamp' in signals_df.columns else signals_df
+    has_ts = 'timestamp' in signals_df.columns and not signals_df.empty and pd.api.types.is_datetime64_any_dtype(signals_df['timestamp'])
+    today_signals = signals_df[signals_df['timestamp'].dt.date == today_date] if has_ts else signals_df
     if today_signals.empty:
         return "No signals generated today yet.\n"
 


### PR DESCRIPTION
## Summary
- When `decision_signals.csv` doesn't exist (fresh PROD deployment), `get_decision_signals_df()` returns an empty DataFrame with object-typed columns
- The `'timestamp'` column name exists but dtype is `object`, not datetime — causing `AttributeError: Can only use .dt accessor with datetimelike values`
- Fixes both occurrences in `generate_executive_summary` (L175) and `generate_morning_signals_report` (L246) by checking `is_datetime64_any_dtype` before using `.dt`

## Test plan
- [x] All 261 tests pass
- [x] Bug reproduced on PROD (observed in orchestrator.log during first deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)