### PR TITLE
Add color cues to P&L metrics in Cockpit

### DIFF
--- a/pages/1_Cockpit.py
+++ b/pages/1_Cockpit.py
@@ -181,7 +181,12 @@ def render_thesis_card_enhanced(thesis: dict, live_data: dict, config: dict = No
 
         with cols[1]:
             if unrealized_pnl is not None:
-                st.metric("Unrealized P&L", f"${unrealized_pnl:+,.2f}")
+                st.metric(
+                    "Unrealized P&L",
+                    f"${unrealized_pnl:+,.2f}",
+                    delta=f"${unrealized_pnl:+,.2f}",
+                    delta_color="normal",
+                )
             else:
                 st.metric("Unrealized P&L", "N/A")
 
@@ -256,7 +261,12 @@ def render_portfolio_risk_summary(live_data: dict):
         if daily_pnl is None or (isinstance(daily_pnl, float) and math.isnan(daily_pnl)):
             st.metric("Daily P&L", "$0", delta="No data", delta_color="off")
         else:
-            st.metric("Daily P&L", f"${daily_pnl:+,.0f}")
+            st.metric(
+                "Daily P&L",
+                f"${daily_pnl:+,.0f}",
+                delta=f"${daily_pnl:+,.0f}",
+                delta_color="normal",
+            )
 
     with cols[3]:
         pos_count = len([p for p in live_data.get('open_positions', []) if p.position != 0])


### PR DESCRIPTION
## Summary

- Color-codes **Unrealized P&L** and **Daily P&L** in the Cockpit using `st.metric`'s native `delta` parameter (green for positive, red for negative)
- Replaces #857 which used raw markdown (broke `st.metric` card layout, had Python 3.9 compat issues, and fragile tests)

## Changes

Two `st.metric` calls updated in `pages/1_Cockpit.py` (+10 lines):
- Thesis card: Unrealized P&L now shows delta arrow with color
- Portfolio summary: Daily P&L now shows delta arrow with color

## Test plan
- [x] `pytest tests/` — 428 passed, 0 failed
- [ ] Visual verification on dashboard with live/mock data

🤖 Generated with [Claude Code](https://claude.com/claude-code)