### PR TITLE
Add settlement window order generation cycle

### DIFF
--- a/config.json
+++ b/config.json
@@ -466,8 +466,8 @@
   },
   "schedule": {
     "daily_trading_cutoff_et": {
-      "hour": 10,
-      "minute": 45
+      "hour": 12,
+      "minute": 15
     }
   },
   "final_column_order": [

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -3888,9 +3888,10 @@ schedule = {
     time(3, 31): process_deferred_triggers,
     time(5, 0): cleanup_orphaned_theses,          # v3.1: Daily thesis cleanup
     time(8, 30): run_position_audit_cycle,
-    time(9, 0): guarded_generate_orders,
+    time(9, 0): guarded_generate_orders,           # Morning cycle
     time(11, 0): close_stale_positions,          # PRIMARY: Peak liquidity
     time(11, 15): run_position_audit_cycle,       # Post-close verification
+    time(11, 45): guarded_generate_orders,        # Settlement window cycle (ICE KC settles ~12:23 ET)
     time(12, 45): close_stale_positions_fallback, # FALLBACK: Retry failures
     time(13, 0): run_position_audit_cycle,        # Pre-close audit
     time(13, 15): emergency_hard_close,           # SAFETY: Market orders
@@ -3934,7 +3935,7 @@ RECOVERY_POLICY = {
     'process_deferred_triggers':      {'policy': 'MARKET_OPEN',   'idempotent': False},
     'cleanup_orphaned_theses':        {'policy': 'ALWAYS',        'idempotent': True},
     'run_position_audit_cycle':       {'policy': 'MARKET_OPEN',   'idempotent': True},
-    'guarded_generate_orders':        {'policy': 'BEFORE_CUTOFF', 'idempotent': False},
+    'guarded_generate_orders':        {'policy': 'BEFORE_CUTOFF', 'idempotent': False},  # Covers both 9:00 and 11:45 cycles
     'close_stale_positions':          {'policy': 'MARKET_OPEN',   'idempotent': True},
     'close_stale_positions_fallback': {'policy': 'MARKET_OPEN',   'idempotent': True},
     'emergency_hard_close':           {'policy': 'MARKET_OPEN',   'idempotent': True},


### PR DESCRIPTION
## Summary
- Schedule a second `guarded_generate_orders` at **11:45 AM ET** so the council cycle (15-30 min) places limit orders in the book during the ICE Coffee C daily settlement window (~12:23-12:25 ET) — the highest-liquidity period of the trading day
- Push `daily_trading_cutoff_et` from **10:45 → 12:15 ET** to allow the new cycle while still blocking orders 8 minutes before settlement
- No new functions — reuses existing `guarded_generate_orders` with all its safety checks (cutoff, drawdown, budget, compliance)

## Test plan
- [x] `pytest tests/ --timeout=120` — 261 passed, 0 failed
- [ ] Verify `data/active_schedule.json` shows two `guarded_generate_orders` entries after restart
- [ ] Observe PROD logs during first settlement window — council cycle starts ~11:45 ET, orders placed before 12:23 ET

🤖 Generated with [Claude Code](https://claude.com/claude-code)