### PR TITLE
Fix flaky test_initialization picking up real discovered_topics.json

### DIFF
--- a/tests/test_prediction_market_sentinel.py
+++ b/tests/test_prediction_market_sentinel.py
@@ -4,6 +4,16 @@ from unittest.mock import AsyncMock, patch, MagicMock
 from datetime import datetime, timezone, timedelta
 from trading_bot.sentinels import PredictionMarketSentinel, SentinelTrigger
 
+
+@pytest.fixture(autouse=True)
+def _no_discovered_topics(monkeypatch):
+    """Prevent tests from picking up real data/discovered_topics.json."""
+    monkeypatch.setattr(
+        PredictionMarketSentinel, '_merge_discovered_topics',
+        lambda self, static: [t for t in static if t.get('enabled', True)]
+    )
+
+
 @pytest.fixture
 def mock_config():
     return {


### PR DESCRIPTION
The test expected 1 topic (from mock config) but got 4 because _merge_discovered_topics read the real data/discovered_topics.json. Added autouse fixture to monkeypatch the merge to use only static topics.