### PR TITLE
Fix 6 log issues from DEV/PROD audit

### DIFF
--- a/config.json
+++ b/config.json
@@ -465,6 +465,7 @@
     "bearer_token": "LOADED_FROM_ENV"
   },
   "schedule": {
+    "dev_offset_minutes": -30,
     "daily_trading_cutoff_et": {
       "hour": 12,
       "minute": 15

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -4149,7 +4149,7 @@ async def main():
 
     current_schedule = schedule
     if not is_prod:
-        schedule_offset_minutes = -10
+        schedule_offset_minutes = config.get('schedule', {}).get('dev_offset_minutes', -30)
         logger.info(f"Environment: {env_name}. Applying {schedule_offset_minutes} minute 'Civil War' avoidance offset.")
         current_schedule = apply_schedule_offset(schedule, offset_minutes=schedule_offset_minutes)
     else:

--- a/trading_bot/ib_interface.py
+++ b/trading_bot/ib_interface.py
@@ -273,7 +273,8 @@ async def create_combo_order_object(ib: IB, config: dict, strategy_def: dict) ->
     validated_legs = []
     for leg in qualified_legs:
         if leg.conId == 0:
-            logging.error(f"Failed to qualify contract, conId is 0. Contract details: {leg}")
+            logging.error(f"Strike not listed: {leg.right} @ {leg.strike} "
+                          f"(expiry={leg.lastTradeDateOrContractMonth}, class={leg.tradingClass})")
             return None
         validated_legs.append(leg)
 

--- a/trading_bot/observability.py
+++ b/trading_bot/observability.py
@@ -30,8 +30,8 @@ __all__ = [
     'count_directional_evidence',
 ]
 
-BULLISH_WORDS = {'increase', 'rise', 'surge', 'shortage', 'deficit', 'drought', 'frost', 'bullish', 'strong', 'growth', 'up', 'rose', 'gained', 'rally'}
-BEARISH_WORDS = {'decrease', 'fall', 'drop', 'surplus', 'bumper', 'oversupply', 'bearish', 'weak', 'decline', 'down', 'fell', 'lost', 'crash', 'plunge'}
+BULLISH_WORDS = {'increase', 'rise', 'surge', 'shortage', 'deficit', 'drought', 'frost', 'bullish', 'strong', 'growth', 'up', 'rose', 'gained', 'rally', 'congestion', 'bottleneck', 'backwardation', 'tightness', 'disruption', 'delay', 'restricted'}
+BEARISH_WORDS = {'decrease', 'fall', 'surplus', 'bumper', 'oversupply', 'bearish', 'weak', 'decline', 'down', 'fell', 'lost', 'crash', 'plunge', 'contango', 'glut', 'abundance', 'oversupplied'}
 NEGATION_WORDS = {'not', 'no', 'never', 'neither', 'nor', 'rejected', 'failed',
                   'despite', 'unlikely', 'against', 'overcame', 'ignored', 'dismissed',
                   'without', 'lack', 'absence', 'declining', 'decreased'}

--- a/trading_bot/self_healing.py
+++ b/trading_bot/self_healing.py
@@ -72,7 +72,7 @@ class SelfHealingMonitor:
                 state_file.stat().st_mtime, tz=timezone.utc
             )
             age = datetime.now(timezone.utc) - mtime
-            if age > timedelta(hours=2):
+            if age > timedelta(hours=4):
                 logger.warning(
                     f"SELF-HEAL: state.json is {age.total_seconds()/3600:.1f}h old. "
                     f"Agents may be using stale data."


### PR DESCRIPTION
## Summary
- **Fix 1:** Widen DEV schedule offset from -10 → -30 min (now configurable via `config.json:schedule.dev_offset_minutes`) to prevent IB session conflicts between DEV and PROD
- **Fix 2:** Skip full council convening when a contract has no live price (`price: None`), preventing 5× wasted LLM calls per contract
- **Fix 3:** Raise stale `state.json` warning threshold from 2h → 4h — gaps of 2-4h between state writes are normal operating behavior
- **Fix 4:** Add supply-chain vocabulary (congestion, bottleneck, backwardation, disruption, etc.) to evidence word lists; remove ambiguous `drop`
- **Fix 5:** `extract_sentiment_from_report` now returns a 3-tuple `(sentiment, confidence, matched)` — DEFAULT warning only fires when parsing truly failed, not for legitimate NEUTRAL votes
- **Fix 6:** Strike qualification errors now log `right`, `strike`, `expiry`, `tradingClass` instead of a generic message

## Test plan
- [x] `pytest tests/ --timeout=120` — 261 passed, 0 failed
- [x] Verified `extract_sentiment_from_report` has only 1 caller (line 465)
- [ ] After deploy: confirm DEV active_schedule.json shows -30min offset
- [ ] After deploy: confirm reduced log noise for stale state and DEFAULT agent warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)