### PR TITLE
Fix 4 PROD log issues (round 2)

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -4145,7 +4145,7 @@ async def main():
         logger.info("Market Closed. Deferred triggers will remain queued.")
 
     env_name = os.getenv("ENV_NAME", "DEV") 
-    is_prod = env_name == "PROD 🚀"
+    is_prod = env_name.startswith("PROD")
 
     current_schedule = schedule
     if not is_prod:

--- a/trading_bot/observability.py
+++ b/trading_bot/observability.py
@@ -30,8 +30,8 @@ __all__ = [
     'count_directional_evidence',
 ]
 
-BULLISH_WORDS = {'increase', 'rise', 'surge', 'shortage', 'deficit', 'drought', 'frost', 'bullish', 'strong', 'growth', 'up', 'rose', 'gained', 'rally', 'congestion', 'bottleneck', 'backwardation', 'tightness', 'disruption', 'delay', 'restricted'}
-BEARISH_WORDS = {'decrease', 'fall', 'surplus', 'bumper', 'oversupply', 'bearish', 'weak', 'decline', 'down', 'fell', 'lost', 'crash', 'plunge', 'contango', 'glut', 'abundance', 'oversupplied'}
+BULLISH_WORDS = {'increase', 'rise', 'surge', 'shortage', 'deficit', 'drought', 'frost', 'bullish', 'strong', 'growth', 'up', 'rose', 'gained', 'rally', 'congestion', 'bottleneck', 'backwardation', 'tightness', 'disruption', 'delay', 'restricted', 'drawdown', 'depletion', 'thinning', 'rationing', 'hawkish', 'hoarding', 'scarcity'}
+BEARISH_WORDS = {'decrease', 'fall', 'surplus', 'bumper', 'oversupply', 'bearish', 'weak', 'decline', 'down', 'fell', 'lost', 'crash', 'plunge', 'contango', 'glut', 'abundance', 'oversupplied', 'liquidation', 'selloff', 'selling', 'overproduction', 'ample', 'easing', 'normalizing', 'weakening', 'buildup', 'accumulation', 'stockpile', 'plentiful', 'resolved', 'resolution', 'deleverage'}
 NEGATION_WORDS = {'not', 'no', 'never', 'neither', 'nor', 'rejected', 'failed',
                   'despite', 'unlikely', 'against', 'overcame', 'ignored', 'dismissed',
                   'without', 'lack', 'absence', 'declining', 'decreased'}


### PR DESCRIPTION
## Summary
- **Fix A:** `is_prod` check used exact match against `"PROD 🚀"` but PROD `.env` has `ENV_NAME=PROD` — PROD was getting DEV's -30min schedule offset. Changed to `startswith("PROD")`.
- **Fix B:** Direction-evidence word lists in `observability.py` lacked commodity domain vocabulary (e.g. "stockpile", "drawdown", "selloff"), causing false mismatch warnings that clamped agent confidence from 0.80-0.90 down to 0.30.
- **Fix C:** Replaced `_suppress_300` event handler with a `logging.Filter` on `ib_insync.wrapper` to actually suppress Error 300 log lines during liquidity checks. Old handler didn't prevent ib_insync's own logger from emitting at ERROR level.
- **Fix D:** Removed unreachable `validated_legs` list and mismatch check — made dead by the per-leg `conId == 0` early return added in PR #789.

## Test plan
- [x] Full test suite: 261 passed, 0 failed
- [x] Grep `is_prod` — only 2 uses in schedule block
- [x] Grep `PROD 🚀` — only in log message, not in check
- [x] Grep `validated_legs` — gone from ib_interface.py
- [x] Grep `Mismatch between number` — gone from ib_interface.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)