### PR TITLE
⚡ Bolt: Parallelize Sentinel RSS Fetching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2025-01-31 - Efficient Timestamp Parsing
 **Learning:** Parsing timestamps on a large, concatenated dataframe repeatedly is O(N) where N grows with history. Parsing on the components *before* concatenation allows caching the parsed result for static historical data, reducing the runtime cost to O(New Data).
 **Action:** Implemented in `dashboard_utils.py` for council history loading.
+## 2025-02-04 - Parallel Sentinel Fetching
+**Learning:** Sequential execution of I/O bound tasks (like RSS fetching in sentinels) inside an `async` loop needlessly increases cycle duration. `asyncio.gather` reduces total latency from `sum(tasks)` to `max(tasks)`, which is critical for maintaining responsiveness in the single-threaded orchestrator loop.
+**Action:** Parallelize independent I/O tasks in `LogisticsSentinel` and `NewsSentinel`.

--- a/trading_bot/sentinels.py
+++ b/trading_bot/sentinels.py
@@ -808,10 +808,10 @@ class LogisticsSentinel(Sentinel):
              self._consecutive_failures = 0
              logger.info("LogisticsSentinel: Circuit breaker reset")
 
-        headlines = []
-        for url in self.urls:
-            new_titles = await self._fetch_rss_safe(url, self._seen_links, max_age_hours=48)
-            headlines.extend(new_titles)
+        # OPTIMIZATION: Fetch RSS feeds in parallel to reduce latency
+        tasks = [self._fetch_rss_safe(url, self._seen_links, max_age_hours=48) for url in self.urls]
+        results = await asyncio.gather(*tasks)
+        headlines = [title for sublist in results for title in sublist]
 
         # Save cache
         self._save_seen_cache()
@@ -989,10 +989,10 @@ class NewsSentinel(Sentinel):
             self._consecutive_failures = 0
             logger.info("NewsSentinel: Circuit breaker reset")
 
-        headlines = []
-        for url in self.urls:
-            new_titles = await self._fetch_rss_safe(url, self._seen_links, max_age_hours=48)
-            headlines.extend(new_titles)
+        # OPTIMIZATION: Fetch RSS feeds in parallel to reduce latency
+        tasks = [self._fetch_rss_safe(url, self._seen_links, max_age_hours=48) for url in self.urls]
+        results = await asyncio.gather(*tasks)
+        headlines = [title for sublist in results for title in sublist]
 
         # Save cache
         self._save_seen_cache()


### PR DESCRIPTION
Implemented `asyncio.gather` for RSS fetching in `LogisticsSentinel` and `NewsSentinel` to improve performance by executing network requests in parallel. This replaces the previous sequential iteration, significantly reducing the total time spent waiting for I/O operations. Added journal entry documenting the learning. Fixed an initial duplication error caught during review. Verified functionality with existing sentinel tests.

---
*PR created automatically by Jules for task [2261650613814396111](https://jules.google.com/task/2261650613814396111) started by @rozavala*