### PR TITLE
Fix workflow permissions for model health check

### DIFF
--- a/.github/workflows/model-health-check.yml
+++ b/.github/workflows/model-health-check.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 14 * * 1'  # Every Monday 14:00 UTC (09:00 ET)
   workflow_dispatch:       # Allow manual trigger
 
+permissions:
+  issues: write
+
 jobs:
   check-models:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `permissions: issues: write` to the model health check workflow
- Without this, the "Create issue on failure" step gets a 403 from the GitHub API

First run revealed `XAI_API_KEY` secret is also incorrect — needs to be updated in repo settings separately.

## Test plan
- [ ] Fix `XAI_API_KEY` secret in repo settings
- [ ] Re-run the workflow: Actions → Weekly Model Availability Check → Run workflow
- [ ] Verify all 4 providers pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)