### PR TITLE
Fix 7 broken config tests + RSS security hardening

### DIFF
--- a/tests/test_config_loader_mechanic.py
+++ b/tests/test_config_loader_mechanic.py
@@ -23,6 +23,12 @@ SAMPLE_CONFIG = {
     "connection": {
         "port": 7497,
         "clientId": 1
+    },
+    "strategy": {
+        "quantity": 1
+    },
+    "risk_management": {
+        "min_confidence_threshold": 0.6
     }
 }
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -25,7 +25,9 @@ class TestConfigValidation(unittest.TestCase):
             "gemini": {"api_key": "LOADED_FROM_ENV"},
             "anthropic": {"api_key": "LOADED_FROM_ENV"},
             "openai": {"api_key": "LOADED_FROM_ENV"},
-            "xai": {"api_key": "LOADED_FROM_ENV"}
+            "xai": {"api_key": "LOADED_FROM_ENV"},
+            "strategy": {"quantity": 1},
+            "risk_management": {"min_confidence_threshold": 0.6}
         }
 
     @patch('config_loader.load_dotenv')

--- a/tests/test_rss_filtering.py
+++ b/tests/test_rss_filtering.py
@@ -55,8 +55,12 @@ async def test_rss_date_filtering_logic():
     with patch('aiohttp.ClientSession.get') as mock_get:
         mock_response = MagicMock()
         mock_response.status = 200
-        # Mock text() as an async method
-        mock_response.text = AsyncMock(return_value="dummy content")
+
+        # Mock content.iter_chunked to return dummy bytes (used by size-limited reader)
+        async def _chunk_gen(chunk_size):
+            yield b"dummy content"
+        mock_response.content = MagicMock()
+        mock_response.content.iter_chunked = _chunk_gen
 
         # Async context manager mock
         mock_ctx = MagicMock()


### PR DESCRIPTION
## Summary
- **Fix 7 broken tests** in `test_config_loader_mechanic.py` (4) and `test_config_validation.py` (3) — test configs were missing `strategy` and `risk_management` sections required by validation added in PR #826
- **Cherry-pick RSS security hardening** from PR #834 (code only, not the test/docs):
  - DoS protection: `_fetch_rss_safe` uses `iter_chunked` with 5MB size limit instead of unbounded `response.text()`
  - XML sanitization: `_escape_xml` strips invalid XML control characters (0x00-0x1F except tab/LF/CR)
  - `feedparser` receives raw bytes for more robust encoding detection
- **Fix `test_rss_filtering.py`** to mock `response.content.iter_chunked` instead of `response.text()`

## Test plan
- [x] All 320 tests pass (was 313 passed + 7 failed, now 320 passed + 0 failed)
- [x] `test_rss_date_filtering_logic` works with new chunked reading mock
- [x] All 7 previously broken config tests pass with added `strategy`/`risk_management` sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)