### PR TITLE
Externalize schedule to config + per-instance task tracking

### DIFF
--- a/config.json
+++ b/config.json
@@ -478,7 +478,28 @@
     "daily_trading_cutoff_et": {
       "hour": 12,
       "minute": 15
-    }
+    },
+    "tasks": [
+      {"id": "start_monitoring",          "time_et": "03:30", "function": "start_monitoring",              "label": "Start Position Monitoring"},
+      {"id": "process_deferred_triggers", "time_et": "03:31", "function": "process_deferred_triggers",     "label": "Process Deferred Triggers"},
+      {"id": "cleanup_orphaned_theses",   "time_et": "05:00", "function": "cleanup_orphaned_theses",       "label": "Daily Thesis Cleanup"},
+      {"id": "signal_early",              "time_et": "09:00", "function": "guarded_generate_orders",       "label": "Signal: Early Session (04:00 ET)"},
+      {"id": "signal_euro",               "time_et": "11:00", "function": "guarded_generate_orders",       "label": "Signal: EU Overlap (06:00 ET)"},
+      {"id": "signal_us_open",            "time_et": "13:00", "function": "guarded_generate_orders",       "label": "Signal: US Open (08:00 ET)"},
+      {"id": "signal_peak",               "time_et": "15:00", "function": "guarded_generate_orders",       "label": "Signal: Peak Liquidity (10:00 ET)"},
+      {"id": "signal_settlement",         "time_et": "17:00", "function": "guarded_generate_orders",       "label": "Signal: Settlement (12:00 ET)"},
+      {"id": "audit_morning",             "time_et": "13:30", "function": "run_position_audit_cycle",      "label": "Audit: Morning (08:30 ET)"},
+      {"id": "close_stale_primary",       "time_et": "15:30", "function": "close_stale_positions",         "label": "Close Stale (Primary)"},
+      {"id": "audit_post_close",          "time_et": "15:45", "function": "run_position_audit_cycle",      "label": "Audit: Post-Close (10:45 ET)"},
+      {"id": "close_stale_fallback",      "time_et": "16:30", "function": "close_stale_positions_fallback","label": "Close Stale (Fallback)"},
+      {"id": "audit_pre_close",           "time_et": "17:15", "function": "run_position_audit_cycle",      "label": "Audit: Pre-Close (12:15 ET)"},
+      {"id": "emergency_hard_close",      "time_et": "17:30", "function": "emergency_hard_close",          "label": "Emergency Hard Close"},
+      {"id": "eod_shutdown",              "time_et": "18:00", "function": "cancel_and_stop_monitoring",    "label": "End-of-Day Shutdown"},
+      {"id": "log_equity_snapshot",       "time_et": "18:20", "function": "log_equity_snapshot",           "label": "Log Equity Snapshot"},
+      {"id": "reconcile_and_analyze",     "time_et": "18:25", "function": "reconcile_and_analyze",         "label": "Reconcile & Analyze"},
+      {"id": "brier_reconciliation",      "time_et": "18:35", "function": "run_brier_reconciliation",     "label": "Brier Reconciliation"},
+      {"id": "sentinel_effectiveness",    "time_et": "18:40", "function": "sentinel_effectiveness_check",  "label": "Sentinel Effectiveness Check"}
+    ]
   },
   "final_column_order": [
     "date",

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -15,6 +15,8 @@ import os
 import json
 import hashlib
 from collections import deque
+from dataclasses import dataclass
+from typing import Callable
 import time as time_module
 from datetime import datetime, time, timedelta, timezone
 import pytz
@@ -1910,13 +1912,31 @@ async def cancel_and_stop_monitoring(config: dict):
     logger.info("--- End-of-day shutdown sequence complete ---")
 
 
-def get_next_task(now_utc: datetime, schedule: dict) -> tuple[datetime, callable]:
+def get_next_task(now_utc: datetime, task_schedule):
     """Calculates the next scheduled task.
 
-    The schedule keys are in NY Local Time.
+    The schedule times are in NY Local Time.
     We calculate the corresponding UTC run time dynamically to handle DST.
     Automatically skips weekends (Saturday/Sunday).
+
+    Accepts either:
+      - list[ScheduledTask] → returns (datetime, ScheduledTask)
+      - dict{time: callable} → returns (datetime, callable)  [legacy compat]
     """
+    # Normalize input: convert legacy dict to list of ScheduledTask
+    if isinstance(task_schedule, dict):
+        items = [
+            ScheduledTask(
+                id=func.__name__, time_et=rt, function=func,
+                func_name=func.__name__, label=func.__name__,
+            )
+            for rt, func in task_schedule.items()
+        ]
+        _return_callable = True
+    else:
+        items = task_schedule
+        _return_callable = False
+
     ny_tz = pytz.timezone('America/New_York')
     utc = pytz.UTC
     now_ny = now_utc.astimezone(ny_tz)
@@ -1934,18 +1954,12 @@ def get_next_task(now_utc: datetime, schedule: dict) -> tuple[datetime, callable
 
     next_run_utc, next_task = None, None
 
-    # Sort by time
-    sorted_times = sorted(schedule.keys(), key=lambda t: (t.hour, t.minute))
-
-    for rt in sorted_times:
+    for task in items:
+        rt = task.time_et
         # Construct run time in NY for today
         try:
             candidate_ny = now_ny.replace(hour=rt.hour, minute=rt.minute, second=0, microsecond=0)
         except ValueError:
-            # Handle rare edge cases like 2:30 AM on DST change day (doesn't exist)
-            # by normalizing via adding 0 timedelta (or just skip)
-            # But simple replace usually works or raises.
-            # Ideally we use localize, but replace is robust enough for standard trading hours.
             continue
 
         # If this time has passed in NY, move to tomorrow
@@ -1953,21 +1967,20 @@ def get_next_task(now_utc: datetime, schedule: dict) -> tuple[datetime, callable
              candidate_ny += timedelta(days=1)
 
         # === CHECK IF CANDIDATE IS ON WEEKEND ===
-        # After potentially moving to tomorrow, check if we landed on a weekend
         if candidate_ny.weekday() == 5:  # Saturday -> Move to Monday
             candidate_ny += timedelta(days=2)
-            # logger.info(f"Task scheduled for Saturday moved to Monday {candidate_ny.strftime('%Y-%m-%d')}")
         elif candidate_ny.weekday() == 6: # Sunday -> Move to Monday
             candidate_ny += timedelta(days=1)
-            # logger.info(f"Task scheduled for Sunday moved to Monday {candidate_ny.strftime('%Y-%m-%d')}")
 
         # Convert to UTC
         candidate_utc = candidate_ny.astimezone(utc)
 
         if next_run_utc is None or candidate_utc < next_run_utc:
             next_run_utc = candidate_utc
-            next_task = schedule[rt]
+            next_task = task
 
+    if _return_callable and next_task is not None:
+        return next_run_utc, next_task.function
     return next_run_utc, next_task
 
 
@@ -4049,35 +4062,132 @@ async def guarded_generate_orders(config: dict):
     except Exception as e:
         logger.warning(f"Failed to invalidate semantic cache post-scheduled: {e}")
 
-schedule = {
-    time(3, 30): start_monitoring,
-    time(3, 31): process_deferred_triggers,
-    time(5, 0): cleanup_orphaned_theses,          # v3.1: Daily thesis cleanup
-    # --- Signal generation cycles (5x, ~2h apart across KC market hours) ---
-    # KC trades 04:00-13:30 ET (09:00-18:30 UTC). Spread cycles to sample
-    # different market conditions and accelerate Brier score calibration.
-    time(9, 0): guarded_generate_orders,           # 04:00 ET — Early session
-    time(11, 0): guarded_generate_orders,          # 06:00 ET — European overlap
-    time(13, 0): guarded_generate_orders,          # 08:00 ET — US morning open
-    time(15, 0): guarded_generate_orders,          # 10:00 ET — Peak liquidity
-    time(17, 0): guarded_generate_orders,          # 12:00 ET — Settlement window (ICE KC ~12:23 ET)
-    # --- Position management (US hours for liquidity) ---
-    time(13, 30): run_position_audit_cycle,        # 08:30 ET — Morning audit
-    time(15, 30): close_stale_positions,           # 10:30 ET — PRIMARY: Peak liquidity close
-    time(15, 45): run_position_audit_cycle,        # 10:45 ET — Post-close verification
-    time(16, 30): close_stale_positions_fallback,  # 11:30 ET — FALLBACK: Retry failures
-    time(17, 15): run_position_audit_cycle,        # 12:15 ET — Pre-close audit
-    time(17, 30): emergency_hard_close,            # 12:30 ET — SAFETY: Market orders
-    time(18, 0): cancel_and_stop_monitoring,       # 13:00 ET — End of session
-    time(18, 20): log_equity_snapshot,
-    time(18, 25): reconcile_and_analyze,           # v5.4: Backfill council_history FIRST
-    time(18, 35): run_brier_reconciliation,        # v5.4: Score against freshly backfilled data
-    time(18, 40): sentinel_effectiveness_check,    # Meta-monitor
+@dataclass
+class ScheduledTask:
+    """A single scheduled task with a unique ID for per-instance tracking."""
+    id: str           # Unique task ID (e.g., "signal_early")
+    time_et: time     # NY local time
+    function: Callable
+    func_name: str    # function.__name__, for RECOVERY_POLICY lookup
+    label: str        # Human-readable label for dashboard/logs
+
+# Maps config.json function name strings to actual Python callables.
+FUNCTION_REGISTRY = {
+    'start_monitoring': start_monitoring,
+    'process_deferred_triggers': process_deferred_triggers,
+    'cleanup_orphaned_theses': cleanup_orphaned_theses,
+    'guarded_generate_orders': guarded_generate_orders,
+    'run_position_audit_cycle': run_position_audit_cycle,
+    'close_stale_positions': close_stale_positions,
+    'close_stale_positions_fallback': close_stale_positions_fallback,
+    'emergency_hard_close': emergency_hard_close,
+    'cancel_and_stop_monitoring': cancel_and_stop_monitoring,
+    'log_equity_snapshot': log_equity_snapshot,
+    'reconcile_and_analyze': reconcile_and_analyze,
+    'run_brier_reconciliation': run_brier_reconciliation,
+    'sentinel_effectiveness_check': sentinel_effectiveness_check,
 }
 
-def apply_schedule_offset(original_schedule: dict, offset_minutes: int) -> dict:
-    new_schedule = {}
+
+def _build_default_schedule() -> list:
+    """Backward-compatible default schedule (19 tasks) as list[ScheduledTask]."""
+    defaults = [
+        ("start_monitoring",          time(3, 30),  start_monitoring,              "Start Position Monitoring"),
+        ("process_deferred_triggers", time(3, 31),  process_deferred_triggers,     "Process Deferred Triggers"),
+        ("cleanup_orphaned_theses",   time(5, 0),   cleanup_orphaned_theses,       "Daily Thesis Cleanup"),
+        ("signal_early",              time(9, 0),   guarded_generate_orders,       "Signal: Early Session (04:00 ET)"),
+        ("signal_euro",               time(11, 0),  guarded_generate_orders,       "Signal: EU Overlap (06:00 ET)"),
+        ("signal_us_open",            time(13, 0),  guarded_generate_orders,       "Signal: US Open (08:00 ET)"),
+        ("signal_peak",               time(15, 0),  guarded_generate_orders,       "Signal: Peak Liquidity (10:00 ET)"),
+        ("signal_settlement",         time(17, 0),  guarded_generate_orders,       "Signal: Settlement (12:00 ET)"),
+        ("audit_morning",             time(13, 30), run_position_audit_cycle,      "Audit: Morning (08:30 ET)"),
+        ("close_stale_primary",       time(15, 30), close_stale_positions,         "Close Stale (Primary)"),
+        ("audit_post_close",          time(15, 45), run_position_audit_cycle,      "Audit: Post-Close (10:45 ET)"),
+        ("close_stale_fallback",      time(16, 30), close_stale_positions_fallback,"Close Stale (Fallback)"),
+        ("audit_pre_close",           time(17, 15), run_position_audit_cycle,      "Audit: Pre-Close (12:15 ET)"),
+        ("emergency_hard_close",      time(17, 30), emergency_hard_close,          "Emergency Hard Close"),
+        ("eod_shutdown",              time(18, 0),  cancel_and_stop_monitoring,    "End-of-Day Shutdown"),
+        ("log_equity_snapshot",       time(18, 20), log_equity_snapshot,           "Log Equity Snapshot"),
+        ("reconcile_and_analyze",     time(18, 25), reconcile_and_analyze,         "Reconcile & Analyze"),
+        ("brier_reconciliation",      time(18, 35), run_brier_reconciliation,      "Brier Reconciliation"),
+        ("sentinel_effectiveness",    time(18, 40), sentinel_effectiveness_check,  "Sentinel Effectiveness Check"),
+    ]
+    return [
+        ScheduledTask(id=tid, time_et=t, function=fn, func_name=fn.__name__, label=lbl)
+        for tid, t, fn, lbl in defaults
+    ]
+
+
+def build_schedule(config: dict) -> list:
+    """Build schedule from config.json tasks array, falling back to defaults.
+
+    Returns list[ScheduledTask] sorted by time_et.
+    Raises ValueError on duplicate task IDs.
+    Logs warning and skips unknown function names.
+    """
+    tasks_cfg = config.get('schedule', {}).get('tasks')
+    if not tasks_cfg:
+        logger.info("No schedule.tasks in config — using built-in default schedule")
+        return _build_default_schedule()
+
+    result = []
+    seen_ids = set()
+    for entry in tasks_cfg:
+        task_id = entry['id']
+        if task_id in seen_ids:
+            raise ValueError(f"Duplicate schedule task ID: '{task_id}'")
+        seen_ids.add(task_id)
+
+        func_name = entry['function']
+        func = FUNCTION_REGISTRY.get(func_name)
+        if func is None:
+            logger.warning(f"Unknown function '{func_name}' in schedule task '{task_id}' — skipping")
+            continue
+
+        h, m = map(int, entry['time_et'].split(':'))
+        result.append(ScheduledTask(
+            id=task_id,
+            time_et=time(h, m),
+            function=func,
+            func_name=func_name,
+            label=entry.get('label', task_id),
+        ))
+
+    result.sort(key=lambda t: (t.time_et.hour, t.time_et.minute))
+    logger.info(f"Built config-driven schedule: {len(result)} tasks")
+    return result
+
+
+# Backward-compat: module-level schedule dict (used by test_weekend_behavior.py
+# and sequential_main). Keys are time objects, values are callables — note that
+# dict keys collapse duplicate times (e.g., multiple guarded_generate_orders).
+schedule = {task.time_et: task.function for task in _build_default_schedule()}
+
+
+def apply_schedule_offset(original_schedule, offset_minutes: int):
+    """Shift schedule times by offset_minutes.
+
+    Accepts list[ScheduledTask] (preferred) or dict (legacy).
+    Returns same type as input.
+    """
     today = datetime.now(timezone.utc).date()
+
+    if isinstance(original_schedule, list):
+        result = []
+        for task in original_schedule:
+            dt_original = datetime.combine(today, task.time_et)
+            dt_shifted = dt_original + timedelta(minutes=offset_minutes)
+            result.append(ScheduledTask(
+                id=task.id,
+                time_et=dt_shifted.time(),
+                function=task.function,
+                func_name=task.func_name,
+                label=task.label,
+            ))
+        return result
+
+    # Legacy dict path
+    new_schedule = {}
     for run_time, task_func in original_schedule.items():
         dt_original = datetime.combine(today, run_time)
         dt_shifted = dt_original + timedelta(minutes=offset_minutes)
@@ -4119,10 +4229,10 @@ RECOVERY_POLICY = {
     'sentinel_effectiveness_check':   {'policy': 'ALWAYS',        'idempotent': False},
 }
 
-# Startup validation: warn if schedule has tasks not covered by RECOVERY_POLICY
-_schedule_names = {func.__name__ for func in schedule.values()}
+# Startup validation: warn if default schedule has tasks not covered by RECOVERY_POLICY
+_schedule_func_names = {task.func_name for task in _build_default_schedule()}
 _policy_names = set(RECOVERY_POLICY.keys())
-_uncovered = _schedule_names - _policy_names
+_uncovered = _schedule_func_names - _policy_names
 if _uncovered:
     import logging as _log
     _log.getLogger(__name__).warning(
@@ -4139,8 +4249,9 @@ async def recover_missed_tasks(missed_tasks: list, config: dict):
     For non-idempotent tasks, checks the completion tracker to avoid
     re-executing tasks that already ran before a crash.
 
-    Deduplicates repeated functions (e.g., multiple run_position_audit_cycle
-    instances) — each unique function runs at most once during recovery.
+    Each unique task_id recovers independently — if 3 signal cycles were
+    missed, all 3 are evaluated (not deduplicated). RECOVERY_POLICY is
+    looked up by func_name (policy is about function behavior, not instance).
 
     IMPORTANT — Crash-during-execution edge case:
     If the orchestrator crashes AFTER a task sends an IB order but BEFORE
@@ -4151,7 +4262,7 @@ async def recover_missed_tasks(missed_tasks: list, config: dict):
     line of defense for this edge case.
 
     Args:
-        missed_tasks: List of (time, task_name, task_func) tuples
+        missed_tasks: List of ScheduledTask objects (or legacy (time, name, func) tuples)
         config: Application config dict
     """
     if not missed_tasks:
@@ -4172,36 +4283,50 @@ async def recover_missed_tasks(missed_tasks: list, config: dict):
     )
     market_open = is_market_open()
 
-    # Sort chronologically by time object (time objects are directly comparable)
-    sorted_missed = sorted(missed_tasks, key=lambda x: x[0])
+    # Normalize: support both ScheduledTask and legacy (time, name, func) tuples
+    normalized = []
+    for item in missed_tasks:
+        if isinstance(item, ScheduledTask):
+            normalized.append(item)
+        else:
+            # Legacy tuple: (time, task_name, task_func)
+            rt, name, func = item
+            normalized.append(ScheduledTask(
+                id=name, time_et=rt, function=func,
+                func_name=name, label=name,
+            ))
 
-    # Deduplicate: same function scheduled multiple times only runs once
-    seen_functions = set()
+    # Sort chronologically
+    sorted_missed = sorted(normalized, key=lambda t: (t.time_et.hour, t.time_et.minute))
+
+    # Deduplicate by task_id — each instance recovers independently
+    seen_ids = set()
     recovered = 0
     skipped = 0
     already_ran = 0
 
     logger.info(f"--- Recovery: Evaluating {len(sorted_missed)} missed tasks ---")
 
-    for run_time, task_name, task_func in sorted_missed:
-        if task_name in seen_functions:
+    for task in sorted_missed:
+        if task.id in seen_ids:
             logger.debug(
-                f"  ⏭️ {task_name} @ {run_time.strftime('%H:%M')} ET "
-                f"(duplicate, already recovered)"
+                f"  ⏭️ {task.id} @ {task.time_et.strftime('%H:%M')} ET "
+                f"(duplicate ID, already recovered)"
             )
             continue
-        seen_functions.add(task_name)
+        seen_ids.add(task.id)
 
+        # Look up policy by func_name (policy is about function behavior)
         policy_entry = RECOVERY_POLICY.get(
-            task_name, {'policy': 'MARKET_OPEN', 'idempotent': False}
+            task.func_name, {'policy': 'MARKET_OPEN', 'idempotent': False}
         )
         policy = policy_entry['policy']
         is_idempotent = policy_entry['idempotent']
 
         # --- Completion check for non-idempotent tasks ---
-        if not is_idempotent and has_task_completed_today(task_name):
+        if not is_idempotent and has_task_completed_today(task.id):
             logger.info(
-                f"✅ ALREADY RAN: {task_name} completed earlier today "
+                f"✅ ALREADY RAN: {task.id} completed earlier today "
                 f"(before restart). Skipping re-execution."
             )
             already_ran += 1
@@ -4230,21 +4355,21 @@ async def recover_missed_tasks(missed_tasks: list, config: dict):
 
         if should_run:
             logger.info(
-                f"🔄 RECOVERY: Running missed {task_name} "
-                f"(was scheduled {run_time.strftime('%H:%M')} ET)"
+                f"🔄 RECOVERY: Running missed {task.id} [{task.func_name}] "
+                f"(was scheduled {task.time_et.strftime('%H:%M')} ET)"
             )
             try:
-                await task_func(config)
-                record_task_completion(task_name)
-                logger.info(f"✅ RECOVERY: {task_name} completed")
+                await task.function(config)
+                record_task_completion(task.id)
+                logger.info(f"✅ RECOVERY: {task.id} completed")
                 recovered += 1
             except Exception as e:
                 logger.error(
-                    f"❌ RECOVERY: {task_name} failed: {e}\n"
+                    f"❌ RECOVERY: {task.id} failed: {e}\n"
                     f"{traceback.format_exc()}"
                 )
         else:
-            logger.info(f"⏭️ RECOVERY SKIP: {task_name} — {skip_reason}")
+            logger.info(f"⏭️ RECOVERY SKIP: {task.id} — {skip_reason}")
             skipped += 1
 
     total_evaluated = recovered + skipped + already_ran
@@ -4343,12 +4468,24 @@ async def main():
     env_name = os.getenv("ENV_NAME", "DEV") 
     is_prod = env_name.startswith("PROD")
 
-    current_schedule = schedule
+    # Build config-driven schedule (falls back to defaults if no tasks in config)
+    task_list = build_schedule(config)
+
+    # Runtime RECOVERY_POLICY validation for config-driven schedule
+    _cfg_func_names = {t.func_name for t in task_list}
+    _cfg_uncovered = _cfg_func_names - set(RECOVERY_POLICY.keys())
+    if _cfg_uncovered:
+        logger.warning(
+            f"Config schedule has functions without RECOVERY_POLICY entries "
+            f"(will use safe defaults): {_cfg_uncovered}"
+        )
+
     if not is_prod:
         schedule_offset_minutes = config.get('schedule', {}).get('dev_offset_minutes', -30)
         logger.info(f"Environment: {env_name}. Applying {schedule_offset_minutes} minute 'Civil War' avoidance offset.")
-        current_schedule = apply_schedule_offset(schedule, offset_minutes=schedule_offset_minutes)
+        task_list = apply_schedule_offset(task_list, offset_minutes=schedule_offset_minutes)
     else:
+        schedule_offset_minutes = 0
         logger.info("Environment: PROD 🚀. Using standard master schedule.")
 
     # === WRITE ACTIVE SCHEDULE FOR DASHBOARD ===
@@ -4359,16 +4496,15 @@ async def main():
             "generated_at": datetime.now(timezone.utc).isoformat(),
             "env": env_name,
             "offset_minutes": 0 if is_prod else schedule_offset_minutes,
-            "tasks": sorted(
-                [
-                    {
-                        "time_et": rt.strftime('%H:%M'),
-                        "name": func.__name__,
-                    }
-                    for rt, func in current_schedule.items()
-                ],
-                key=lambda t: t["time_et"]
-            )
+            "tasks": [
+                {
+                    "id": task.id,
+                    "time_et": task.time_et.strftime('%H:%M'),
+                    "name": task.func_name,
+                    "label": task.label,
+                }
+                for task in task_list
+            ]
         }
         schedule_file = os.path.join(
             os.path.dirname(__file__), 'data', 'active_schedule.json'
@@ -4387,13 +4523,13 @@ async def main():
     now_ny = datetime.now(timezone.utc).astimezone(ny_tz)
 
     missed_tasks = []
-    for run_time, task_func in current_schedule.items():
-        task_ny = now_ny.replace(hour=run_time.hour, minute=run_time.minute, second=0, microsecond=0)
+    for task in task_list:
+        task_ny = now_ny.replace(hour=task.time_et.hour, minute=task.time_et.minute, second=0, microsecond=0)
         if task_ny < now_ny:
-            missed_tasks.append((run_time, task_func.__name__, task_func))
+            missed_tasks.append(task)
 
     if missed_tasks:
-        missed_names = [f"  - {t.strftime('%H:%M')} ET: {name}" for t, name, _ in missed_tasks]
+        missed_names = [f"  - {t.time_et.strftime('%H:%M')} ET: {t.id}" for t in missed_tasks]
         logger.warning(
             f"⚠️ LATE START DETECTED: {len(missed_tasks)} scheduled tasks already passed:\n"
             + "\n".join(missed_names)
@@ -4436,24 +4572,24 @@ async def main():
         while True:
             try:
                 now_utc = datetime.now(pytz.UTC)
-                next_run_time, next_task_func = get_next_task(now_utc, current_schedule)
+                next_run_time, next_task = get_next_task(now_utc, task_list)
                 wait_seconds = (next_run_time - now_utc).total_seconds()
 
-                task_name = next_task_func.__name__
-                logger.info(f"Next task '{task_name}' scheduled for {next_run_time.strftime('%Y-%m-%d %H:%M:%S UTC')}. "
+                logger.info(f"Next task '{next_task.id}' ({next_task.label}) scheduled for "
+                            f"{next_run_time.strftime('%Y-%m-%d %H:%M:%S UTC')}. "
                             f"Waiting for {wait_seconds / 3600:.2f} hours.")
 
                 await asyncio.sleep(wait_seconds)
 
-                logger.info(f"--- Running scheduled task: {task_name} ---")
+                logger.info(f"--- Running scheduled task: {next_task.id} [{next_task.func_name}] ---")
 
                 # Set global cooldown during scheduled cycle (e.g. 10 mins)
                 # This prevents Sentinels from firing Emergency Cycles while we are busy
                 GLOBAL_DEDUPLICATOR.set_cooldown("GLOBAL", 600)
 
                 try:
-                    await next_task_func(config)
-                    record_task_completion(task_name)
+                    await next_task.function(config)
+                    record_task_completion(next_task.id)
                 finally:
                     # Clear cooldown immediately after task finishes
                     GLOBAL_DEDUPLICATOR.clear_cooldown("GLOBAL")

--- a/tests/test_schedule_config.py
+++ b/tests/test_schedule_config.py
@@ -1,0 +1,315 @@
+"""Tests for config-driven schedule infrastructure.
+
+Covers: build_schedule, _build_default_schedule, apply_schedule_offset,
+get_next_task (both ScheduledTask list and legacy dict), per-instance
+completion tracking, and active_schedule.json format.
+"""
+
+import pytest
+import json
+import os
+from datetime import datetime, time, timedelta
+from unittest.mock import MagicMock, AsyncMock, patch
+import pytz
+
+from orchestrator import (
+    ScheduledTask,
+    FUNCTION_REGISTRY,
+    build_schedule,
+    _build_default_schedule,
+    apply_schedule_offset,
+    get_next_task,
+    schedule,
+)
+
+
+# === build_schedule ===
+
+def test_build_schedule_from_config():
+    """Config tasks array produces correct ScheduledTask list."""
+    config = {
+        'schedule': {
+            'tasks': [
+                {'id': 'signal_early', 'time_et': '09:00', 'function': 'guarded_generate_orders', 'label': 'Signal: Early'},
+                {'id': 'signal_peak',  'time_et': '15:00', 'function': 'guarded_generate_orders', 'label': 'Signal: Peak'},
+                {'id': 'audit_am',     'time_et': '13:30', 'function': 'run_position_audit_cycle', 'label': 'Audit: AM'},
+            ]
+        }
+    }
+    result = build_schedule(config)
+
+    assert len(result) == 3
+    # Should be sorted by time
+    assert result[0].id == 'signal_early'
+    assert result[0].time_et == time(9, 0)
+    assert result[0].func_name == 'guarded_generate_orders'
+    assert result[0].label == 'Signal: Early'
+    assert callable(result[0].function)
+
+    assert result[1].id == 'audit_am'
+    assert result[1].time_et == time(13, 30)
+
+    assert result[2].id == 'signal_peak'
+    assert result[2].time_et == time(15, 0)
+
+
+def test_build_schedule_fallback():
+    """No 'tasks' key in config falls back to 19-task default."""
+    config = {'schedule': {'dev_offset_minutes': 0}}
+    result = build_schedule(config)
+    assert len(result) == 19
+    # Check a few known defaults
+    ids = [t.id for t in result]
+    assert 'signal_early' in ids
+    assert 'signal_euro' in ids
+    assert 'signal_us_open' in ids
+    assert 'signal_peak' in ids
+    assert 'signal_settlement' in ids
+    assert 'audit_morning' in ids
+    assert 'audit_post_close' in ids
+    assert 'audit_pre_close' in ids
+
+
+def test_build_schedule_empty_config():
+    """Empty config falls back to defaults."""
+    result = build_schedule({})
+    assert len(result) == 19
+
+
+def test_build_schedule_duplicate_id_raises():
+    """Duplicate task IDs raise ValueError."""
+    config = {
+        'schedule': {
+            'tasks': [
+                {'id': 'my_task', 'time_et': '09:00', 'function': 'guarded_generate_orders', 'label': 'A'},
+                {'id': 'my_task', 'time_et': '10:00', 'function': 'guarded_generate_orders', 'label': 'B'},
+            ]
+        }
+    }
+    with pytest.raises(ValueError, match="Duplicate schedule task ID.*my_task"):
+        build_schedule(config)
+
+
+def test_build_schedule_unknown_function_skipped():
+    """Unknown function names are skipped with a warning."""
+    config = {
+        'schedule': {
+            'tasks': [
+                {'id': 'good', 'time_et': '09:00', 'function': 'guarded_generate_orders', 'label': 'Good'},
+                {'id': 'bad',  'time_et': '10:00', 'function': 'nonexistent_function',    'label': 'Bad'},
+            ]
+        }
+    }
+    result = build_schedule(config)
+    assert len(result) == 1
+    assert result[0].id == 'good'
+
+
+# === _build_default_schedule ===
+
+def test_default_schedule_structure():
+    """Default schedule has 19 tasks with unique IDs."""
+    defaults = _build_default_schedule()
+    assert len(defaults) == 19
+    ids = [t.id for t in defaults]
+    assert len(set(ids)) == 19, "All task IDs must be unique"
+
+    # All functions must be callable
+    for task in defaults:
+        assert callable(task.function)
+        assert task.func_name == task.function.__name__
+        assert task.label  # non-empty label
+
+
+def test_default_schedule_matches_config():
+    """Default schedule IDs match the config.json tasks array."""
+    # Load config
+    config_path = os.path.join(os.path.dirname(__file__), '..', 'config.json')
+    with open(config_path) as f:
+        config = json.load(f)
+
+    config_ids = [t['id'] for t in config['schedule']['tasks']]
+    default_ids = [t.id for t in _build_default_schedule()]
+    assert config_ids == default_ids, "config.json task IDs must match built-in defaults"
+
+
+# === Backward-compat module-level schedule dict ===
+
+def test_module_schedule_dict_exists():
+    """Module-level `schedule` dict exists for backward compat."""
+    assert isinstance(schedule, dict)
+    assert len(schedule) > 0
+    # All values should be callables
+    for t, func in schedule.items():
+        assert isinstance(t, time)
+        assert callable(func)
+
+
+# === apply_schedule_offset ===
+
+def test_apply_offset_preserves_ids():
+    """Offset shifts times but preserves IDs and labels."""
+    tasks = [
+        ScheduledTask(id='signal_early', time_et=time(9, 0),
+                      function=MagicMock(), func_name='guarded_generate_orders',
+                      label='Signal: Early'),
+        ScheduledTask(id='audit_am', time_et=time(13, 30),
+                      function=MagicMock(), func_name='run_position_audit_cycle',
+                      label='Audit: AM'),
+    ]
+    shifted = apply_schedule_offset(tasks, offset_minutes=-30)
+
+    assert len(shifted) == 2
+    assert shifted[0].id == 'signal_early'
+    assert shifted[0].time_et == time(8, 30)
+    assert shifted[0].label == 'Signal: Early'
+    assert shifted[0].func_name == 'guarded_generate_orders'
+
+    assert shifted[1].id == 'audit_am'
+    assert shifted[1].time_et == time(13, 0)
+
+
+def test_apply_offset_legacy_dict():
+    """Offset on legacy dict returns a dict."""
+    mock_fn = MagicMock(__name__='mock_fn')
+    original = {time(9, 0): mock_fn}
+    shifted = apply_schedule_offset(original, offset_minutes=30)
+    assert isinstance(shifted, dict)
+    assert time(9, 30) in shifted
+    assert shifted[time(9, 30)] is mock_fn
+
+
+# === get_next_task ===
+
+def test_get_next_task_with_scheduled_tasks():
+    """get_next_task with list[ScheduledTask] returns (datetime, ScheduledTask)."""
+    mock_fn = MagicMock(__name__='mock_fn')
+    tasks = [
+        ScheduledTask(id='early', time_et=time(9, 0), function=mock_fn,
+                      func_name='mock_fn', label='Early Task'),
+        ScheduledTask(id='late', time_et=time(15, 0), function=mock_fn,
+                      func_name='mock_fn', label='Late Task'),
+    ]
+
+    # Wednesday 08:00 NY → next should be 'early' at 09:00
+    ny_tz = pytz.timezone('America/New_York')
+    utc = pytz.UTC
+    now_ny = ny_tz.localize(datetime(2026, 1, 14, 8, 0, 0))  # Wednesday
+    now_utc = now_ny.astimezone(utc)
+
+    next_run, next_task = get_next_task(now_utc, tasks)
+
+    assert isinstance(next_task, ScheduledTask)
+    assert next_task.id == 'early'
+    assert next_task.label == 'Early Task'
+
+    expected_ny = ny_tz.localize(datetime(2026, 1, 14, 9, 0, 0))
+    assert next_run == expected_ny.astimezone(utc)
+
+
+def test_get_next_task_legacy_dict():
+    """get_next_task with dict returns (datetime, callable) for backward compat."""
+    mock_task = MagicMock(__name__='mock_task')
+    test_schedule = {time(9, 0): mock_task}
+
+    ny_tz = pytz.timezone('America/New_York')
+    utc = pytz.UTC
+    now_ny = ny_tz.localize(datetime(2026, 1, 14, 8, 0, 0))  # Wednesday
+    now_utc = now_ny.astimezone(utc)
+
+    next_run, next_task = get_next_task(now_utc, test_schedule)
+
+    # Legacy path returns the callable directly, not a ScheduledTask
+    assert next_task is mock_task
+    assert not isinstance(next_task, ScheduledTask)
+
+
+def test_get_next_task_picks_correct_instance():
+    """With multiple same-function tasks, returns the correct instance by time."""
+    mock_fn = MagicMock(__name__='guarded_generate_orders')
+    tasks = [
+        ScheduledTask(id='signal_early', time_et=time(9, 0), function=mock_fn,
+                      func_name='guarded_generate_orders', label='Early'),
+        ScheduledTask(id='signal_peak', time_et=time(15, 0), function=mock_fn,
+                      func_name='guarded_generate_orders', label='Peak'),
+    ]
+
+    ny_tz = pytz.timezone('America/New_York')
+    utc = pytz.UTC
+
+    # At 10:00 → should pick signal_peak (09:00 already passed)
+    now_ny = ny_tz.localize(datetime(2026, 1, 14, 10, 0, 0))  # Wednesday, 10 AM
+    now_utc = now_ny.astimezone(utc)
+
+    _, next_task = get_next_task(now_utc, tasks)
+    assert next_task.id == 'signal_peak'
+
+
+# === Per-instance completion tracking ===
+
+def test_per_instance_completion_tracking():
+    """Different task_ids are tracked independently by task_tracker."""
+    from trading_bot.task_tracker import record_task_completion, has_task_completed_today
+
+    # Record two different signal completions
+    record_task_completion('signal_early')
+    record_task_completion('signal_euro')
+
+    assert has_task_completed_today('signal_early')
+    assert has_task_completed_today('signal_euro')
+    assert not has_task_completed_today('signal_us_open')
+    assert not has_task_completed_today('signal_peak')
+
+
+# === active_schedule.json format ===
+
+def test_active_schedule_json_format():
+    """Verify the active_schedule.json structure includes id and label fields."""
+    # Simulate what main() writes
+    task_list = _build_default_schedule()
+
+    schedule_data = {
+        "generated_at": datetime.now().isoformat(),
+        "env": "DEV",
+        "offset_minutes": 0,
+        "tasks": [
+            {
+                "id": task.id,
+                "time_et": task.time_et.strftime('%H:%M'),
+                "name": task.func_name,
+                "label": task.label,
+            }
+            for task in task_list
+        ]
+    }
+
+    assert len(schedule_data['tasks']) == 19
+
+    # Every entry has id, time_et, name, and label
+    for entry in schedule_data['tasks']:
+        assert 'id' in entry
+        assert 'time_et' in entry
+        assert 'name' in entry
+        assert 'label' in entry
+        assert entry['id']  # non-empty
+        assert entry['label']  # non-empty
+
+    # Verify unique IDs
+    ids = [e['id'] for e in schedule_data['tasks']]
+    assert len(set(ids)) == 19
+
+    # Verify signal tasks have distinct IDs but same function name
+    signal_entries = [e for e in schedule_data['tasks'] if e['name'] == 'guarded_generate_orders']
+    assert len(signal_entries) == 5
+    signal_ids = [e['id'] for e in signal_entries]
+    assert len(set(signal_ids)) == 5  # all unique
+
+
+# === FUNCTION_REGISTRY ===
+
+def test_function_registry_covers_all_defaults():
+    """All functions used in default schedule exist in FUNCTION_REGISTRY."""
+    defaults = _build_default_schedule()
+    for task in defaults:
+        assert task.func_name in FUNCTION_REGISTRY, f"{task.func_name} missing from FUNCTION_REGISTRY"
+        assert FUNCTION_REGISTRY[task.func_name] is task.function


### PR DESCRIPTION
## Summary
- **Schedule in config.json**: 19 tasks defined with unique IDs (`signal_early`, `signal_euro`, `audit_morning`, etc.), human-readable labels, and function mappings — adjustable without code changes
- **Per-instance tracking**: Dashboard Cockpit now shows each signal/audit cycle independently instead of collapsing duplicates by function name; recovery evaluates each missed instance separately
- **Backward compatible**: Legacy dict-based `schedule`, `get_next_task()`, and `apply_schedule_offset()` still work for existing tests and `sequential_main()`

### What this fixes
| Before | After |
|--------|-------|
| Cockpit shows "completed" after 1st of 5 signal cycles | Each cycle tracked distinctly (`signal_early`, `signal_euro`, ...) |
| `recover_missed_tasks` deduplicates by function name — only 1 of 3 missed cycles recovered | Deduplicates by task_id — all missed instances recover independently |
| Changing schedule times requires editing orchestrator.py | Edit `config.json` `schedule.tasks` array |

### Files changed
- `config.json` — Added `schedule.tasks` array (19 entries)
- `orchestrator.py` — `ScheduledTask` dataclass, `FUNCTION_REGISTRY`, `build_schedule()`, refactored `get_next_task`/`apply_schedule_offset`/`recover_missed_tasks`/main loop
- `dashboard_utils.py` — Per-instance labels via `id`/`label` from JSON, dual-key completion lookup for transition
- `tests/test_schedule_config.py` — 16 new tests

## Test plan
- [x] `pytest tests/test_schedule_config.py` — 16/16 pass (build_schedule, fallback, duplicate ID, unknown function, offset, get_next_task dispatch, per-instance tracking, JSON format)
- [x] `pytest tests/test_weekend_behavior.py` — 5/5 pass (backward compat confirmed)
- [x] `pytest tests/` — 385 passed, 0 failed (full suite, no regressions)
- [ ] Manual: restart orchestrator on dev, verify `data/active_schedule.json` has `id` and `label` fields
- [ ] Manual: Cockpit shows 19 distinct rows with per-instance labels
- [ ] Manual: after 2+ signal cycles, `data/task_completions.json` has separate entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)