### PR TITLE
⚡ Bolt: Optimize `calculate_agent_scores` memory usage

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2025-02-17 - Vectorized Decision Grading
 **Learning:** Iterating over DataFrame rows with `iterrows()` for conditional logic is extremely slow (O(N) Python loop overhead). Boolean masking and vectorized pandas operations provided a ~30x speedup for decision grading logic, which is critical for dashboard responsiveness as history grows.
 **Action:** Always prefer vectorized operations (`loc` with boolean masks) over row-wise iteration for data processing.
+## 2025-02-13 - Efficient DataFrame Copying
+**Learning:** Calling `df.copy()` on a large DataFrame copies all columns, including large text fields not needed for downstream processing. This introduces significant memory and CPU overhead. Subsetting to only necessary columns *before* copying reduced execution time by ~11% on large datasets (10k rows) and significantly lowered peak memory usage.
+**Action:** Always filter DataFrames to the minimal required columns before creating a copy for isolated processing.


### PR DESCRIPTION
**Optimization:**
- In `dashboard_utils.py`, modified `calculate_agent_scores` to select only the necessary columns (`prediction_type`, `strategy_type`, `volatility_outcome`, `volatility_sentiment`, `master_decision`, `entry_price`, `actual_trend_direction`, and agent columns) before calling `df.copy()`.
- This avoids copying large text columns like `master_reasoning` and `supporting_data` which are not used in the scoring logic but contribute significantly to memory overhead and copy time.

**Testing:**
- Added a new test case `test_calculate_agent_scores_basic` in `tests/test_dashboard_optimization.py` to verify the logic remains correct.
- Ran reproduction script on a synthetic large dataset (10,000 rows with large text fields) showing a reduction in execution time from ~79ms to ~71ms (~11% improvement) and reduced peak memory usage.
- Ran existing regression tests (`tests/test_dashboard_optimization.py`) which all passed.

**Impact:**
- Reduces the memory footprint of the dashboard when analyzing long history.
- Improves responsiveness of the "Scorecard" page.


---
*PR created automatically by Jules for task [11306204007550165945](https://jules.google.com/task/11306204007550165945) started by @rozavala*