### PR TITLE
Fix model health check: add contents:read permission

### DIFF
--- a/.github/workflows/model-health-check.yml
+++ b/.github/workflows/model-health-check.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:       # Allow manual trigger
 
 permissions:
+  contents: read
   issues: write
 
 jobs:


### PR DESCRIPTION
## Summary

- Adds `contents: read` to the workflow permissions block

Root cause of #881: when a workflow declares explicit `permissions`, it replaces **all** defaults. The workflow only had `issues: write`, so `actions/checkout@v4` lost `contents: read` and failed with "repository not found". The failure handler then created a false-positive issue.

## Test plan

- [x] Trigger manually via Actions > Weekly Model Availability Check > Run workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)