### PR TITLE
Fix reflexion expansion and semantic cache audit gaps

### DIFF
--- a/config.json
+++ b/config.json
@@ -125,7 +125,7 @@
     }
   },
   "semantic_cache": {
-    "enabled": false,
+    "enabled": true,
     "similarity_threshold": 0.92,
     "ttl_minutes": 60,
     "max_entries": 100,

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -2659,8 +2659,10 @@ async def run_emergency_cycle(trigger: SentinelTrigger, config: dict, ib: IB):
                 # Load Regime Context
                 regime_context = load_regime_context()
 
-                # 5. Semantic Cache check (skip council if market state unchanged)
+                # 5. Semantic Cache — sentinel fire invalidates other sources' cached decisions
                 semantic_cache = get_semantic_cache(config)
+                semantic_cache.invalidate_cross_source(contract_name, trigger.source)
+
                 severity_threshold = config.get('semantic_cache', {}).get('severity_bypass_threshold', 8)
                 cache_bypass = trigger.severity >= severity_threshold
 

--- a/trading_bot/agents.py
+++ b/trading_bot/agents.py
@@ -1339,12 +1339,14 @@ OUTPUT: JSON with 'proceed' (bool), 'risks' (list of strings), 'recommendation' 
                         f"TASK: Re-evaluate your domain in light of this new information."
                     )
 
-                    # Run cued agents in parallel
+                    # Run cued agents in parallel (with reflexion if configured)
                     logger.info(f"Waking up cued agents: {cues_to_run}")
-                    cued_tasks = {
-                        agent: self.research_topic(agent, cue_instruction, regime_context=regime_context)
-                        for agent in cues_to_run
-                    }
+                    cued_tasks = {}
+                    for agent in cues_to_run:
+                        if agent in reflexion_agents:
+                            cued_tasks[agent] = self.research_topic_with_reflexion(agent, cue_instruction, regime_context=regime_context)
+                        else:
+                            cued_tasks[agent] = self.research_topic(agent, cue_instruction, regime_context=regime_context)
 
                     cued_results = await asyncio.gather(*cued_tasks.values(), return_exceptions=True)
 

--- a/trading_bot/signal_generator.py
+++ b/trading_bot/signal_generator.py
@@ -147,7 +147,7 @@ async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_ty
                 contract_sym = contract.localSymbol
 
                 # Agents using reflexion (double-check loop) for higher accuracy
-                _reflexion_agents = {'agronomist', 'technical'}
+                _reflexion_agents = set(config.get('strategy', {}).get('reflexion_agents', ['agronomist', 'technical']))
 
                 tasks = {}
                 for agent_key in ['agronomist', 'macro', 'geopolitical', 'supply_chain',


### PR DESCRIPTION
## Summary
Audit of Phase 1 roadmap items found two incomplete implementations. This PR closes the gaps.

### A.3 Reflexion Expansion
- **signal_generator.py** hardcoded `{'agronomist', 'technical'}` instead of reading `config.strategy.reflexion_agents` (which lists all 8 Tier 2 agents). 6 of 8 agents were missing the two-step self-critique loop in regular cycles (~75% of cycles).
- **agents.py** cross-cued agents always called `research_topic()` — now checks if the agent is in `reflexion_agents` and uses `research_topic_with_reflexion()` when configured.

### C.1 Semantic Cache
- **config.json**: `enabled: false` → `true` — module was fully wired but switched off.
- **semantic_cache.py**: New `invalidate_cross_source(contract, keep_source)` method — when a sentinel fires, flushes cached decisions from *other* trigger sources while keeping the firing source's entries for rapid-fire dedup.
- **orchestrator.py**: Calls `invalidate_cross_source()` at emergency cycle entry before the cache check.

## Test plan
- [x] Full suite: **314 passed, 0 failures**
- [x] Reflexion config respected: `signal_generator.py` reads from `config.strategy.reflexion_agents`
- [x] Cross-cue path routes through reflexion when agent is in config list
- [x] Semantic cache enabled and cross-source invalidation wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)