### PR TITLE
🌿 Gardener: Refactor calculate_agent_scores

### DIFF
--- a/tests/test_calculate_agent_scores.py
+++ b/tests/test_calculate_agent_scores.py
@@ -11,6 +11,12 @@ sys.modules['streamlit'] = MagicMock()
 sys.modules['streamlit'].cache_data = lambda func=None, ttl=None: (lambda f: f) if func is None else func
 sys.modules['streamlit'].error = MagicMock()
 
+# Mock matplotlib to avoid heavy dependencies and import errors
+sys.modules['matplotlib'] = MagicMock()
+sys.modules['matplotlib.pyplot'] = MagicMock()
+sys.modules['matplotlib.dates'] = MagicMock()
+sys.modules['matplotlib.ticker'] = MagicMock()
+
 # Add project root to path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 


### PR DESCRIPTION
Refactored `calculate_agent_scores` in `dashboard_utils.py` into smaller helper functions (`_prepare_scoring_dataframe`, `_score_volatility_trades`, `_score_directional_trades`, `_calculate_final_percentages`) to improve readability and maintainability. Also updated `tests/test_calculate_agent_scores.py` to mock `matplotlib` to avoid heavy dependencies and ensure tests pass reliably. Linting issues were also addressed.

---
*PR created automatically by Jules for task [18372399323488605791](https://jules.google.com/task/18372399323488605791) started by @rozavala*