### PR TITLE
Replace hardcoded coffee constants with profile-driven logic

### DIFF
--- a/trading_bot/agents.py
+++ b/trading_bot/agents.py
@@ -821,7 +821,7 @@ OUTPUT FORMAT (JSON):
             f"OUTPUT FORMAT (JSON ONLY):\n"
             f"{{ \n"
             f"  'evidence': 'Cite 3-5 specific data points from the Grounded Data Packet above.',\n"
-            f"  'analysis': 'Explain what this data implies for Coffee supply/demand.',\n"
+            f"  'analysis': 'Explain what this data implies for {self.commodity_profile.name if self.commodity_profile else 'commodity'} supply/demand.',\n"
             f"  'confidence': 0.0-1.0 (Float based on data quality),\n"
             f"  'sentiment': 'BULLISH'|'BEARISH'|'NEUTRAL'\n"
             f"}}"

--- a/verify_system_readiness.py
+++ b/verify_system_readiness.py
@@ -414,7 +414,7 @@ async def check_compliance_volume(config: dict) -> CheckResult:
         bag.symbol = ticker_sym
         bag.exchange = ibkr_exchange
         bag.currency = 'USD'
-        bag.comboLegs = [ComboLeg(conId=valid_option.conId, ratio=1, action='BUY', exchange='NYBOT')]
+        bag.comboLegs = [ComboLeg(conId=valid_option.conId, ratio=1, action='BUY', exchange=ibkr_exchange)]
 
         guardian = ComplianceGuardian({'compliance': config.get('compliance', {'max_volume_pct': 0.10})})
 


### PR DESCRIPTION
## Summary
- Replaces all hardcoded coffee-specific constants (37500 multiplier, strike >100 heuristic, NYBOT exchange, 03:30-13:30 hours, "Coffee" strings) with `CommodityProfile`-driven values across 7 files
- Fixes 4 CRITICAL issues that would produce wrong P&L, broken strike normalization, or incorrect exchange routing for non-KC commodities (e.g., Cocoa CC)
- Fixes 3 MEDIUM issues (dashboard hours, agent prompt template, sentinel keyword whitelists)

## Test plan
- [x] Full test suite: 437 passed, 0 failed
- [ ] Verify KC behavior unchanged in production (no regression)
- [ ] Verify CC profile loads correctly with new logic paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)