### PR TITLE
Declutter orchestrator.log: route sentinel logs to sentinels.log

### DIFF
--- a/trading_bot/microstructure_sentinel.py
+++ b/trading_bot/microstructure_sentinel.py
@@ -8,6 +8,7 @@ Monitors:
 
 import logging
 import asyncio
+import os
 from datetime import datetime, timezone, time
 import pytz
 from dataclasses import dataclass, field
@@ -16,6 +17,16 @@ from collections import deque
 from trading_bot.sentinels import SentinelTrigger
 
 logger = logging.getLogger(__name__)
+
+# Route microstructure logs to sentinels.log, not orchestrator.log
+if not logger.handlers:
+    _ms_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'logs')
+    os.makedirs(_ms_dir, exist_ok=True)
+    _ms_handler = logging.FileHandler(os.path.join(_ms_dir, 'sentinels.log'))
+    _ms_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+    logger.addHandler(_ms_handler)
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
 
 
 class MicrostructureSentinel:


### PR DESCRIPTION
## Summary
- **Stop sentinel logger propagation** to orchestrator.log — `trading_bot.sentinels` and `trading_bot.microstructure_sentinel` now write directly to `logs/sentinels.log` with `propagate=False`
- **Remove high-frequency noise** — "Checking {sentinel}..." and "{sentinel}: no trigger" INFO lines removed from orchestrator.py (~2,500 lines/day eliminated). Heartbeat already proves the loop is alive.
- **Add emergency cycle OUTCOME logging** to sentinels.log — every exit point in `run_emergency_cycle` now logs `OUTCOME {source}: {result}` to the sentinel diagnostic logger, enabling full trigger-to-outcome tracing in one log file

### What stays in orchestrator.log
- Trigger detection announcements (from orchestrator's own logger)
- Emergency cycle gates (shutdown, cutoff, budget, drawdown)
- Compliance blocks, trade actions, debounce decisions
- Sentinel loop heartbeat, IB connection lifecycle
- All WARNING/ERROR/CRITICAL messages

### What moves to sentinels.log only
- All `trading_bot.sentinels` logger output (sentinel initialization, API errors, parse failures, circuit breaker state, RSS infrastructure)
- All `trading_bot.microstructure_sentinel` logger output
- New OUTCOME lines for full trigger lifecycle tracking

## Test plan
- [x] 313 tests pass (2 pre-existing config_loader failures excluded)
- [ ] After deploy, verify orchestrator.log is noticeably cleaner
- [ ] Verify sentinels.log captures all sentinel activity + OUTCOME lines
- [ ] Verify trigger detections still appear in orchestrator.log (from orchestrator's own logger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)