### PR TITLE
Wire budget guard into LLM router for cost tracking

### DIFF
--- a/config/api_costs.json
+++ b/config/api_costs.json
@@ -7,8 +7,13 @@
         "claude-sonnet": {"input": 0.00300, "output": 0.01500},
         "claude-opus": {"input": 0.01500, "output": 0.07500},
         "grok-2": {"input": 0.00500, "output": 0.01000},
+        "gemini-3-flash-preview": {"input": 0.00010, "output": 0.00040},
+        "gemini-3-pro-preview": {"input": 0.00125, "output": 0.00500},
+        "grok-4-1-fast-reasoning": {"input": 0.00300, "output": 0.01500},
+        "grok-4-fast-non-reasoning": {"input": 0.00050, "output": 0.00200},
+        "o3": {"input": 0.01000, "output": 0.04000},
         "default": {"input": 0.00100, "output": 0.00200}
     },
-    "last_updated": "2026-01-31",
+    "last_updated": "2026-02-11",
     "notes": "Update when API pricing changes. Check provider pricing pages quarterly."
 }

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -53,7 +53,7 @@ from trading_bot.compliance import ComplianceGuardian
 from trading_bot.position_sizer import DynamicPositionSizer
 from trading_bot.weighted_voting import RegimeDetector
 from trading_bot.tms import TransactiveMemory
-from trading_bot.budget_guard import BudgetGuard
+from trading_bot.budget_guard import BudgetGuard, get_budget_guard
 from trading_bot.drawdown_circuit_breaker import DrawdownGuard
 from trading_bot.cycle_id import generate_cycle_id
 from trading_bot.strategy_router import route_strategy
@@ -4143,9 +4143,9 @@ async def main():
     global GLOBAL_DEDUPLICATOR
     GLOBAL_DEDUPLICATOR.critical_severity_threshold = config.get('sentinels', {}).get('critical_severity_threshold', 9)
 
-    # Initialize Budget Guard
+    # Initialize Budget Guard (singleton — shared with heterogeneous_router)
     global GLOBAL_BUDGET_GUARD
-    GLOBAL_BUDGET_GUARD = BudgetGuard(config)
+    GLOBAL_BUDGET_GUARD = get_budget_guard(config)
     logger.info(f"Budget Guard initialized. Daily limit: ${GLOBAL_BUDGET_GUARD.daily_budget}")
 
     # Initialize Drawdown Guard

--- a/tests/test_budget_guard_wiring.py
+++ b/tests/test_budget_guard_wiring.py
@@ -1,0 +1,275 @@
+"""Tests for Budget Guard wiring into HeterogeneousRouter.
+
+Validates:
+- Token extraction from each client's generate() returns (str, int, int)
+- Cost calculation via calculate_api_cost()
+- route() records cost after successful API call
+- Budget throttling blocks low-priority calls
+- Budget throttling allows critical calls
+- Cache hits skip budget check
+- Singleton factory returns same instance
+- Graceful degradation when budget guard is None
+- ROLE_PRIORITY covers all AgentRole values
+"""
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch, PropertyMock
+from trading_bot.heterogeneous_router import (
+    HeterogeneousRouter, AgentRole, ModelProvider
+)
+from trading_bot.budget_guard import (
+    BudgetGuard, BudgetThrottledError, CallPriority,
+    ROLE_PRIORITY, get_budget_guard, calculate_api_cost,
+    _load_cost_config,
+)
+
+
+MOCK_CONFIG = {
+    'gemini': {'api_key': 'mock_gemini'},
+    'openai': {'api_key': 'mock_openai'},
+    'anthropic': {'api_key': 'mock_anthropic'},
+    'xai': {'api_key': 'mock_xai'},
+    'model_registry': {
+        'openai': {'pro': 'gpt-4o', 'flash': 'gpt-4o-mini'},
+        'anthropic': {'pro': 'claude-3-opus'},
+        'gemini': {'pro': 'gemini-1.5-pro', 'flash': 'gemini-1.5-flash'},
+        'xai': {'pro': 'grok-1', 'flash': 'grok-beta'}
+    },
+    'cost_management': {
+        'daily_budget_usd': 15.0,
+        'warning_threshold_pct': 0.75,
+    }
+}
+
+
+@pytest.fixture
+def router():
+    with patch.dict('os.environ', {}, clear=True):
+        return HeterogeneousRouter(MOCK_CONFIG)
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    """Reset budget guard singleton between tests."""
+    import trading_bot.budget_guard as bg
+    bg._budget_guard_instance = None
+    bg._cost_config_cache = None
+    yield
+    bg._budget_guard_instance = None
+    bg._cost_config_cache = None
+
+
+# --- Cost Calculation Tests ---
+
+def test_calculate_api_cost_known_model():
+    """calculate_api_cost uses model-specific rates from api_costs.json."""
+    cost = calculate_api_cost("gpt-4o", 1000, 500)
+    # gpt-4o: input=0.00250/1k, output=0.01000/1k
+    # (1000/1000)*0.00250 + (500/1000)*0.01000 = 0.00250 + 0.00500 = 0.00750
+    assert abs(cost - 0.00750) < 0.0001
+
+
+def test_calculate_api_cost_default_fallback():
+    """Unknown models use default rates."""
+    cost = calculate_api_cost("some-unknown-model-xyz", 1000, 1000)
+    # default: input=0.001/1k, output=0.002/1k
+    # (1000/1000)*0.001 + (1000/1000)*0.002 = 0.003
+    assert abs(cost - 0.003) < 0.0001
+
+
+def test_calculate_api_cost_zero_tokens():
+    """Zero tokens return zero cost."""
+    cost = calculate_api_cost("gpt-4o", 0, 0)
+    assert cost == 0.0
+
+
+def test_calculate_api_cost_gemini_flash():
+    """Gemini Flash model matched by substring."""
+    cost = calculate_api_cost("gemini-3-flash-preview", 10000, 5000)
+    # gemini-3-flash-preview: input=0.00010/1k, output=0.00040/1k
+    # (10000/1000)*0.00010 + (5000/1000)*0.00040 = 0.001 + 0.002 = 0.003
+    assert abs(cost - 0.003) < 0.0001
+
+
+# --- Singleton Factory Tests ---
+
+def test_singleton_returns_none_without_config():
+    """get_budget_guard() returns None when no config provided and not initialized."""
+    result = get_budget_guard()
+    assert result is None
+
+
+def test_singleton_creates_instance():
+    """get_budget_guard(config) creates instance on first call."""
+    with patch.object(BudgetGuard, '_load_state'), \
+         patch.object(BudgetGuard, '_check_reset'):
+        bg = get_budget_guard(MOCK_CONFIG)
+        assert bg is not None
+        assert isinstance(bg, BudgetGuard)
+
+
+def test_singleton_returns_same_instance():
+    """Two get_budget_guard() calls return same instance."""
+    with patch.object(BudgetGuard, '_load_state'), \
+         patch.object(BudgetGuard, '_check_reset'):
+        bg1 = get_budget_guard(MOCK_CONFIG)
+        bg2 = get_budget_guard()
+        assert bg1 is bg2
+
+
+# --- ROLE_PRIORITY Coverage Tests ---
+
+def test_role_priority_covers_all_agent_roles():
+    """Every AgentRole.value has an entry in ROLE_PRIORITY."""
+    for role in AgentRole:
+        assert role.value in ROLE_PRIORITY, f"Missing ROLE_PRIORITY for {role.value}"
+
+
+def test_role_priority_tier_assignments():
+    """Verify priority tiers match architecture."""
+    assert ROLE_PRIORITY['compliance'] == CallPriority.CRITICAL
+    assert ROLE_PRIORITY['master'] == CallPriority.HIGH
+    assert ROLE_PRIORITY['permabear'] == CallPriority.HIGH
+    assert ROLE_PRIORITY['permabull'] == CallPriority.HIGH
+    assert ROLE_PRIORITY['agronomist'] == CallPriority.NORMAL
+    assert ROLE_PRIORITY['weather_sentinel'] == CallPriority.LOW
+
+
+# --- Route Budget Wiring Tests ---
+
+@pytest.mark.asyncio
+async def test_route_records_cost_on_success(router):
+    """route() calls record_cost after successful primary API call."""
+    mock_client = AsyncMock()
+    mock_client.generate.return_value = ("Analysis result", 500, 200)
+
+    mock_budget = MagicMock(spec=BudgetGuard)
+    mock_budget.check_budget.return_value = True
+
+    with patch.object(router, '_get_client', return_value=mock_client), \
+         patch('trading_bot.budget_guard.get_budget_guard', return_value=mock_budget):
+        result = await router.route(AgentRole.MASTER_STRATEGIST, "test prompt")
+
+    assert result == "Analysis result"
+    mock_budget.record_cost.assert_called_once()
+    call_args = mock_budget.record_cost.call_args
+    assert call_args[1].get('source') or 'router/master' in str(call_args)
+
+
+@pytest.mark.asyncio
+async def test_route_records_cost_on_fallback(router):
+    """route() calls record_cost after successful fallback API call."""
+    mock_fail = AsyncMock()
+    mock_fail.generate.side_effect = Exception("Primary failed")
+
+    mock_success = AsyncMock()
+    mock_success.generate.return_value = ("Fallback result", 300, 150)
+
+    mock_budget = MagicMock(spec=BudgetGuard)
+    mock_budget.check_budget.return_value = True
+
+    def client_side_effect(provider, model):
+        if provider == ModelProvider.OPENAI:
+            return mock_fail
+        return mock_success
+
+    with patch.object(router, '_get_client', side_effect=client_side_effect), \
+         patch('trading_bot.budget_guard.get_budget_guard', return_value=mock_budget):
+        result = await router.route(AgentRole.MASTER_STRATEGIST, "test")
+
+    assert result == "Fallback result"
+    mock_budget.record_cost.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_budget_throttle_blocks_low_priority(router):
+    """Budget throttling raises BudgetThrottledError for low-priority calls."""
+    mock_budget = MagicMock(spec=BudgetGuard)
+    mock_budget.check_budget.return_value = False  # Budget depleted
+
+    with patch('trading_bot.budget_guard.get_budget_guard', return_value=mock_budget):
+        with pytest.raises(BudgetThrottledError):
+            await router.route(AgentRole.AGRONOMIST, "test")
+
+
+@pytest.mark.asyncio
+async def test_budget_throttle_allows_critical(router):
+    """Budget allows CRITICAL priority calls even when throttling others."""
+    mock_client = AsyncMock()
+    mock_client.generate.return_value = ("Compliance OK", 200, 100)
+
+    mock_budget = MagicMock(spec=BudgetGuard)
+    mock_budget.check_budget.return_value = True  # CRITICAL still allowed
+
+    with patch.object(router, '_get_client', return_value=mock_client), \
+         patch('trading_bot.budget_guard.get_budget_guard', return_value=mock_budget):
+        result = await router.route(AgentRole.COMPLIANCE_OFFICER, "check")
+
+    assert result == "Compliance OK"
+    mock_budget.check_budget.assert_called_once_with(CallPriority.CRITICAL)
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_skips_budget_check(router):
+    """Cache hits return without budget check."""
+    # Pre-populate cache
+    router.cache.set(":test prompt", AgentRole.MASTER_STRATEGIST.value, "cached result")
+
+    mock_budget = MagicMock(spec=BudgetGuard)
+
+    with patch('trading_bot.budget_guard.get_budget_guard', return_value=mock_budget):
+        result = await router.route(AgentRole.MASTER_STRATEGIST, "test prompt")
+
+    assert result == "cached result"
+    mock_budget.check_budget.assert_not_called()
+    mock_budget.record_cost.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_graceful_degradation_no_budget_guard(router):
+    """route() works normally when get_budget_guard() returns None."""
+    mock_client = AsyncMock()
+    mock_client.generate.return_value = ("No budget tracking", 100, 50)
+
+    with patch.object(router, '_get_client', return_value=mock_client), \
+         patch('trading_bot.budget_guard.get_budget_guard', return_value=None):
+        result = await router.route(AgentRole.MASTER_STRATEGIST, "test")
+
+    assert result == "No budget tracking"
+
+
+@pytest.mark.asyncio
+async def test_no_cost_recorded_on_zero_tokens(router):
+    """route() skips record_cost when tokens are (0, 0)."""
+    mock_client = AsyncMock()
+    mock_client.generate.return_value = ("result", 0, 0)
+
+    mock_budget = MagicMock(spec=BudgetGuard)
+    mock_budget.check_budget.return_value = True
+
+    with patch.object(router, '_get_client', return_value=mock_client), \
+         patch('trading_bot.budget_guard.get_budget_guard', return_value=mock_budget):
+        await router.route(AgentRole.MASTER_STRATEGIST, "test")
+
+    mock_budget.record_cost.assert_not_called()
+
+
+# --- BudgetThrottledError in agents.py ---
+
+@pytest.mark.asyncio
+async def test_budget_throttle_not_caught_by_gemini_fallback():
+    """BudgetThrottledError propagates through _route_call without Gemini fallback."""
+    from trading_bot.agents import TradingCouncil
+
+    mock_router = AsyncMock()
+    mock_router.route.side_effect = BudgetThrottledError("Budget exhausted")
+
+    with patch.object(TradingCouncil, '__init__', lambda self, *a, **kw: None):
+        council = TradingCouncil.__new__(TradingCouncil)
+        council.use_heterogeneous = True
+        council.heterogeneous_router = mock_router
+        council.response_tracker = MagicMock()
+        council.response_tracker.record = MagicMock()
+
+        with pytest.raises(BudgetThrottledError):
+            await council._route_call(AgentRole.AGRONOMIST, "test prompt")

--- a/tests/test_hotfix_repro.py
+++ b/tests/test_hotfix_repro.py
@@ -31,7 +31,7 @@ async def test_metrics_crash():
 
             # Mock the client generation to succeed
             mock_client = MagicMock()
-            mock_client.generate = AsyncMock(return_value="Success response")
+            mock_client.generate = AsyncMock(return_value=("Success response", 100, 50))
 
             router._get_client = MagicMock(return_value=mock_client)
 

--- a/tests/test_router_fallback.py
+++ b/tests/test_router_fallback.py
@@ -27,7 +27,7 @@ def router():
 async def test_tier3_primary_success(router):
     """Test Master Strategist uses Primary (OpenAI Pro) successfully."""
     mock_client = AsyncMock()
-    mock_client.generate.return_value = "Primary Success"
+    mock_client.generate.return_value = ("Primary Success", 100, 50)
 
     with patch.object(router, '_get_client', return_value=mock_client) as mock_get_client:
         response = await router.route(AgentRole.MASTER_STRATEGIST, "test")
@@ -45,7 +45,7 @@ async def test_tier3_fallback_success(router):
     mock_fail.generate.side_effect = Exception("OpenAI Failed")
 
     mock_success = AsyncMock()
-    mock_success.generate.return_value = "Fallback Success"
+    mock_success.generate.return_value = ("Fallback Success", 100, 50)
 
     def side_effect(provider, model):
         if provider == ModelProvider.OPENAI:
@@ -93,7 +93,7 @@ async def test_tier1_sentinel_fallback(router):
     mock_fail.generate.side_effect = Exception("Gemini Failed")
 
     mock_success = AsyncMock()
-    mock_success.generate.return_value = "Sentinel Success"
+    mock_success.generate.return_value = ("Sentinel Success", 100, 50)
 
     def side_effect(provider, model):
         if provider == ModelProvider.GEMINI: # Primary for Sentinel

--- a/trading_bot/agents.py
+++ b/trading_bot/agents.py
@@ -21,6 +21,7 @@ from trading_bot.sentinels import SentinelTrigger
 from trading_bot.semantic_router import SemanticRouter
 from trading_bot.market_data_provider import format_market_context_for_prompt
 from trading_bot.heterogeneous_router import HeterogeneousRouter, AgentRole, get_router, CriticalRPCError
+from trading_bot.budget_guard import BudgetThrottledError
 from trading_bot.tms import TransactiveMemory
 from trading_bot.reliability_scorer import ReliabilityScorer
 from trading_bot.weighted_voting import calculate_weighted_decision, determine_trigger_type
@@ -437,6 +438,8 @@ class TradingCouncil:
                 try:
                     result = await self.heterogeneous_router.route(role, prompt, system_prompt, response_json)
                     return result
+                except BudgetThrottledError:
+                    raise  # Don't fall back to Gemini — budget applies to all providers
                 except Exception as e:
                     logger.warning(f"Router failed for {role.value}, falling back to Gemini: {e}")
 


### PR DESCRIPTION
## Summary
- Wire `BudgetGuard.record_cost()` into `HeterogeneousRouter.route()` so every LLM call records actual token-based cost and respects graduated priority throttling
- Client `generate()` methods now return `(text, input_tokens, output_tokens)` tuples with safe extraction from each provider's response metadata
- Add `get_budget_guard()` singleton factory, `BudgetThrottledError`, `ROLE_PRIORITY` mapping, and `calculate_api_cost()` to `budget_guard.py`
- `BudgetThrottledError` propagates through `agents._route_call()` without triggering Gemini fallback (budget applies to all providers)
- Orchestrator uses singleton so router and orchestrator share the same `BudgetGuard` instance

## Test plan
- [x] 17 new tests in `test_budget_guard_wiring.py` covering cost calculation, singleton, role priority coverage, route cost recording, throttling, cache bypass, graceful degradation
- [x] Updated `test_router_fallback.py` and `test_hotfix_repro.py` mock return values to match new tuple signature
- [x] Full suite: **314 passed, 0 failures**
- [x] Imports verified: `from trading_bot.budget_guard import get_budget_guard, ROLE_PRIORITY, calculate_api_cost`

🤖 Generated with [Claude Code](https://claude.com/claude-code)