### PR TITLE
Fix sentinel task crash: logger=None shadowed module logger

### DIFF
--- a/trading_bot/sentinels.py
+++ b/trading_bot/sentinels.py
@@ -622,7 +622,7 @@ class WeatherSentinel(Sentinel):
             return None
 
         except Exception as e:
-            self.logger.error(f"Error checking weather for {region.name}: {e}")
+            logger.error(f"Error checking weather for {region.name}: {e}")
             return None
 
     def _determine_drought_direction(self, stage: str) -> str:
@@ -2041,10 +2041,7 @@ class MacroContagionSentinel(Sentinel):
     """
     Detects macro shocks that cause cross-asset contagion.
     """
-    def __init__(self, config, event_bus=None, logger=None):
-        # event_bus and logger are passed by orchestrator, but we also inherit config from base Sentinel
-        # Base Sentinel only takes config.
-        # Orchestrator instantiates sentinels with (config).
+    def __init__(self, config, event_bus=None, **kwargs):
         super().__init__(config)
 
         # Commodity-agnostic: load profile
@@ -2063,7 +2060,7 @@ class MacroContagionSentinel(Sentinel):
         self.client = genai.Client(api_key=api_key)
         self.model = self.sentinel_config.get('model', "gemini-3-flash-preview")
 
-        logger.info(f"MacroContagionSentinel initialized with model: {self.model} | "
+        _sentinel_diag.info(f"MacroContagionSentinel initialized with model: {self.model} | "
                      f"DXY thresholds: 1d={self.dxy_threshold_1d:.0%}, 2d={self.dxy_threshold_2d:.0%} | "
                      f"Commodity: {self.profile.name}")
 
@@ -2265,7 +2262,7 @@ class FundamentalRegimeSentinel(Sentinel):
     """
     Determine if the market is in DEFICIT or SURPLUS regime.
     """
-    def __init__(self, config, event_bus=None, logger=None):
+    def __init__(self, config, event_bus=None, **kwargs):
         super().__init__(config)
         ticker = config.get('commodity', {}).get('ticker', 'KC')
         self.profile = get_commodity_profile(ticker)


### PR DESCRIPTION
## Summary

**CRITICAL HOTFIX** — Sentinels have been dead in PROD since initial deployment.

- `MacroContagionSentinel.__init__` accepted `logger=None` as a parameter, which shadowed the module-level `logger`. When the orchestrator instantiates it with just `config`, `logger.info()` crashes: `'NoneType' object has no attribute 'info'`
- This crash killed the entire sentinel asyncio task during initialization, **before** the while loop's try/except could catch it — meaning all sentinels (Weather, Logistics, News, X, PredictionMarket, MacroContagion) were dead
- The crash was invisible until PR #820 added `add_done_callback` which logged: `SENTINEL TASK DIED: 'NoneType' object has no attribute 'info'`

Also fixed:
- `WeatherSentinel`: `self.logger.error()` → `logger.error()` (would crash on any weather API exception)
- `FundamentalRegimeSentinel`: same unused `logger=None` parameter removed

## Test plan
- [x] 320 tests pass
- [ ] Deploy to PROD and verify sentinel loop stays alive
- [ ] Confirm `logs/sentinels.log` shows sentinel check activity
- [ ] Verify `sentinel_health` appears in `data/state.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)