### PR TITLE
Fix deploy failure: revert uv run python to python

### DIFF
--- a/install_log_collection.sh
+++ b/install_log_collection.sh
@@ -185,7 +185,7 @@ fi
 if [ -f "$REPO_DIR/config.json" ]; then
     echo "Copying config.json (redacted)..."
     # Redact sensitive keys before saving to logs
-    uv run python -c "import json,sys,re; r=lambda o: {k:(r(v) if not re.search(r'(key|token|secret|password|sig)',k,re.I) else '[REDACTED]') for k,v in o.items()} if isinstance(o,dict) else [r(x) for x in o] if isinstance(o,list) else o; json.dump(r(json.load(sys.stdin)), sys.stdout, indent=2)" < "$REPO_DIR/config.json" > "$DEST_DIR/config.json"
+    python3 -c "import json,sys,re; r=lambda o: {k:(r(v) if not re.search(r'(key|token|secret|password|sig)',k,re.I) else '[REDACTED]') for k,v in o.items()} if isinstance(o,dict) else [r(x) for x in o] if isinstance(o,list) else o; json.dump(r(json.load(sys.stdin)), sys.stdout, indent=2)" < "$REPO_DIR/config.json" > "$DEST_DIR/config.json"
 fi
 
 # === STATE FILES ===

--- a/scripts/collect_logs.sh
+++ b/scripts/collect_logs.sh
@@ -158,7 +158,7 @@ fi
 if [ -f "$REPO_DIR/config.json" ]; then
     echo "Copying config.json (redacted)..."
     # Redact sensitive keys before saving to logs
-    uv run python -c "import json,sys,re; r=lambda o: {k:(r(v) if not re.search(r'(key|token|secret|password|sig)',k,re.I) else '[REDACTED]') for k,v in o.items()} if isinstance(o,dict) else [r(x) for x in o] if isinstance(o,list) else o; json.dump(r(json.load(sys.stdin)), sys.stdout, indent=2)" < "$REPO_DIR/config.json" > "$DEST_DIR/config.json"
+    python3 -c "import json,sys,re; r=lambda o: {k:(r(v) if not re.search(r'(key|token|secret|password|sig)',k,re.I) else '[REDACTED]') for k,v in o.items()} if isinstance(o,dict) else [r(x) for x in o] if isinstance(o,list) else o; json.dump(r(json.load(sys.stdin)), sys.stdout, indent=2)" < "$REPO_DIR/config.json" > "$DEST_DIR/config.json"
 fi
 
 # === STATE FILES ===

--- a/scripts/start_orchestrator.sh
+++ b/scripts/start_orchestrator.sh
@@ -18,4 +18,4 @@ mkdir -p logs
 
 # Start
 echo "Starting orchestrator from $REPO_ROOT..."
-exec uv run python -u orchestrator.py
+exec python -u orchestrator.py

--- a/scripts/verify_deploy.sh
+++ b/scripts/verify_deploy.sh
@@ -84,7 +84,7 @@ echo "  [3/5] Checking Python imports..."
 # Each import block tests one phase of the HRO guide.
 # We test them individually so failures are pinpointed.
 
-uv run python -c "
+python -c "
 import sys
 errors = []
 
@@ -144,7 +144,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "  [4/5] Validating config files..."
-uv run python -c "
+python -c "
 import json, sys
 configs = ['config.json']
 
@@ -180,7 +180,7 @@ if [ -f "verify_system_readiness.py" ]; then
     # CRITICAL: Use `if !` pattern so set -e doesn't abort on non-zero exit.
     # The readiness check is NON-BLOCKING because IBKR/LLM/YFinance
     # may not be reachable during deploy but will be at runtime.
-    if ! uv run python verify_system_readiness.py --quick --skip-ibkr --skip-llm 2>/dev/null; then
+    if ! python verify_system_readiness.py --quick --skip-ibkr --skip-llm 2>/dev/null; then
         echo "    ⚠️  System readiness check had failures (non-blocking)"
     else
         echo "    ✅ System readiness OK"


### PR DESCRIPTION
## Summary
- PR #826 (Jules bot) replaced `python`/`python3` with `uv run python` in 4 shell scripts
- `uv` is not installed on the PROD server, causing `verify_deploy.sh` to fail at line 87 and trigger automatic rollback
- Reverts all 6 occurrences across `verify_deploy.sh`, `start_orchestrator.sh`, `collect_logs.sh`, and `install_log_collection.sh`

## Test plan
- [ ] Deploy to PROD — verify_deploy.sh passes step [3/5] Python imports
- [ ] Verify orchestrator starts normally via start_orchestrator.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)