### PR TITLE
Add LLM JSON type guards and fix inventory search query

### DIFF
--- a/config/commodity_profiles.py
+++ b/config/commodity_profiles.py
@@ -451,7 +451,11 @@ COFFEE_ARABICA_PROFILE = CommodityProfile(
         "macro": "Search for 'USD BRL exchange rate forecast' and 'Brazil Central Bank Selic rate outlook'. Determine if the BRL is trending to encourage farmer selling.",
         "geopolitical": "Search for 'Red Sea shipping coffee delays', 'Brazil port of Santos wait times', and 'EUDR regulation delay latest news'. Determine if there are logistical bottlenecks.",
         "supply_chain": "Search for 'Cecafé Brazil coffee export report latest', 'Global container freight index rates', and 'Green coffee shipping manifest trends'. Analyze flow volume vs port capacity.",
-        "inventory": "Search for 'ICE Arabica Certified Stocks level current' and 'GCA Green Coffee stocks report latest'. Look for 'Backwardation' in the forward curve.",
+        "inventory": (
+            "Search for 'ICE coffee certified stocks level news 2026' and 'ICO monthly coffee market report global supply'. "
+            "Look for recent specific numbers in bags (e.g., 'ICE stocks rose to X bags'). "
+            "Search for 'coffee forward curve structure' to detect 'Backwardation' or 'Contango'."
+        ),
         "sentiment": "Search for 'Coffee COT report non-commercial net length'. Determine if market is overbought.",
         "technical": "Search for 'Coffee futures technical analysis {contract}' and '{contract} support resistance levels'. Look for 'RSI divergence' or 'Moving Average crossover'. IMPORTANT: You MUST find and explicitly state the current value of the '200-day Simple Moving Average (SMA)'.",
         "volatility": "Search for 'Coffee Futures Implied Volatility Rank current' and '{contract} option volatility skew'. Determine if option premiums are cheap or expensive relative to historical volatility.",

--- a/trading_bot/agents.py
+++ b/trading_bot/agents.py
@@ -565,6 +565,17 @@ OUTPUT FORMAT (JSON):
             # Parse response
             data = json.loads(self._clean_json_text(response))
 
+            # Type guard: LLM may return a JSON array instead of object
+            if isinstance(data, list):
+                data = {
+                    'raw_summary': str(data),
+                    'dated_facts': [item for item in data if isinstance(item, dict)],
+                    'data_freshness': '',
+                    'search_queries_used': []
+                }
+            elif not isinstance(data, dict):
+                data = {'raw_summary': str(data), 'dated_facts': [], 'data_freshness': '', 'search_queries_used': []}
+
             # === COMPUTE ACTUAL DATA FRESHNESS ===
             freshness_hours = self._compute_data_freshness(
                 data.get('dated_facts', []),
@@ -766,6 +777,8 @@ OUTPUT FORMAT (JSON):
             # Parse JSON
             try:
                 data = json.loads(self._clean_json_text(result_raw))
+                if not isinstance(data, dict):
+                    raise ValueError("LLM returned non-dict JSON")
                 # === A1-R1: Canonicalize confidence IMMEDIATELY after JSON parse ===
                 # Phase 2 LLMs may return band strings ('HIGH', 'MODERATE').
                 # Canonicalize here so ALL downstream code — including formatted_text,
@@ -880,6 +893,8 @@ OUTPUT FORMAT (JSON ONLY):
 
         try:
             data = json.loads(self._clean_json_text(revised_raw))
+            if not isinstance(data, dict):
+                raise ValueError("LLM returned non-dict JSON")
             # === A1-R1: Canonicalize confidence immediately (reflexion path) ===
             data['confidence'] = parse_confidence(data.get('confidence', 0.5))
         except (json.JSONDecodeError, ValueError, TypeError, KeyError):
@@ -988,6 +1003,8 @@ OUTPUT: JSON with 'proceed' (bool), 'risks' (list of strings), 'recommendation' 
                     raise ValueError("Empty response")
 
                 result = json.loads(cleaned)
+                if not isinstance(result, dict):
+                    raise ValueError("DA returned non-dict JSON")
 
                 # Validate required fields
                 if 'proceed' not in result:
@@ -1154,6 +1171,8 @@ OUTPUT: JSON with 'proceed' (bool), 'risks' (list of strings), 'recommendation' 
             response_text = await self._route_call(AgentRole.MASTER_STRATEGIST, full_prompt, response_json=True)
             cleaned_text = self._clean_json_text(response_text)
             decision = json.loads(cleaned_text)
+            if not isinstance(decision, dict):
+                raise ValueError("Master Strategist returned non-dict JSON")
 
             # === Direction Validation ===
             # LLM must return a valid direction. If missing or invalid, default to NEUTRAL


### PR DESCRIPTION
## Summary
- **Type guards on all 5 `json.loads()` sites in `agents.py`**: LLMs occasionally return `[{...}]` instead of `{...}`, crashing downstream `.get()` calls with `'list' object has no attribute 'get'`. Each site now validates the parsed type and raises `ValueError` (caught by existing exception handlers) or salvages list items where possible.
- **Inventory search query fix**: Replaced dead GCA (ceased publication ~2023) and unparseable ICE-direct queries with news-proxy intelligence targeting ICO monthly reports and financial news wires (Reuters, Barchart, StoneX) that publish ICE data in plain text.

## Test plan
- [x] `pytest tests/ --timeout=120` — 265 passed, 0 failed
- [x] Grep confirms 5 new `isinstance` guards in agents.py
- [x] Grep confirms old `ICE Arabica Certified Stocks level current` and `GCA Green Coffee stocks report latest` queries removed from research_prompts
- [x] Grep confirms new `ICO monthly coffee market report` query present
- [ ] Monitor PROD logs post-deploy for inventory agent returning data and no `'list' object has no attribute 'get'` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)