### PR TITLE
Add sentinels.log to log collection

### DIFF
--- a/scripts/collect_logs.sh
+++ b/scripts/collect_logs.sh
@@ -111,7 +111,7 @@ if [ -d "$REPO_DIR/logs" ]; then
     echo "Copying specific log files..."
     mkdir -p "$DEST_DIR/logs"
 
-    for logfile in "orchestrator.log" "dashboard.log" "manual_test.log" "performance_analyzer.log" "equity_logger.log"; do
+    for logfile in "orchestrator.log" "dashboard.log" "manual_test.log" "performance_analyzer.log" "equity_logger.log" "sentinels.log"; do
         if [ -f "$REPO_DIR/logs/$logfile" ]; then
             cp "$REPO_DIR/logs/$logfile" "$DEST_DIR/logs/"
         fi


### PR DESCRIPTION
## Summary
- Adds `sentinels.log` to the whitelist in `scripts/collect_logs.sh` so sentinel diagnostic logs are captured on the GitHub logs branch
- Without this, the new diagnostic logging added in PR #820 is only available on the server itself

## Test plan
- [ ] Deploy and run `collect_logs.sh` — verify `sentinels.log` appears in the logs branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)