### PR TITLE
Fix log collection push race + restore leg count guard

### DIFF
--- a/trading_bot/ib_interface.py
+++ b/trading_bot/ib_interface.py
@@ -270,6 +270,10 @@ async def create_combo_order_object(ib: IB, config: dict, strategy_def: dict) ->
         return None
 
     # 3. Validate all legs were qualified successfully before pricing
+    if len(qualified_legs) != len(leg_contracts):
+        logging.error(f"Qualification returned {len(qualified_legs)}/{len(leg_contracts)} legs. Aborting.")
+        return None
+
     for leg in qualified_legs:
         if leg.conId == 0:
             logging.error(f"Strike not listed: {leg.right} @ {leg.strike} "


### PR DESCRIPTION
## Summary
- **Log collection race fix:** DEV and PROD crons both push to the `logs` branch at `:00`/`:30`. When they race, the loser gets a non-fast-forward rejection and `set -e` kills the script. Added retry loop (fetch + rebase + push, up to 3 attempts).
- **Restore leg count check (Fix D regression from #795):** `qualifyContractsAsync` only returns *successfully* qualified contracts — legs that get Error 200 are omitted, not returned with `conId=0`. Without the length check, zero-leg orders could slip through. Confirmed in PROD logs: both KCZ6 option legs got Error 200, `qualified_legs` was empty, and the count check correctly aborted.

## Test plan
- [x] Full test suite: 260 passed (5 pre-existing failures from PR #797 config refactor + chromadb, unrelated)
- [x] Verified 5 failures are pre-existing: same failures with and without this change
- [x] `grep validated_legs ib_interface.py` — still gone (uses `qualified_legs` directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)