### PR TITLE
Revert delayed field checks (AttributeError fix)

### DIFF
--- a/trading_bot/market_data_provider.py
+++ b/trading_bot/market_data_provider.py
@@ -170,17 +170,12 @@ def format_market_context_for_prompt(market_context: dict) -> str:
 # === Private Helpers ===
 
 async def _get_current_price(ib: IB, contract: Future) -> Optional[float]:
-    """Fetch current price from IBKR with timeout.
-
-    Checks both live fields (last, close) and delayed fields (delayedLast,
-    delayedClose) so DEV environments using FORCE_DELAYED_DATA=1 get prices.
-    """
+    """Fetch current price from IBKR with timeout."""
     try:
         ticker = ib.reqMktData(contract, '', False, False)
         # Wait for price with timeout
         for _ in range(50):  # 5 seconds max
             await asyncio.sleep(0.1)
-            # Live fields
             if not _is_nan(ticker.last) and ticker.last > 0:
                 price = ticker.last
                 ib.cancelMktData(contract)
@@ -189,23 +184,12 @@ async def _get_current_price(ib: IB, contract: Future) -> Optional[float]:
                 price = ticker.close
                 ib.cancelMktData(contract)
                 return price
-            # Delayed fields (populated when reqMarketDataType(3) is active)
-            if not _is_nan(ticker.delayedLast) and ticker.delayedLast > 0:
-                price = ticker.delayedLast
-                ib.cancelMktData(contract)
-                return price
-            if not _is_nan(ticker.delayedClose) and ticker.delayedClose > 0:
-                price = ticker.delayedClose
-                ib.cancelMktData(contract)
-                return price
 
         ib.cancelMktData(contract)
 
         # Fallback to delayed/historical
         if not _is_nan(ticker.close) and ticker.close > 0:
             return ticker.close
-        if not _is_nan(ticker.delayedClose) and ticker.delayedClose > 0:
-            return ticker.delayedClose
 
         logger.warning(f"No price available for {contract.localSymbol}")
         return None


### PR DESCRIPTION
## Summary
- Reverts the `delayedLast`/`delayedClose` checks added in PR #790
- ib_insync's `Ticker` object has no such attributes — delayed data (Type 3) transparently populates the same `last`/`close` fields
- The previous code caused `AttributeError: 'Ticker' object has no attribute 'delayedLast'` on every price fetch, failing immediately instead of waiting for data

## Root cause
DEV's lack of ICE futures price data is an **IB account subscription issue**, not a field-mapping issue. The `FORCE_DELAYED_DATA=1` setting is harmless but won't help without an ICE data subscription on the account. Can be removed from DEV `.env`.

## Test plan
- [x] `pytest tests/ --timeout=120` — 261 passed, 0 failed
- [ ] After merge + deploy: verify no more `AttributeError` in dashboard logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)