### PR TITLE
Add shared IB Gateway support for dev via Tailscale

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -35,7 +35,10 @@ def load_config() -> dict | None:
     # If .env has IB_PORT, use it. Otherwise keep config.json value.
     if os.getenv("IB_PORT"):
         config['connection']['port'] = int(os.getenv("IB_PORT"))
-    
+
+    if os.getenv("IB_HOST"):
+        config['connection']['host'] = os.getenv("IB_HOST").strip()
+
     if os.getenv("IB_CLIENT_ID"):
         config['connection']['clientId'] = int(os.getenv("IB_CLIENT_ID"))
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -4280,6 +4280,27 @@ async def main():
             "Trading mode is OFF. Analysis pipeline runs normally. No orders will be placed."
         )
 
+    # Remote Gateway indicator
+    ib_host = config.get('connection', {}).get('host', '127.0.0.1')
+    if ib_host not in ('127.0.0.1', 'localhost', '::1'):
+        logger.warning("=" * 60)
+        logger.warning(f"  IB GATEWAY: REMOTE ({ib_host})")
+        logger.warning(f"  Client IDs: DEV range (10-79)")
+        logger.warning(f"  Trading Mode: {config.get('trading_mode', 'LIVE')}")
+        logger.warning("=" * 60)
+        if not is_trading_off():
+            logger.critical(
+                "SAFETY: Remote gateway with TRADING_MODE=LIVE! "
+                "Set TRADING_MODE=OFF in .env for dev environments."
+            )
+            send_pushover_notification(
+                config.get('notifications', {}),
+                "REMOTE GW + LIVE MODE",
+                f"Orchestrator on remote GW ({ib_host}) with TRADING_MODE=LIVE. "
+                "Likely a misconfiguration — set TRADING_MODE=OFF.",
+                priority=1
+            )
+
     # Update deduplicator with config values
     global GLOBAL_DEDUPLICATOR
     GLOBAL_DEDUPLICATOR.critical_severity_threshold = config.get('sentinels', {}).get('critical_severity_threshold', 9)

--- a/scripts/ib_gateway_firewall.sh
+++ b/scripts/ib_gateway_firewall.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# ib_gateway_firewall.sh — Restrict IB Gateway port to localhost + Tailscale
+#
+# Usage: sudo bash scripts/ib_gateway_firewall.sh [PORT]
+#   PORT defaults to 4001 (IB Gateway live trading)
+#
+# Idempotent: flushes existing rules for the port before applying new ones.
+# Run on the PRODUCTION droplet to allow dev connections via Tailscale only.
+
+set -euo pipefail
+
+PORT="${1:-4001}"
+TAILSCALE_IF="tailscale0"
+
+echo "=== IB Gateway Firewall Setup ==="
+echo "Port: $PORT"
+echo "Tailscale interface: $TAILSCALE_IF"
+
+# Verify tailscale0 exists
+if ! ip link show "$TAILSCALE_IF" &>/dev/null; then
+    echo "ERROR: Interface $TAILSCALE_IF not found. Is Tailscale running?"
+    exit 1
+fi
+
+# Flush any existing rules for this port (idempotent)
+echo "Flushing existing rules for port $PORT..."
+iptables -S INPUT 2>/dev/null | grep -- "--dport $PORT" | while read -r rule; do
+    # Convert -A to -D for deletion
+    delete_rule="${rule/-A INPUT/-D INPUT}"
+    iptables $delete_rule 2>/dev/null || true
+done
+
+# Allow localhost (loopback)
+echo "Allowing localhost..."
+iptables -A INPUT -i lo -p tcp --dport "$PORT" -j ACCEPT
+
+# Allow Tailscale interface
+echo "Allowing Tailscale ($TAILSCALE_IF)..."
+iptables -A INPUT -i "$TAILSCALE_IF" -p tcp --dport "$PORT" -j ACCEPT
+
+# Drop everything else to this port
+echo "Dropping all other traffic to port $PORT..."
+iptables -A INPUT -p tcp --dport "$PORT" -j DROP
+
+echo "=== Firewall rules applied ==="
+echo ""
+echo "Current rules for port $PORT:"
+iptables -L INPUT -n -v | head -2
+iptables -L INPUT -n -v | grep "$PORT"
+echo ""
+echo "NOTE: These rules are NOT persistent across reboots."
+echo "To persist: apt install iptables-persistent && netfilter-persistent save"

--- a/tests/test_config_loader_mechanic.py
+++ b/tests/test_config_loader_mechanic.py
@@ -71,3 +71,28 @@ def test_notifications_valid_creds_loads(mock_config_file):
             config = config_loader.load_config()
             assert config["notifications"]["pushover_user_key"] == "user_key"
             assert config["notifications"]["pushover_api_token"] == "api_token"
+
+
+def test_ib_host_env_override(mock_config_file):
+    """IB_HOST env var should override the default connection host."""
+    with patch.dict(os.environ, {
+        "GEMINI_API_KEY": "test_key",
+        "PUSHOVER_USER_KEY": "u",
+        "PUSHOVER_API_TOKEN": "a",
+        "IB_HOST": "100.64.0.1",
+    }, clear=True):
+        with patch("config_loader.load_dotenv"):
+            config = config_loader.load_config()
+            assert config["connection"]["host"] == "100.64.0.1"
+
+
+def test_ib_host_default_when_not_set(mock_config_file):
+    """Without IB_HOST, connection.host should default to 127.0.0.1."""
+    with patch.dict(os.environ, {
+        "GEMINI_API_KEY": "test_key",
+        "PUSHOVER_USER_KEY": "u",
+        "PUSHOVER_API_TOKEN": "a",
+    }, clear=True):
+        with patch("config_loader.load_dotenv"):
+            config = config_loader.load_config()
+            assert config["connection"]["host"] == "127.0.0.1"

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1,7 +1,13 @@
 import pytest
 import asyncio
 from unittest.mock import MagicMock, patch, AsyncMock
-from trading_bot.connection_pool import IBConnectionPool
+from trading_bot.connection_pool import (
+    IBConnectionPool,
+    DEV_CLIENT_ID_BASE,
+    DEV_CLIENT_ID_JITTER,
+    DEV_CLIENT_ID_DEFAULT,
+    _is_remote_gateway,
+)
 
 @pytest.mark.asyncio
 async def test_get_connection_disconnects_on_failure():
@@ -41,3 +47,97 @@ async def test_get_connection_disconnects_on_failure():
 
         # Verify that it waited for cleanup (the 0.5s sleep)
         mock_sleep.assert_called_with(0.5)
+
+
+def test_is_remote_gateway():
+    """_is_remote_gateway returns True for non-localhost hosts."""
+    assert _is_remote_gateway({"connection": {"host": "100.64.0.1"}}) is True
+    assert _is_remote_gateway({"connection": {"host": "10.0.0.5"}}) is True
+    assert _is_remote_gateway({"connection": {"host": "127.0.0.1"}}) is False
+    assert _is_remote_gateway({"connection": {"host": "localhost"}}) is False
+    assert _is_remote_gateway({"connection": {"host": "::1"}}) is False
+    assert _is_remote_gateway({}) is False  # defaults to 127.0.0.1
+
+
+@pytest.mark.asyncio
+async def test_dev_client_id_range_for_remote_host():
+    """When config host is a Tailscale IP, client ID should be in 10-79 range."""
+    purpose = "test_dev_range"
+    config = {"connection": {"host": "100.64.0.1", "port": 4001}}
+
+    IBConnectionPool._instances.clear()
+    IBConnectionPool._locks.clear()
+    IBConnectionPool._reconnect_backoff.clear()
+    IBConnectionPool._consecutive_failures.clear()
+
+    with patch('trading_bot.connection_pool.IB') as MockIB, \
+         patch('trading_bot.connection_pool.asyncio.sleep', new_callable=AsyncMock):
+
+        mock_ib = MockIB.return_value
+        mock_ib.connectAsync = AsyncMock()
+        mock_ib.isConnected.return_value = False
+        mock_ib.disconnect = MagicMock()
+
+        await IBConnectionPool.get_connection(purpose, config)
+
+        # Verify connectAsync was called with a dev-range client ID (75-79 for unknown purpose)
+        call_kwargs = mock_ib.connectAsync.call_args
+        client_id = call_kwargs.kwargs.get('clientId') or call_kwargs[1].get('clientId')
+        assert DEV_CLIENT_ID_DEFAULT <= client_id <= DEV_CLIENT_ID_DEFAULT + DEV_CLIENT_ID_JITTER, \
+            f"Unknown purpose should use dev default range, got {client_id}"
+
+
+@pytest.mark.asyncio
+async def test_dev_client_id_known_purpose():
+    """Known purposes on remote host should use their specific dev ID base."""
+    purpose = "emergency"
+    config = {"connection": {"host": "100.64.0.1", "port": 4001}}
+
+    IBConnectionPool._instances.clear()
+    IBConnectionPool._locks.clear()
+    IBConnectionPool._reconnect_backoff.clear()
+    IBConnectionPool._consecutive_failures.clear()
+
+    with patch('trading_bot.connection_pool.IB') as MockIB, \
+         patch('trading_bot.connection_pool.asyncio.sleep', new_callable=AsyncMock):
+
+        mock_ib = MockIB.return_value
+        mock_ib.connectAsync = AsyncMock()
+        mock_ib.isConnected.return_value = False
+        mock_ib.disconnect = MagicMock()
+
+        await IBConnectionPool.get_connection(purpose, config)
+
+        call_kwargs = mock_ib.connectAsync.call_args
+        client_id = call_kwargs.kwargs.get('clientId') or call_kwargs[1].get('clientId')
+        expected_base = DEV_CLIENT_ID_BASE["emergency"]  # 20
+        assert expected_base <= client_id <= expected_base + DEV_CLIENT_ID_JITTER, \
+            f"Emergency purpose should use dev base {expected_base}, got {client_id}"
+
+
+@pytest.mark.asyncio
+async def test_prod_client_id_range_for_localhost():
+    """When config host is 127.0.0.1, client ID should be in production range (100-279)."""
+    purpose = "test_prod_range"
+    config = {"connection": {"host": "127.0.0.1", "port": 7497}}
+
+    IBConnectionPool._instances.clear()
+    IBConnectionPool._locks.clear()
+    IBConnectionPool._reconnect_backoff.clear()
+    IBConnectionPool._consecutive_failures.clear()
+
+    with patch('trading_bot.connection_pool.IB') as MockIB, \
+         patch('trading_bot.connection_pool.asyncio.sleep', new_callable=AsyncMock):
+
+        mock_ib = MockIB.return_value
+        mock_ib.connectAsync = AsyncMock()
+        mock_ib.isConnected.return_value = False
+        mock_ib.disconnect = MagicMock()
+
+        await IBConnectionPool.get_connection(purpose, config)
+
+        call_kwargs = mock_ib.connectAsync.call_args
+        client_id = call_kwargs.kwargs.get('clientId') or call_kwargs[1].get('clientId')
+        # Default prod base is 200 + random(0,9)
+        assert 200 <= client_id <= 209, \
+            f"Unknown purpose on localhost should use prod default range, got {client_id}"


### PR DESCRIPTION
## Summary
- **IB_HOST env var override** in `config_loader.py` — allows dev to point at prod's Gateway over Tailscale
- **Dev client ID range (10-79)** in `connection_pool.py` — avoids collision with prod IDs (100-279) when sharing a Gateway
- **Remote Gateway startup banner** in `orchestrator.py` — logs remote host + safety alarm if `TRADING_MODE=LIVE` on a remote gateway (Pushover priority=1 notification)
- **`scripts/ib_gateway_firewall.sh`** — idempotent iptables script to restrict Gateway port to localhost + Tailscale on prod

## How it works
Dev `.env` sets `IB_HOST=<prod-tailscale-ip>`, `IB_PORT=4001`, `TRADING_MODE=OFF`. The connection pool detects non-localhost host and switches to the compressed dev ID range. Existing `TRADING_MODE=OFF` guards in `ib_interface.py` prevent any order placement. All changes are backward-compatible — prod behavior is unchanged when `IB_HOST` is unset.

## Test plan
- [x] 6 new tests: `IB_HOST` override, default fallback, `_is_remote_gateway`, dev ID range (unknown + known purpose), prod ID range for localhost
- [x] Full suite: **361 passed, 0 failed**
- [ ] On dev droplet: set `IB_HOST` in `.env`, verify startup logs show `[REMOTE]` and `TRADING MODE: OFF`
- [ ] On dev droplet: `nc -zv <prod-tailscale-ip> 4001` connects
- [ ] On prod: run `sudo bash scripts/ib_gateway_firewall.sh` and verify no client ID collisions after dev connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)