### PR TITLE
Set IB Gateway schedule offset to 0

### DIFF
--- a/config.json
+++ b/config.json
@@ -467,7 +467,7 @@
     "bearer_token": "LOADED_FROM_ENV"
   },
   "schedule": {
-    "dev_offset_minutes": -30,
+    "dev_offset_minutes": 0,
     "daily_trading_cutoff_et": {
       "hour": 12,
       "minute": 15


### PR DESCRIPTION
## Summary
- Changed `schedule.dev_offset_minutes` from `-30` to `0` in config.json
- Now that PROD has its own dedicated IB Gateway user, the "Civil War" avoidance offset between DEV and PROD is no longer needed
- The `apply_schedule_offset()` code path still runs but with offset=0 (no-op), keeping the option available if needed in the future

## Test plan
- [ ] Verify DEV orchestrator starts with offset=0 in logs (no more "Civil War" message showing -30 minutes)
- [ ] Confirm DEV and PROD sentinel/trading schedules align

🤖 Generated with [Claude Code](https://claude.com/claude-code)