### PR TITLE
Add json.loads type guards to orchestrator and TMS

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -760,6 +760,8 @@ Return JSON: {{"verdict": "HOLD" or "CLOSE", "confidence": 0.0-1.0, "reasoning":
             # Clean up response if needed (remove markdown)
             clean_response = verdict_response.replace('```json', '').replace('```', '')
             verdict_data = json.loads(clean_response)
+            if not isinstance(verdict_data, dict):
+                raise ValueError("Thesis validation returned non-dict JSON")
             if verdict_data.get('verdict') == 'CLOSE' and verdict_data.get('confidence', 0) > confidence_threshold:
                 return {
                     'action': 'CLOSE',

--- a/trading_bot/tms.py
+++ b/trading_bot/tms.py
@@ -533,7 +533,8 @@ class TransactiveMemory:
                 include=['documents', 'metadatas']
             )
             if results and results['documents']:
-                return json.loads(results['documents'][0])
+                data = json.loads(results['documents'][0])
+                return data if isinstance(data, dict) else None
             return None
         except Exception as e:
             logger.error(f"TMS retrieve_thesis failed: {e}")
@@ -554,7 +555,8 @@ class TransactiveMemory:
                 ]},
                 include=['documents', 'metadatas']
             )
-            return [json.loads(doc) for doc in results.get('documents', [])]
+            docs = [json.loads(doc) for doc in results.get('documents', [])]
+            return [d for d in docs if isinstance(d, dict)]
         except Exception as e:
             logger.error(f"TMS get_active_theses failed: {e}")
             return []
@@ -600,6 +602,8 @@ class TransactiveMemory:
                             continue
 
                         thesis_data = json.loads(doc_content)
+                        if not isinstance(thesis_data, dict):
+                            continue
                         # Ensure trade_id is present
                         metadata = results['metadatas'][i]
                         if 'trade_id' not in thesis_data and metadata:
@@ -641,6 +645,9 @@ class TransactiveMemory:
             # 2. Parse
             current_doc_str = results['documents'][0]
             current_doc = json.loads(current_doc_str)
+            if not isinstance(current_doc, dict):
+                logger.error(f"TMS update failed: Thesis {thesis_id} doc is not a dict")
+                return
 
             # 3. Update field
             current_doc['supporting_data'] = new_supporting_data


### PR DESCRIPTION
## Summary
Extends the type guard pattern from PR #807 to the remaining unguarded `json.loads()` sites:

- **`orchestrator.py:762`** — Thesis validation (exit logic). If LLM returns a JSON array, `.get('verdict')` would `AttributeError`. Now raises `ValueError`, caught by existing `except Exception` → logs clearly and returns `None` (hold position, fail-closed).
- **`tms.py:536`** — `retrieve_thesis()`: Returns `None` instead of a non-dict parsed value.
- **`tms.py:557`** — `get_active_theses()`: Filters out non-dict items from parsed document list.
- **`tms.py:602`** — `get_all_theses()`: Skips non-dict documents with `continue`.
- **`tms.py:643`** — `update_thesis_supporting_data()`: Early-returns with error log if parsed doc is not a dict.

All 5 sites already had broad `except Exception` handlers, so these were failing safely but logging misleading `AttributeError` traces instead of the real cause.

## Test plan
- [x] `pytest tests/ --timeout=120` — 265 passed, 0 failed
- [x] All guards are minimal (1-2 lines each), no behavioral change when JSON is well-formed
- [ ] Monitor PROD logs for clearer error messages when LLM returns malformed JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)