### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSV Injection vulnerability in log files

### DIFF
--- a/tests/test_csv_sanitization.py
+++ b/tests/test_csv_sanitization.py
@@ -1,0 +1,26 @@
+import pytest
+from trading_bot.utils import sanitize_for_csv
+
+def test_sanitize_normal_string():
+    """Test that normal strings are left untouched."""
+    assert sanitize_for_csv("hello world") == "hello world"
+    assert sanitize_for_csv("123") == "123"
+    assert sanitize_for_csv("") == ""
+
+def test_sanitize_injection_patterns():
+    """Test that injection patterns are escaped."""
+    assert sanitize_for_csv("=1+1") == "'=1+1"
+    assert sanitize_for_csv("+1+1") == "'+1+1"
+    assert sanitize_for_csv("-1+1") == "'-1+1"
+    assert sanitize_for_csv("@SUM(1,1)") == "'@SUM(1,1)"
+
+def test_sanitize_non_string():
+    """Test that non-string inputs are handled gracefully."""
+    assert sanitize_for_csv(123) == 123
+    assert sanitize_for_csv(None) is None
+    assert sanitize_for_csv(1.23) == 1.23
+
+def test_sanitize_whitespace_prefix():
+    """Test that whitespace before injection characters is handled."""
+    # Ensure aggressive sanitization even with leading whitespace
+    assert sanitize_for_csv(" =1+1") == "' =1+1"


### PR DESCRIPTION
This PR addresses a High Priority security vulnerability: **CSV Injection (Formula Injection)**.

### Vulnerability
If an attacker (or a malfunctioning component/LLM) injects data starting with `=`, `+`, `-`, or `@` into fields like `message`, `reason`, or `master_reasoning`, and an admin opens the resulting CSV log file in Excel or Google Sheets, the spreadsheet software might execute the cell content as a formula. This can lead to:
- **Data Exfiltration:** Sending cell contents to an external server via `=HYPERLINK`.
- **Client-Side RCE:** In older versions of Excel, potentially executing system commands (DDE).

### Fix
I introduced a helper function `sanitize_for_csv` in `trading_bot/utils.py` that checks if a string starts with these dangerous characters (even with leading whitespace) and prepends a single quote `'` to neutralize the formula.

### Verification
A new test suite `tests/test_csv_sanitization.py` was added to verify:
- Normal strings are untouched.
- Strings starting with `=`, `+`, `-`, `@` are escaped.
- Strings with leading whitespace before triggers are also escaped.
- Non-string inputs are handled gracefully.

Ran `pytest tests/test_csv_sanitization.py` and `pytest tests/test_utils.py` to ensure correctness and no regressions.

---
*PR created automatically by Jules for task [10244332286866580824](https://jules.google.com/task/10244332286866580824) started by @rozavala*