### PR TITLE
Expand reflexion self-critique loop to all 8 Tier 2 agents

### DIFF
--- a/config.json
+++ b/config.json
@@ -40,7 +40,8 @@
     "signal_threshold": 0.005,
     "min_underlying_volume": 20,
     "max_days_to_expiry": 180,
-    "min_voter_quorum": 3
+    "min_voter_quorum": 3,
+    "reflexion_agents": ["agronomist", "macro", "geopolitical", "sentiment", "technical", "volatility", "inventory", "supply_chain"]
   },
   "strategy_tuning": {
     "spread_width_percentage": 0.01425,

--- a/trading_bot/agents.py
+++ b/trading_bot/agents.py
@@ -1288,7 +1288,8 @@ OUTPUT: JSON with 'proceed' (bool), 'risks' (list of strings), 'recommendation' 
         logger.info(f"Waking up {active_agent_key}...")
 
         # Use Reflexion for high-ambiguity roles
-        if active_agent_key in ['agronomist', 'macro']:
+        reflexion_agents = self.full_config.get('strategy', {}).get('reflexion_agents', ['agronomist', 'macro'])
+        if active_agent_key in reflexion_agents:
             fresh_report = await self.research_topic_with_reflexion(active_agent_key, search_instruction, regime_context=regime_context)
         else:
             fresh_report = await self.research_topic(active_agent_key, search_instruction, regime_context=regime_context)


### PR DESCRIPTION
## Summary

- Expands the Tier 2 reflexion loop (`research_topic_with_reflexion()`) from 2 agents (agronomist, macro) to all 8 Tier 2 agents (+ geopolitical, sentiment, technical, volatility, inventory, supply_chain)
- Adds a `reflexion_agents` config key in `config.json` so reflexion can be toggled per-agent without code changes (falls back to `['agronomist', 'macro']` if key is missing)
- Cross-cue path (`research_topic()` for secondary agents) left unchanged — reflexion there would double cost with diminishing returns

## Cost impact

~$0.18-0.36/day extra (+1 LLM call per agent per fresh run, ~2-4 fresh runs/day with cache TTLs)

## Test plan

- [x] `pytest tests/ --timeout=120` — 265 passed, 0 failed
- [x] Config key parses correctly (`config.json` valid JSON)
- [x] Fallback default preserves original behavior if key is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)