### PR TITLE
Add automated issue-to-PR pipeline with Claude Code Action

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -1,0 +1,72 @@
+name: Auto-fix Issue with Claude
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.label.name == 'claude-fix' &&
+      !contains(github.event.issue.labels.*.name, 'claude-fix-attempted')
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are fixing issue #${{ github.event.issue.number }} in a production trading system.
+
+            BEFORE MAKING ANY CHANGES:
+            1. Read CLAUDE.md thoroughly — it contains critical project conventions
+            2. Run `git log --oneline -20` to understand recent changes
+            3. Check if recent commits are related to this issue's area
+            4. Read the issue carefully and understand the root cause
+
+            RULES:
+            - This is a PRODUCTION TRADING SYSTEM that trades real money
+            - NEVER modify execution-path files (order_manager.py, ib_interface.py,
+              compliance.py) without extreme care — these control real trades
+            - All components must fail closed — if unsure, block rather than allow
+            - Run `pytest tests/` before committing to verify no regressions
+            - Keep changes minimal and focused on the issue
+            - Create the PR with "Closes #${{ github.event.issue.number }}" in the body
+          claude_args: "--max-turns 30"
+
+      - name: Mark as attempted
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Add 'claude-fix-attempted' label to prevent re-runs
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'claude-fix-attempted',
+              });
+            } catch {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'claude-fix-attempted',
+                color: 'e0e0e0',
+              });
+            }
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['claude-fix-attempted'],
+            });

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -73,6 +73,12 @@ jobs:
             EOF
           } >> "$GITHUB_OUTPUT"
 
+      - name: Read triage model from config
+        id: model
+        run: |
+          MODEL=$(python3 -c "import json; c=json.load(open('config.json')); print(c.get('error_reporter',{}).get('triage_model', c.get('model_registry',{}).get('anthropic',{}).get('pro','claude-sonnet-4-5-20250929')))")
+          echo "id=$MODEL" >> "$GITHUB_OUTPUT"
+
       - name: Triage with Claude
         id: triage
         env:
@@ -83,67 +89,14 @@ jobs:
           ISSUE_LABELS: ${{ steps.issue.outputs.labels }}
           ISSUE_COMMENTS: ${{ steps.issue.outputs.comments }}
           PROJECT_CONTEXT: ${{ steps.context.outputs.FILES }}
+          TRIAGE_MODEL: ${{ steps.model.outputs.id }}
         run: |
-          # Read CLAUDE.md for project understanding (first 100 lines for token efficiency)
-          CLAUDE_MD=$(head -100 CLAUDE.md)
-
-          # Build the prompt
-          cat > /tmp/triage_prompt.json << 'PROMPT_EOF'
-          {
-            "model": "claude-sonnet-4-5-20250929",
-            "max_tokens": 1024,
-            "messages": [
-              {
-                "role": "user",
-                "content": "PLACEHOLDER"
-              }
-            ]
-          }
-          PROMPT_EOF
-
-          # Construct the actual prompt content
-          PROMPT_CONTENT=$(cat << CONTENT_EOF
-          You are a triage bot for a production commodity futures trading system (Real Options).
-
-          PROJECT CONTEXT:
-          ${CLAUDE_MD}
-
-          ${PROJECT_CONTEXT}
-
-          ISSUE #${ISSUE_NUMBER}:
-          Title: ${ISSUE_TITLE}
-          Author: ${ISSUE_AUTHOR}
-          Current Labels: ${ISSUE_LABELS}
-          Body:
-          ${ISSUE_BODY}
-
-          Comments: ${ISSUE_COMMENTS}
-
-          Triage this issue. Respond with ONLY a JSON object (no markdown, no code fences):
-          {
-            "priority": "critical|high|medium|low",
-            "category": "bug|feature|security|ops|docs|question",
-            "affected_components": ["list of affected files or modules"],
-            "summary": "1-2 sentence assessment",
-            "suggested_labels": ["label1", "label2"],
-            "requires_immediate_attention": true/false,
-            "recommended_action": "Brief recommendation for next steps"
-          }
-
-          Priority guide:
-          - critical: Production trading at risk, data loss, security vulnerability
-          - high: Affects trading decisions, model accuracy, or system reliability
-          - medium: Non-urgent improvements, non-critical bugs
-          - low: Documentation, cosmetic, nice-to-have
-          CONTENT_EOF
-          )
-
           # Use python to make the API call (handles JSON escaping properly)
           python3 << 'PYEOF'
           import json, os, urllib.request, urllib.error
 
           api_key = os.environ["ANTHROPIC_API_KEY"]
-          prompt = os.environ.get("PROMPT_CONTENT", "")
+          triage_model = os.environ.get("TRIAGE_MODEL", "claude-sonnet-4-5-20250929")
 
           # Reconstruct prompt from env vars
           claude_md = os.popen("head -100 CLAUDE.md").read()
@@ -188,7 +141,7 @@ jobs:
           - low: Documentation, cosmetic, nice-to-have"""
 
           payload = json.dumps({
-              "model": "claude-sonnet-4-5-20250929",
+              "model": triage_model,
               "max_tokens": 1024,
               "messages": [{"role": "user", "content": prompt_text}]
           }).encode()
@@ -284,6 +237,7 @@ jobs:
               p.affected_components.forEach(c => { body += `- \`${c}\`\n`; });
             }
             body += `\n### Recommended Action\n${p.recommended_action}\n`;
+            body += `\n> The \`claude-fix\` label has been added — Claude will automatically attempt a fix and create a PR.\n`;
             body += `\n---\n*🤖 Triaged by Claude Sonnet*`;
 
             await github.rest.issues.createComment({
@@ -297,7 +251,8 @@ jobs:
             const labelsToAdd = [
               `priority:${p.priority}`,
               p.category,
-              'triaged'
+              'triaged',
+              'claude-fix'
             ];
 
             // Ensure labels exist, create if needed
@@ -321,6 +276,7 @@ jobs:
                   'docs': '0075ca',
                   'question': 'd876e3',
                   'triaged': 'c5def5',
+                  'claude-fix': '6f42c1',
                 };
                 await github.rest.issues.createLabel({
                   owner: context.repo.owner,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,15 @@ These files are generated at runtime and tracked in `.gitignore`:
 - `*.sqlite3` - SQLite databases
 - `.env` - Secrets
 
+## Automated Issue-to-PR Pipeline
+
+Issues are automatically created from log errors (`scripts/error_reporter.py`), triaged by Claude (`issue-triage.yml`), and fixed by Claude Code (`claude-fix.yml`). The `claude-fix` label triggers the fix workflow.
+
+**When fixing issues (in CI or locally):**
+- Always check `git log --oneline -20` to understand recent changes before modifying code
+- Look for related recent commits that may provide context for the issue
+- Read the full issue including any triage comments for context
+
 ## Things to Watch Out For
 
 - **Tick rounding**: Coffee options have specific tick sizes. Use `utils.py` tick-rounding helpers, not raw floats.

--- a/config.json
+++ b/config.json
@@ -571,5 +571,19 @@
     "shipping_proxy",
     "volatility_index",
     "dgs10_yield"
-  ]
+  ],
+  "error_reporter": {
+    "enabled": true,
+    "github_owner": "rozavala",
+    "github_repo": "real_options",
+    "github_token_env": "GITHUB_ERROR_REPORTER_TOKEN",
+    "log_directory": "logs",
+    "dedup_cooldown_hours": 24,
+    "max_issues_per_day": 3,
+    "max_critical_issues_per_day": 5,
+    "daily_summary_threshold": 5,
+    "default_labels": ["automated", "error-report"],
+    "notify_on_issue_created": true,
+    "triage_model": "claude-sonnet-4-5-20250929"
+  }
 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -262,6 +262,16 @@ else
     echo "  ⏭️  No worktree sync script found, skipping"
 fi
 
+# =========================================================================
+# STEP 11: Error reporter cron (every 15 min) — idempotent cron.d file
+# =========================================================================
+echo "--- 11. Setting up error reporter cron... ---"
+cat > /etc/cron.d/trading-bot-error-reporter << CRON_EOF
+*/15 * * * * rodrigo cd $REPO_ROOT && $REPO_ROOT/venv/bin/python scripts/error_reporter.py >> logs/error_reporter.log 2>&1
+CRON_EOF
+chmod 644 /etc/cron.d/trading-bot-error-reporter
+echo "  ✅ Error reporter cron installed"
+
 echo ""
 echo "--- ✅ Deployment finished successfully! ---"
 echo "--- Commit: $CURR_COMMIT ---"

--- a/scripts/error_reporter.py
+++ b/scripts/error_reporter.py
@@ -1,0 +1,827 @@
+#!/usr/bin/env python3
+"""Automated Error-to-GitHub-Issue Reporter.
+
+Scans log files for ERROR/CRITICAL entries, classifies and deduplicates them,
+sanitizes sensitive data, and creates GitHub issues for tracking.
+
+Runs as a standalone cron job (every 15 minutes). Completely decoupled from
+the trading orchestrator — never imports or affects trading-path code.
+
+Usage:
+    python scripts/error_reporter.py            # Normal mode
+    python scripts/error_reporter.py --dry-run  # Parse only, no issues created
+
+Exit codes:
+    0 — Completed (issues may or may not have been created)
+    1 — Fatal error (config missing, lock contention, etc.)
+"""
+
+import hashlib
+import json
+import logging
+import os
+import re
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Allow imports from project root
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from config_loader import load_config
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger("ErrorReporter")
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LogEntry:
+    timestamp: str
+    logger_name: str
+    level: str  # "ERROR" or "CRITICAL"
+    message: str
+    source_file: str  # Which log file this came from
+
+
+@dataclass
+class ErrorSignature:
+    category: str  # "ib_connection", "llm_api", etc.
+    fingerprint: str  # MD5 of (category + normalized_message)
+    sample_message: str  # First occurrence, sanitized
+    count: int
+    first_seen: str
+    last_seen: str
+    level: str  # Highest severity seen
+
+
+# ---------------------------------------------------------------------------
+# Error classification
+# ---------------------------------------------------------------------------
+
+# Category → list of compiled regex patterns
+ERROR_PATTERNS: dict[str, list[re.Pattern]] = {
+    "ib_connection": [
+        re.compile(r"IB.*connection failed", re.IGNORECASE),
+        re.compile(r"reqPositionsAsync timed out", re.IGNORECASE),
+        re.compile(r"DISCONNECTED", re.IGNORECASE),
+        re.compile(r"Connection pool.*exhaust", re.IGNORECASE),
+        re.compile(r"IB Gateway.*not reachable", re.IGNORECASE),
+    ],
+    "llm_api": [
+        re.compile(r"CriticalRPCError", re.IGNORECASE),
+        re.compile(r"All.*providers? exhausted", re.IGNORECASE),
+        re.compile(r"Rate limit slot timeout", re.IGNORECASE),
+        re.compile(r"LLM.*call failed", re.IGNORECASE),
+        re.compile(r"API key.*invalid", re.IGNORECASE),
+    ],
+    "parse_error": [
+        re.compile(r"Could not parse", re.IGNORECASE),
+        re.compile(r"JSONDecodeError", re.IGNORECASE),
+        re.compile(r"Schema validation failed", re.IGNORECASE),
+        re.compile(r"Failed to parse.*response", re.IGNORECASE),
+    ],
+    "file_io": [
+        re.compile(r"Failed to save.*state", re.IGNORECASE),
+        re.compile(r"PermissionError", re.IGNORECASE),
+        re.compile(r"Error writing to", re.IGNORECASE),
+        re.compile(r"FileNotFoundError", re.IGNORECASE),
+    ],
+    "trading_execution": [
+        re.compile(r"Compliance.*failed", re.IGNORECASE),
+        re.compile(r"Error closing position", re.IGNORECASE),
+        re.compile(r"FLASH CRASH", re.IGNORECASE),
+        re.compile(r"Drawdown PANIC", re.IGNORECASE),
+        re.compile(r"Order.*rejected", re.IGNORECASE),
+    ],
+    "budget": [
+        re.compile(r"Budget.*hit", re.IGNORECASE),
+        re.compile(r"BudgetThrottledError", re.IGNORECASE),
+        re.compile(r"Capital.*exceeded", re.IGNORECASE),
+    ],
+    "data_integrity": [
+        re.compile(r"Reconciliation.*failed", re.IGNORECASE),
+        re.compile(r"corrupted timestamps", re.IGNORECASE),
+        re.compile(r"CSV.*corrupt", re.IGNORECASE),
+        re.compile(r"State file.*corrupt", re.IGNORECASE),
+    ],
+}
+
+# Patterns for transient errors that should be skipped entirely
+TRANSIENT_PATTERNS: list[re.Pattern] = [
+    re.compile(r"RSS.*timed?\s*out", re.IGNORECASE),
+    re.compile(r"rate limit.*fallback", re.IGNORECASE),
+    re.compile(r"weather.*fetch.*retry", re.IGNORECASE),
+    re.compile(r"Retrying in \d+ seconds", re.IGNORECASE),
+    re.compile(r"Temporary failure.*name resolution", re.IGNORECASE),
+]
+
+
+def classify_error(message: str) -> str | None:
+    """Classify an error message into a category. Returns None for transient errors."""
+    for pattern in TRANSIENT_PATTERNS:
+        if pattern.search(message):
+            return None  # Skip transient
+
+    for category, patterns in ERROR_PATTERNS.items():
+        for pattern in patterns:
+            if pattern.search(message):
+                return category
+
+    return "uncategorized"
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint normalization
+# ---------------------------------------------------------------------------
+
+# Patterns to normalize variable parts of messages before hashing
+_NORMALIZE_RULES: list[tuple[re.Pattern, str]] = [
+    (re.compile(r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}[\.\d]*[Z]?"), "<TS>"),
+    (re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE), "<UUID>"),
+    (re.compile(r"\b(orderId|permId|conId|reqId|order_id)[=: ]*\d+"), r"\1=<ID>"),
+    (re.compile(r"\b\d+\.\d+s\b"), "<N>s"),
+    (re.compile(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(:\d+)?"), "<HOST>"),
+    (re.compile(r"PID[=: ]*\d+"), "PID=<ID>"),
+]
+
+
+def normalize_for_fingerprint(message: str) -> str:
+    """Strip variable parts from a message before hashing."""
+    result = message
+    for pattern, replacement in _NORMALIZE_RULES:
+        result = pattern.sub(replacement, result)
+    return result
+
+
+def compute_fingerprint(category: str, message: str) -> str:
+    """Compute a stable fingerprint for deduplication."""
+    normalized = normalize_for_fingerprint(message)
+    raw = f"{category}:{normalized}"
+    return hashlib.md5(raw.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Log sanitizer
+# ---------------------------------------------------------------------------
+
+_SANITIZE_RULES: list[tuple[re.Pattern, str]] = [
+    # API keys / tokens / secrets (various formats)
+    (re.compile(r"(?i)(api[_-]?key|token|secret|password|authorization)[=: ]+\S+"), r"\1=<REDACTED>"),
+    (re.compile(r"sk-[a-zA-Z0-9]{20,}"), "<REDACTED>"),
+    (re.compile(r"AIza[a-zA-Z0-9_-]{35}"), "<REDACTED>"),
+    # IB account numbers (U1234567 or DU1234567)
+    (re.compile(r"\b[DU]{0,2}U\d{5,8}\b"), "<ACCT>"),
+    # Dollar amounts ($1,234.56 or 1234.56 USD)
+    (re.compile(r"\$[\d,]+\.?\d*"), "<AMT>"),
+    (re.compile(r"[\d,]+\.?\d*\s*USD"), "<AMT>"),
+    # Position sizes (bare numbers in context of lots/contracts)
+    (re.compile(r"\b\d+\s*(lots?|contracts?|shares?)\b", re.IGNORECASE), "<N> \\1"),
+    # Strike prices in option context
+    (re.compile(r"(?i)(strike|premium|price)[=: ]*[\d.]+"), r"\1=<PRICE>"),
+    # File paths with usernames
+    (re.compile(r"/home/\w+/"), "/home/<USER>/"),
+    (re.compile(r"/Users/\w+/"), "/Users/<USER>/"),
+    # Env var values for known sensitive vars
+    (re.compile(r"(?i)(GEMINI_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|XAI_API_KEY|"
+                r"PUSHOVER_USER_KEY|PUSHOVER_API_TOKEN|FLEX_TOKEN|FRED_API_KEY|"
+                r"NASDAQ_API_KEY|X_BEARER_TOKEN|GITHUB_TOKEN|IB_PASSWORD)[=: ]+\S+"),
+     r"\1=<REDACTED>"),
+]
+
+
+def sanitize_message(message: str) -> str:
+    """Redact sensitive data from a log message."""
+    result = message
+    for pattern, replacement in _SANITIZE_RULES:
+        result = pattern.sub(replacement, result)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Log file parsing
+# ---------------------------------------------------------------------------
+
+# Log format: "2026-02-16 10:30:45,123 - LoggerName - ERROR - The message"
+_LOG_LINE_RE = re.compile(
+    r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d+)\s+-\s+(\S+)\s+-\s+(ERROR|CRITICAL)\s+-\s+(.*)$"
+)
+
+# Pattern for rotated log files (date stamp in name) — skip these
+_ROTATED_LOG_RE = re.compile(r"-\d{4}-\d{2}-\d{2}T")
+
+
+def discover_log_files(log_dir: str) -> list[str]:
+    """Find all active (non-rotated) .log files in the given directory."""
+    log_path = Path(log_dir)
+    if not log_path.is_dir():
+        return []
+    result = []
+    for f in sorted(log_path.iterdir()):
+        if f.suffix == ".log" and not _ROTATED_LOG_RE.search(f.name):
+            result.append(str(f))
+    return result
+
+
+def parse_log_file(
+    filepath: str, start_offset: int = 0
+) -> tuple[list[LogEntry], int]:
+    """Parse ERROR/CRITICAL entries from a log file starting at byte offset.
+
+    Returns (entries, new_offset). Handles log rotation (file shrunk).
+    """
+    entries: list[LogEntry] = []
+    try:
+        file_size = os.path.getsize(filepath)
+    except OSError:
+        return entries, start_offset
+
+    # Rotation detection: file smaller than stored offset → reset
+    if file_size < start_offset:
+        start_offset = 0
+
+    if file_size == start_offset:
+        return entries, start_offset  # Nothing new
+
+    try:
+        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+            f.seek(start_offset)
+            # Skip first partial line if we seeked into the middle of a line
+            if start_offset > 0:
+                # Check if we're at a line boundary by reading the byte before
+                f.seek(start_offset - 1)
+                prev_char = f.read(1)
+                if prev_char != "\n":
+                    # We're mid-line, skip to the next line
+                    f.readline()
+                # else: we're at a line boundary, no skip needed
+            for line in f:
+                m = _LOG_LINE_RE.match(line.rstrip())
+                if m:
+                    entries.append(LogEntry(
+                        timestamp=m.group(1),
+                        logger_name=m.group(2),
+                        level=m.group(3),
+                        message=m.group(4),
+                        source_file=filepath,
+                    ))
+            new_offset = f.tell()
+    except OSError as e:
+        logger.warning(f"Could not read {filepath}: {e}")
+        return entries, start_offset
+
+    return entries, new_offset
+
+
+# ---------------------------------------------------------------------------
+# State management
+# ---------------------------------------------------------------------------
+
+STATE_VERSION = 1
+
+
+def _default_state() -> dict:
+    return {
+        "version": STATE_VERSION,
+        "last_run": "",
+        "log_offsets": {},
+        "reported_signatures": {},
+        "daily_counters": {"date": "", "issues_created": 0, "critical_issues_created": 0},
+        "accumulated_errors": {},
+    }
+
+
+def load_state(state_path: str) -> dict:
+    """Load reporter state from disk. Returns default state on any failure."""
+    try:
+        with open(state_path, "r") as f:
+            state = json.load(f)
+        if state.get("version") != STATE_VERSION:
+            logger.warning("State version mismatch, starting fresh")
+            return _default_state()
+        return state
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+        return _default_state()
+
+
+def save_state(state: dict, state_path: str) -> None:
+    """Atomically save state: temp file + fsync + os.replace."""
+    state["last_run"] = datetime.now(timezone.utc).isoformat()
+    state_dir = os.path.dirname(state_path)
+    if state_dir:
+        os.makedirs(state_dir, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=state_dir or ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(state, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, state_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Deduplication and rate limiting
+# ---------------------------------------------------------------------------
+
+def is_deduped(fingerprint: str, state: dict, cooldown_hours: int) -> bool:
+    """Check if this fingerprint was reported recently."""
+    reported = state.get("reported_signatures", {})
+    if fingerprint not in reported:
+        return False
+    cooldown_until = reported[fingerprint].get("cooldown_until", "")
+    if not cooldown_until:
+        return False
+    try:
+        until = datetime.fromisoformat(cooldown_until)
+        return datetime.now(timezone.utc) < until
+    except (ValueError, TypeError):
+        return False
+
+
+def check_rate_limit(state: dict, is_critical: bool, max_normal: int, max_critical: int) -> bool:
+    """Returns True if we're within rate limits (OK to create issue)."""
+    counters = state.get("daily_counters", {})
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if counters.get("date") != today:
+        # New day, reset counters
+        state["daily_counters"] = {"date": today, "issues_created": 0, "critical_issues_created": 0}
+        counters = state["daily_counters"]
+
+    if is_critical:
+        return counters.get("critical_issues_created", 0) < max_critical
+    else:
+        return counters.get("issues_created", 0) < max_normal
+
+
+def record_issue_created(state: dict, fingerprint: str, category: str,
+                         issue_number: int, cooldown_hours: int, is_critical: bool) -> None:
+    """Update state after creating an issue."""
+    now = datetime.now(timezone.utc)
+    cooldown_until = (now + timedelta(hours=cooldown_hours)).isoformat()
+
+    state.setdefault("reported_signatures", {})[fingerprint] = {
+        "category": category,
+        "reported_at": now.isoformat(),
+        "issue_number": issue_number,
+        "cooldown_until": cooldown_until,
+    }
+
+    counters = state.setdefault("daily_counters", {})
+    today = now.strftime("%Y-%m-%d")
+    if counters.get("date") != today:
+        counters.update({"date": today, "issues_created": 0, "critical_issues_created": 0})
+
+    if is_critical:
+        counters["critical_issues_created"] = counters.get("critical_issues_created", 0) + 1
+    else:
+        counters["issues_created"] = counters.get("issues_created", 0) + 1
+
+
+# ---------------------------------------------------------------------------
+# Issue formatting
+# ---------------------------------------------------------------------------
+
+_IMPACT_NOTES = {
+    "ib_connection": "IB connection issues can prevent order execution and position monitoring.",
+    "llm_api": "LLM API failures degrade decision quality — the council may produce incomplete analysis.",
+    "parse_error": "Parse errors may cause agents to produce fallback (conservative) decisions.",
+    "file_io": "File I/O errors can cause state loss or logging gaps.",
+    "trading_execution": "Trading execution errors may indicate failed orders or compliance blocks.",
+    "budget": "Budget errors indicate capital allocation limits have been reached.",
+    "data_integrity": "Data integrity errors may produce incorrect reconciliation or corrupt state.",
+    "uncategorized": "Investigate to determine impact on trading operations.",
+}
+
+
+def format_critical_issue(sig: ErrorSignature) -> tuple[str, str, list[str]]:
+    """Format a CRITICAL-level issue. Returns (title, body, labels)."""
+    title = f"[CRITICAL] {sig.category}: {_truncate(sig.sample_message, 80)}"
+    impact = _IMPACT_NOTES.get(sig.category, _IMPACT_NOTES["uncategorized"])
+
+    body = f"""## Error Report
+
+| Field | Value |
+|-------|-------|
+| **Category** | `{sig.category}` |
+| **Severity** | {sig.level} |
+| **First seen** | {sig.first_seen} |
+| **Last seen** | {sig.last_seen} |
+| **Occurrences** | {sig.count} |
+
+### Sample Log Entry
+
+```
+{sig.sample_message}
+```
+
+### Impact
+
+{impact}
+
+> The `claude-fix` label will be added after triage — Claude will automatically attempt a fix.
+
+---
+*Automated report by `scripts/error_reporter.py` — fingerprint: `{sig.fingerprint[:12]}`*
+"""
+    labels = ["automated", "error-report", "priority:critical"]
+    return title, body, labels
+
+
+def format_summary_issue(
+    date_str: str,
+    signatures: list[ErrorSignature],
+    total_count: int,
+) -> tuple[str, str, list[str]]:
+    """Format a daily summary issue. Returns (title, body, labels)."""
+    categories = sorted(set(s.category for s in signatures))
+    title = f"[Daily Summary] {date_str}: {total_count} errors across {len(categories)} categories"
+
+    # Build per-category breakdown
+    sections = []
+    for cat in categories:
+        cat_sigs = [s for s in signatures if s.category == cat]
+        cat_count = sum(s.count for s in cat_sigs)
+        lines = [f"### `{cat}` — {cat_count} occurrences\n"]
+        for sig in sorted(cat_sigs, key=lambda s: -s.count)[:5]:
+            lines.append(f"- **{sig.count}x** `{_truncate(sig.sample_message, 100)}`")
+        sections.append("\n".join(lines))
+
+    body = f"""## Daily Error Summary — {date_str}
+
+**Total errors:** {total_count}
+**Categories:** {', '.join(f'`{c}`' for c in categories)}
+
+{chr(10).join(sections)}
+
+> The `claude-fix` label will be added after triage — Claude will automatically attempt a fix.
+
+---
+*Automated report by `scripts/error_reporter.py`*
+"""
+    labels = ["automated", "error-report", "daily-summary"]
+    return title, body, labels
+
+
+def _truncate(s: str, maxlen: int) -> str:
+    return s if len(s) <= maxlen else s[:maxlen - 3] + "..."
+
+
+# ---------------------------------------------------------------------------
+# GitHub issue creation
+# ---------------------------------------------------------------------------
+
+class GitHubIssueCreator:
+    """Creates GitHub issues via the REST API using urllib (no extra deps)."""
+
+    API_BASE = "https://api.github.com"
+
+    def __init__(self, owner: str, repo: str, token: str):
+        self.owner = owner
+        self.repo = repo
+        self.token = token
+
+    def create_issue(self, title: str, body: str, labels: list[str]) -> int | None:
+        """Create a GitHub issue. Returns the issue number, or None on failure."""
+        url = f"{self.API_BASE}/repos/{self.owner}/{self.repo}/issues"
+        payload = json.dumps({
+            "title": title,
+            "body": body,
+            "labels": labels,
+        }).encode("utf-8")
+
+        req = urllib.request.Request(
+            url,
+            data=payload,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                result = json.loads(resp.read())
+                issue_number = result.get("number")
+                logger.info(f"Created issue #{issue_number}: {title}")
+                return issue_number
+        except urllib.error.HTTPError as e:
+            body_text = e.read().decode("utf-8", errors="replace")[:500]
+            logger.error(f"GitHub API error {e.code}: {body_text}")
+            return None
+        except Exception as e:
+            logger.error(f"GitHub API request failed: {e}")
+            return None
+
+    def ensure_labels_exist(self, labels: list[str]) -> None:
+        """Create labels if they don't exist (best-effort)."""
+        label_colors = {
+            "automated": "c5def5",
+            "error-report": "f9d0c4",
+            "priority:critical": "B60205",
+            "daily-summary": "0075ca",
+        }
+        for label in labels:
+            url = f"{self.API_BASE}/repos/{self.owner}/{self.repo}/labels"
+            payload = json.dumps({
+                "name": label,
+                "color": label_colors.get(label, "ededed"),
+            }).encode("utf-8")
+            req = urllib.request.Request(
+                url,
+                data=payload,
+                headers={
+                    "Authorization": f"Bearer {self.token}",
+                    "Accept": "application/vnd.github+json",
+                    "Content-Type": "application/json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+                method="POST",
+            )
+            try:
+                urllib.request.urlopen(req, timeout=10)
+            except urllib.error.HTTPError:
+                pass  # Label already exists (422) or other non-fatal error
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Lock file (prevent concurrent runs)
+# ---------------------------------------------------------------------------
+
+class LockFile:
+    """Simple PID-based lockfile."""
+
+    def __init__(self, path: str):
+        self.path = path
+        self._held = False
+
+    def acquire(self) -> bool:
+        """Try to acquire the lock. Returns False if another process holds it."""
+        try:
+            if os.path.exists(self.path):
+                with open(self.path, "r") as f:
+                    pid = int(f.read().strip())
+                # Check if PID is still running
+                try:
+                    os.kill(pid, 0)
+                    return False  # Process is alive, lock is held
+                except OSError:
+                    pass  # Stale lock, proceed to overwrite
+
+            os.makedirs(os.path.dirname(self.path) or ".", exist_ok=True)
+            with open(self.path, "w") as f:
+                f.write(str(os.getpid()))
+            self._held = True
+            return True
+        except Exception as e:
+            logger.warning(f"Lock acquisition failed: {e}")
+            return False
+
+    def release(self) -> None:
+        if self._held:
+            try:
+                os.unlink(self.path)
+            except OSError:
+                pass
+            self._held = False
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
+
+def run_pipeline(config: dict, dry_run: bool = False) -> int:
+    """Main pipeline: scan logs → classify → dedup → create issues.
+
+    Returns the number of issues created (0 in dry-run mode).
+    """
+    er_config = config.get("error_reporter", {})
+    if not er_config.get("enabled", False):
+        logger.info("Error reporter is disabled in config")
+        return 0
+
+    project_root = Path(__file__).resolve().parent.parent
+    log_dir = str(project_root / er_config.get("log_directory", "logs"))
+    state_path = str(project_root / "data" / "error_reporter_state.json")
+    cooldown_hours = er_config.get("dedup_cooldown_hours", 24)
+    max_normal = er_config.get("max_issues_per_day", 3)
+    max_critical = er_config.get("max_critical_issues_per_day", 5)
+    summary_threshold = er_config.get("daily_summary_threshold", 5)
+    default_labels = er_config.get("default_labels", ["automated", "error-report"])
+
+    # GitHub setup
+    github_owner = er_config.get("github_owner", "")
+    github_repo = er_config.get("github_repo", "")
+    token_env = er_config.get("github_token_env", "GITHUB_ERROR_REPORTER_TOKEN")
+    github_token = os.environ.get(token_env, "")
+
+    if not dry_run and not github_token:
+        logger.warning(f"No GitHub token found in ${token_env}, exiting gracefully")
+        return 0
+
+    github: GitHubIssueCreator | None = None
+    if not dry_run and github_token and github_owner and github_repo:
+        github = GitHubIssueCreator(github_owner, github_repo, github_token)
+
+    # Load state
+    state = load_state(state_path)
+
+    # Discover and parse log files
+    log_files = discover_log_files(log_dir)
+    if not log_files:
+        logger.info(f"No log files found in {log_dir}")
+        save_state(state, state_path)
+        return 0
+
+    all_entries: list[LogEntry] = []
+    offsets = state.get("log_offsets", {})
+
+    for lf in log_files:
+        prev_offset = offsets.get(lf, 0)
+        entries, new_offset = parse_log_file(lf, prev_offset)
+        offsets[lf] = new_offset
+        all_entries.extend(entries)
+
+    state["log_offsets"] = offsets
+
+    if not all_entries:
+        logger.info("No new ERROR/CRITICAL entries found")
+        save_state(state, state_path)
+        return 0
+
+    logger.info(f"Found {len(all_entries)} new error entries across {len(log_files)} log files")
+
+    # Classify and group by fingerprint
+    signatures: dict[str, ErrorSignature] = {}
+
+    for entry in all_entries:
+        category = classify_error(entry.message)
+        if category is None:
+            continue  # Transient, skip
+
+        sanitized = sanitize_message(entry.message)
+        fp = compute_fingerprint(category, entry.message)
+
+        if fp in signatures:
+            sig = signatures[fp]
+            sig.count += 1
+            sig.last_seen = entry.timestamp
+            if entry.level == "CRITICAL" and sig.level != "CRITICAL":
+                sig.level = "CRITICAL"
+        else:
+            signatures[fp] = ErrorSignature(
+                category=category,
+                fingerprint=fp,
+                sample_message=sanitized,
+                count=1,
+                first_seen=entry.timestamp,
+                last_seen=entry.timestamp,
+                level=entry.level,
+            )
+
+    if not signatures:
+        logger.info("All errors were transient, nothing to report")
+        save_state(state, state_path)
+        return 0
+
+    # Process signatures
+    issues_created = 0
+    accumulated_for_summary: list[ErrorSignature] = []
+
+    for fp, sig in signatures.items():
+        if is_deduped(fp, state, cooldown_hours):
+            logger.info(f"Skipping deduped: {sig.category} ({fp[:12]})")
+            continue
+
+        if sig.level == "CRITICAL":
+            # CRITICAL → immediate issue
+            if not check_rate_limit(state, is_critical=True, max_normal=max_normal, max_critical=max_critical):
+                logger.warning("Critical issue rate limit reached")
+                continue
+
+            title, body, labels = format_critical_issue(sig)
+            if dry_run:
+                logger.info(f"[DRY RUN] Would create issue: {title}")
+                logger.info(f"[DRY RUN] Labels: {labels}")
+            else:
+                if github:
+                    github.ensure_labels_exist(labels)
+                    issue_num = github.create_issue(title, body, labels)
+                    if issue_num:
+                        record_issue_created(state, fp, sig.category, issue_num,
+                                             cooldown_hours, is_critical=True)
+                        issues_created += 1
+        else:
+            # ERROR — accumulate for summary if count >= threshold, or
+            # create individual issue if count is very high
+            if sig.count >= summary_threshold:
+                accumulated_for_summary.append(sig)
+            # Even below threshold, track it for potential future summary
+            state.setdefault("accumulated_errors", {})[fp] = asdict(sig)
+
+    # Create daily summary if we have enough accumulated errors
+    if accumulated_for_summary:
+        total_count = sum(s.count for s in accumulated_for_summary)
+        if not check_rate_limit(state, is_critical=False, max_normal=max_normal, max_critical=max_critical):
+            logger.warning("Daily summary rate limit reached")
+        else:
+            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+            # Check dedup for summary (use a special fingerprint)
+            summary_fp = compute_fingerprint("daily_summary", today)
+            if not is_deduped(summary_fp, state, cooldown_hours):
+                title, body, labels = format_summary_issue(today, accumulated_for_summary, total_count)
+                if dry_run:
+                    logger.info(f"[DRY RUN] Would create summary issue: {title}")
+                else:
+                    if github:
+                        github.ensure_labels_exist(labels)
+                        issue_num = github.create_issue(title, body, labels)
+                        if issue_num:
+                            record_issue_created(state, summary_fp, "daily_summary",
+                                                 issue_num, cooldown_hours, is_critical=False)
+                            issues_created += 1
+                            # Clear accumulated errors after creating summary
+                            state["accumulated_errors"] = {}
+
+    save_state(state, state_path)
+    return issues_created
+
+
+def main() -> int:
+    """Entry point."""
+    dry_run = "--dry-run" in sys.argv
+
+    config = load_config()
+    if not config:
+        logger.error("Failed to load config")
+        return 1
+
+    er_config = config.get("error_reporter", {})
+    if not er_config.get("enabled", False):
+        logger.info("Error reporter disabled, exiting")
+        return 0
+
+    # Lockfile
+    project_root = Path(__file__).resolve().parent.parent
+    lock_path = str(project_root / "data" / ".error_reporter.lock")
+    lock = LockFile(lock_path)
+    if not lock.acquire():
+        logger.warning("Another error_reporter instance is running, exiting")
+        return 0
+
+    try:
+        issues_created = run_pipeline(config, dry_run=dry_run)
+
+        # Send Pushover notification if issues were created
+        if issues_created > 0 and er_config.get("notify_on_issue_created", True):
+            try:
+                from notifications import send_pushover_notification
+                notif_config = config.get("notifications", {})
+                send_pushover_notification(
+                    config=notif_config,
+                    title="Error Reporter: Issues Created",
+                    message=f"Created {issues_created} GitHub issue(s) from log errors.",
+                    priority=0,
+                )
+            except Exception as e:
+                logger.warning(f"Pushover notification failed: {e}")
+
+        if dry_run:
+            logger.info("Dry run complete — no issues were created")
+        elif issues_created:
+            logger.info(f"Created {issues_created} issue(s)")
+        else:
+            logger.info("No new issues needed")
+
+        return 0
+
+    except Exception as e:
+        logger.error(f"Pipeline failed: {e}", exc_info=True)
+        return 1
+    finally:
+        lock.release()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_error_reporter.py
+++ b/tests/test_error_reporter.py
@@ -1,0 +1,599 @@
+"""Tests for the automated error-to-GitHub-issue reporter."""
+
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import from scripts directory
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from error_reporter import (
+    ErrorSignature,
+    GitHubIssueCreator,
+    LockFile,
+    LogEntry,
+    check_rate_limit,
+    classify_error,
+    compute_fingerprint,
+    discover_log_files,
+    format_critical_issue,
+    format_summary_issue,
+    is_deduped,
+    load_state,
+    normalize_for_fingerprint,
+    parse_log_file,
+    record_issue_created,
+    run_pipeline,
+    sanitize_message,
+    save_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Classification tests
+# ---------------------------------------------------------------------------
+
+class TestClassifyError:
+    def test_ib_connection_patterns(self):
+        assert classify_error("IB Gateway connection failed after 3 retries") == "ib_connection"
+        assert classify_error("reqPositionsAsync timed out after 10s") == "ib_connection"
+        assert classify_error("Client state: DISCONNECTED") == "ib_connection"
+
+    def test_llm_api_patterns(self):
+        assert classify_error("CriticalRPCError: Gemini returned 503") == "llm_api"
+        assert classify_error("All 4 providers exhausted for agronomist") == "llm_api"
+        assert classify_error("Rate limit slot timeout after 30s") == "llm_api"
+
+    def test_parse_error_patterns(self):
+        assert classify_error("Could not parse Devil's Advocate response") == "parse_error"
+        assert classify_error("JSONDecodeError in council output") == "parse_error"
+        assert classify_error("Schema validation failed for signal") == "parse_error"
+
+    def test_file_io_patterns(self):
+        assert classify_error("Failed to save drawdown state: disk full") == "file_io"
+        assert classify_error("PermissionError: [Errno 13] Permission denied") == "file_io"
+        assert classify_error("Error writing to council_history.csv") == "file_io"
+
+    def test_trading_execution_patterns(self):
+        assert classify_error("Compliance check failed: VaR exceeded") == "trading_execution"
+        assert classify_error("Error closing position for KC Mar 2026") == "trading_execution"
+        assert classify_error("FLASH CRASH detected: price moved 5%") == "trading_execution"
+        assert classify_error("Drawdown PANIC: -12% unrealized") == "trading_execution"
+
+    def test_budget_patterns(self):
+        assert classify_error("Budget limit hit for weekly allocation") == "budget"
+        assert classify_error("BudgetThrottledError: max trades reached") == "budget"
+
+    def test_data_integrity_patterns(self):
+        assert classify_error("Reconciliation with IBKR failed: mismatch") == "data_integrity"
+        assert classify_error("CSV file corrupt: unexpected EOF") == "data_integrity"
+
+    def test_uncategorized(self):
+        assert classify_error("Something went terribly wrong") == "uncategorized"
+
+    def test_transient_detection(self):
+        """Transient errors return None (should be skipped)."""
+        assert classify_error("RSS feed timed out after 5s") is None
+        assert classify_error("RSS fetch timeout for reuters") is None
+        assert classify_error("rate limit exceeded, using fallback provider") is None
+        assert classify_error("weather fetch retry #2 of 3") is None
+        assert classify_error("Retrying in 5 seconds") is None
+
+    def test_case_insensitivity(self):
+        assert classify_error("ib gateway CONNECTION FAILED") == "ib_connection"
+        assert classify_error("jsondecodeError in output") == "parse_error"
+
+
+# ---------------------------------------------------------------------------
+# Sanitization tests
+# ---------------------------------------------------------------------------
+
+class TestSanitize:
+    def test_api_keys(self):
+        msg = "api_key=sk-abc123xyz789foo token=AIzaSyD12345678901234567890"
+        result = sanitize_message(msg)
+        assert "sk-abc123xyz789" not in result
+        assert "AIzaSyD123456789" not in result
+        assert "<REDACTED>" in result
+
+    def test_ib_account_numbers(self):
+        msg = "Account U1234567 has position in KC"
+        result = sanitize_message(msg)
+        assert "U1234567" not in result
+        assert "<ACCT>" in result
+
+    def test_du_account_numbers(self):
+        msg = "Paper account DU9876543 disconnected"
+        result = sanitize_message(msg)
+        assert "DU9876543" not in result
+        assert "<ACCT>" in result
+
+    def test_dollar_amounts(self):
+        msg = "P&L is $1,234.56 and margin is $50,000"
+        result = sanitize_message(msg)
+        assert "$1,234.56" not in result
+        assert "$50,000" not in result
+        assert "<AMT>" in result
+
+    def test_file_paths(self):
+        msg = "Error in /home/rodrigo/real_options/data/state.json"
+        result = sanitize_message(msg)
+        assert "rodrigo" not in result
+        assert "/home/<USER>/" in result
+
+    def test_env_var_values(self):
+        msg = "OPENAI_API_KEY=sk-realkey123 was loaded"
+        result = sanitize_message(msg)
+        assert "sk-realkey123" not in result
+        assert "OPENAI_API_KEY=<REDACTED>" in result
+
+    def test_strike_prices(self):
+        msg = "Option with strike=285.50 expired"
+        result = sanitize_message(msg)
+        assert "285.50" not in result
+        assert "strike=<PRICE>" in result
+
+    def test_position_sizes(self):
+        msg = "Holding 5 contracts of KC"
+        result = sanitize_message(msg)
+        assert "<N> contracts" in result
+
+    def test_no_false_positives(self):
+        """Normal messages should pass through mostly unchanged."""
+        msg = "Council vote complete: BULLISH consensus"
+        result = sanitize_message(msg)
+        assert "Council vote complete" in result
+        assert "BULLISH consensus" in result
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint tests
+# ---------------------------------------------------------------------------
+
+class TestFingerprint:
+    def test_stability_across_timestamps(self):
+        """Same error with different timestamps produces same fingerprint."""
+        msg1 = "2026-02-16T10:30:00 IB connection failed for orderId=123"
+        msg2 = "2026-02-16T11:45:00 IB connection failed for orderId=456"
+        fp1 = compute_fingerprint("ib_connection", msg1)
+        fp2 = compute_fingerprint("ib_connection", msg2)
+        assert fp1 == fp2
+
+    def test_stability_across_ips(self):
+        msg1 = "Connection to 192.168.1.1:7497 refused"
+        msg2 = "Connection to 10.0.0.5:7497 refused"
+        fp1 = compute_fingerprint("ib_connection", msg1)
+        fp2 = compute_fingerprint("ib_connection", msg2)
+        assert fp1 == fp2
+
+    def test_different_errors_different_fingerprints(self):
+        fp1 = compute_fingerprint("ib_connection", "IB connection failed")
+        fp2 = compute_fingerprint("llm_api", "CriticalRPCError from Gemini")
+        assert fp1 != fp2
+
+    def test_normalization_uuids(self):
+        result = normalize_for_fingerprint("trace=550e8400-e29b-41d4-a716-446655440000 failed")
+        assert "<UUID>" in result
+        assert "550e8400" not in result
+
+    def test_normalization_pids(self):
+        result = normalize_for_fingerprint("PID=12345 crashed")
+        assert "PID=<ID>" in result
+
+    def test_normalization_durations(self):
+        result = normalize_for_fingerprint("took 45.2s to respond")
+        assert "<N>s" in result
+
+
+# ---------------------------------------------------------------------------
+# Log parsing tests
+# ---------------------------------------------------------------------------
+
+class TestParseLogFile:
+    def test_normal_parsing(self, tmp_path):
+        log_content = (
+            "2026-02-16 10:00:00,123 - Orchestrator - INFO - Starting cycle\n"
+            "2026-02-16 10:00:01,456 - Orchestrator - ERROR - Something failed\n"
+            "2026-02-16 10:00:02,789 - Sentinel - CRITICAL - Flash crash detected\n"
+            "2026-02-16 10:00:03,012 - Orchestrator - INFO - Cycle complete\n"
+        )
+        log_file = tmp_path / "test.log"
+        log_file.write_text(log_content)
+
+        entries, offset = parse_log_file(str(log_file))
+        assert len(entries) == 2
+        assert entries[0].level == "ERROR"
+        assert entries[0].logger_name == "Orchestrator"
+        assert entries[1].level == "CRITICAL"
+        assert entries[1].logger_name == "Sentinel"
+        assert offset == len(log_content)
+
+    def test_offset_tracking(self, tmp_path):
+        log_file = tmp_path / "test.log"
+        log_file.write_text(
+            "2026-02-16 10:00:00,123 - A - ERROR - First error\n"
+        )
+        entries1, offset1 = parse_log_file(str(log_file))
+        assert len(entries1) == 1
+
+        # Append more content
+        with open(log_file, "a") as f:
+            f.write("2026-02-16 10:01:00,123 - B - ERROR - Second error\n")
+
+        entries2, offset2 = parse_log_file(str(log_file), offset1)
+        assert len(entries2) == 1
+        assert entries2[0].message == "Second error"
+        assert offset2 > offset1
+
+    def test_rotation_detection(self, tmp_path):
+        """If file is smaller than stored offset, reset to 0."""
+        log_file = tmp_path / "test.log"
+        log_file.write_text(
+            "2026-02-16 10:00:00,123 - A - ERROR - After rotation\n"
+        )
+        # Pretend we had a much larger offset before rotation
+        entries, offset = parse_log_file(str(log_file), start_offset=999999)
+        assert len(entries) == 1
+        assert entries[0].message == "After rotation"
+
+    def test_partial_line_skip(self, tmp_path):
+        """When seeking into middle of file, skip the first (partial) line."""
+        log_file = tmp_path / "test.log"
+        content = (
+            "2026-02-16 10:00:00,123 - A - ERROR - First line\n"
+            "2026-02-16 10:00:01,456 - B - ERROR - Second line\n"
+        )
+        log_file.write_text(content)
+        # Seek to middle of first line
+        entries, _ = parse_log_file(str(log_file), start_offset=10)
+        assert len(entries) == 1
+        assert entries[0].message == "Second line"
+
+    def test_empty_file(self, tmp_path):
+        log_file = tmp_path / "test.log"
+        log_file.write_text("")
+        entries, offset = parse_log_file(str(log_file))
+        assert len(entries) == 0
+        assert offset == 0
+
+    def test_missing_file(self):
+        entries, offset = parse_log_file("/nonexistent/path.log")
+        assert len(entries) == 0
+
+
+# ---------------------------------------------------------------------------
+# Log discovery tests
+# ---------------------------------------------------------------------------
+
+class TestDiscoverLogFiles:
+    def test_discovers_log_files(self, tmp_path):
+        (tmp_path / "orchestrator.log").write_text("content")
+        (tmp_path / "sentinels.log").write_text("content")
+        (tmp_path / "dashboard.log").write_text("content")
+        files = discover_log_files(str(tmp_path))
+        assert len(files) == 3
+
+    def test_skips_rotated_logs(self, tmp_path):
+        (tmp_path / "orchestrator.log").write_text("current")
+        (tmp_path / "orchestrator-2026-02-15T12:34:56.log").write_text("old")
+        files = discover_log_files(str(tmp_path))
+        assert len(files) == 1
+        assert "orchestrator.log" in files[0]
+
+    def test_skips_non_log_files(self, tmp_path):
+        (tmp_path / "orchestrator.log").write_text("content")
+        (tmp_path / "notes.txt").write_text("content")
+        (tmp_path / "data.json").write_text("content")
+        files = discover_log_files(str(tmp_path))
+        assert len(files) == 1
+
+    def test_empty_directory(self, tmp_path):
+        files = discover_log_files(str(tmp_path))
+        assert len(files) == 0
+
+    def test_nonexistent_directory(self):
+        files = discover_log_files("/nonexistent/dir")
+        assert len(files) == 0
+
+
+# ---------------------------------------------------------------------------
+# Deduplication and rate limiting tests
+# ---------------------------------------------------------------------------
+
+class TestDedup:
+    def test_new_fingerprint_not_deduped(self):
+        state = {"reported_signatures": {}}
+        assert not is_deduped("abc123", state, cooldown_hours=24)
+
+    def test_recent_fingerprint_deduped(self):
+        now = datetime.now(timezone.utc)
+        future = (now + timedelta(hours=12)).isoformat()
+        state = {
+            "reported_signatures": {
+                "abc123": {"cooldown_until": future}
+            }
+        }
+        assert is_deduped("abc123", state, cooldown_hours=24)
+
+    def test_expired_fingerprint_not_deduped(self):
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        state = {
+            "reported_signatures": {
+                "abc123": {"cooldown_until": past}
+            }
+        }
+        assert not is_deduped("abc123", state, cooldown_hours=24)
+
+
+class TestRateLimiting:
+    def test_within_normal_limit(self):
+        state = {"daily_counters": {
+            "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+            "issues_created": 2,
+            "critical_issues_created": 0,
+        }}
+        assert check_rate_limit(state, is_critical=False, max_normal=3, max_critical=5)
+
+    def test_at_normal_limit(self):
+        state = {"daily_counters": {
+            "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+            "issues_created": 3,
+            "critical_issues_created": 0,
+        }}
+        assert not check_rate_limit(state, is_critical=False, max_normal=3, max_critical=5)
+
+    def test_critical_separate_limit(self):
+        state = {"daily_counters": {
+            "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+            "issues_created": 3,
+            "critical_issues_created": 4,
+        }}
+        # Normal limit exceeded, but critical still has room
+        assert check_rate_limit(state, is_critical=True, max_normal=3, max_critical=5)
+
+    def test_new_day_resets(self):
+        state = {"daily_counters": {
+            "date": "2020-01-01",  # Old date
+            "issues_created": 999,
+            "critical_issues_created": 999,
+        }}
+        assert check_rate_limit(state, is_critical=False, max_normal=3, max_critical=5)
+        # Counters should have been reset
+        assert state["daily_counters"]["issues_created"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue formatting tests
+# ---------------------------------------------------------------------------
+
+class TestFormatIssues:
+    def test_format_critical_issue(self):
+        sig = ErrorSignature(
+            category="ib_connection",
+            fingerprint="abc123def456",
+            sample_message="IB connection failed after 3 retries",
+            count=5,
+            first_seen="2026-02-16 10:00:00,123",
+            last_seen="2026-02-16 10:30:00,456",
+            level="CRITICAL",
+        )
+        title, body, labels = format_critical_issue(sig)
+        assert "[CRITICAL]" in title
+        assert "ib_connection" in title
+        assert "ib_connection" in body
+        assert "CRITICAL" in body
+        assert "5" in body  # count
+        assert "abc123def456"[:12] in body
+        assert "priority:critical" in labels
+        assert "automated" in labels
+
+    def test_format_summary_issue(self):
+        sigs = [
+            ErrorSignature("ib_connection", "fp1", "conn failed", 10,
+                           "10:00", "10:30", "ERROR"),
+            ErrorSignature("llm_api", "fp2", "API timeout", 5,
+                           "10:00", "10:15", "ERROR"),
+        ]
+        title, body, labels = format_summary_issue("2026-02-16", sigs, 15)
+        assert "[Daily Summary]" in title
+        assert "2026-02-16" in title
+        assert "15 errors" in title
+        assert "2 categories" in title
+        assert "ib_connection" in body
+        assert "llm_api" in body
+        assert "daily-summary" in labels
+
+
+# ---------------------------------------------------------------------------
+# State persistence tests
+# ---------------------------------------------------------------------------
+
+class TestStatePersistence:
+    def test_save_load_roundtrip(self, tmp_path):
+        state_path = str(tmp_path / "state.json")
+        original = {
+            "version": 1,
+            "last_run": "",
+            "log_offsets": {"logs/orchestrator.log": 12345},
+            "reported_signatures": {
+                "fp1": {"category": "ib_connection", "cooldown_until": "2026-02-17T00:00:00"}
+            },
+            "daily_counters": {"date": "2026-02-16", "issues_created": 2, "critical_issues_created": 1},
+            "accumulated_errors": {},
+        }
+        save_state(original, state_path)
+        loaded = load_state(state_path)
+
+        assert loaded["log_offsets"] == original["log_offsets"]
+        assert loaded["reported_signatures"] == original["reported_signatures"]
+        assert loaded["daily_counters"] == original["daily_counters"]
+        assert loaded["last_run"] != ""  # save_state sets this
+
+    def test_load_missing_file(self, tmp_path):
+        state = load_state(str(tmp_path / "nonexistent.json"))
+        assert state["version"] == 1
+        assert state["log_offsets"] == {}
+
+    def test_load_corrupt_file(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        state_path.write_text("not valid json{{{")
+        state = load_state(str(state_path))
+        assert state["version"] == 1  # Falls back to default
+
+    def test_atomic_write(self, tmp_path):
+        """State file should be written atomically (no partial writes)."""
+        state_path = str(tmp_path / "state.json")
+        state = {"version": 1, "last_run": "", "log_offsets": {},
+                 "reported_signatures": {}, "daily_counters": {},
+                 "accumulated_errors": {}}
+        save_state(state, state_path)
+        # File should exist and be valid JSON
+        with open(state_path) as f:
+            loaded = json.load(f)
+        assert loaded["version"] == 1
+
+
+# ---------------------------------------------------------------------------
+# GitHub API mock tests
+# ---------------------------------------------------------------------------
+
+class TestGitHubIssueCreator:
+    @patch("error_reporter.urllib.request.urlopen")
+    def test_create_issue_success(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"number": 42}).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        creator = GitHubIssueCreator("owner", "repo", "token123")
+        result = creator.create_issue("Test", "Body", ["bug"])
+        assert result == 42
+
+        # Verify the request was made correctly
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        assert "repos/owner/repo/issues" in req.full_url
+        assert req.get_header("Authorization") == "Bearer token123"
+        payload = json.loads(req.data)
+        assert payload["title"] == "Test"
+        assert payload["labels"] == ["bug"]
+
+    @patch("error_reporter.urllib.request.urlopen")
+    def test_create_issue_api_error(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url="", code=422, msg="Unprocessable", hdrs={}, fp=MagicMock(read=lambda: b"error")
+        )
+        creator = GitHubIssueCreator("owner", "repo", "token123")
+        result = creator.create_issue("Test", "Body", [])
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Lock file tests
+# ---------------------------------------------------------------------------
+
+class TestLockFile:
+    def test_acquire_and_release(self, tmp_path):
+        lock_path = str(tmp_path / "test.lock")
+        lock = LockFile(lock_path)
+        assert lock.acquire()
+        assert os.path.exists(lock_path)
+        lock.release()
+        assert not os.path.exists(lock_path)
+
+    def test_stale_lock_overwritten(self, tmp_path):
+        lock_path = str(tmp_path / "test.lock")
+        # Write a PID that doesn't exist
+        with open(lock_path, "w") as f:
+            f.write("999999999")
+        lock = LockFile(lock_path)
+        assert lock.acquire()  # Should succeed — stale lock
+        lock.release()
+
+
+# ---------------------------------------------------------------------------
+# Integration: run_pipeline with mocked GitHub
+# ---------------------------------------------------------------------------
+
+class TestRunPipeline:
+    def test_pipeline_disabled(self):
+        config = {"error_reporter": {"enabled": False}}
+        assert run_pipeline(config) == 0
+
+    def test_pipeline_no_logs(self, tmp_path):
+        config = {
+            "error_reporter": {
+                "enabled": True,
+                "log_directory": str(tmp_path / "empty_logs"),
+                "github_owner": "test",
+                "github_repo": "test",
+                "github_token_env": "FAKE_TOKEN",
+            }
+        }
+        os.makedirs(tmp_path / "empty_logs", exist_ok=True)
+        assert run_pipeline(config, dry_run=True) == 0
+
+    def test_pipeline_dry_run(self, tmp_path, monkeypatch):
+        # Create a log file with errors
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        log_file = log_dir / "test.log"
+        log_file.write_text(
+            "2026-02-16 10:00:00,123 - Test - CRITICAL - IB connection failed badly\n"
+            "2026-02-16 10:00:01,456 - Test - ERROR - Something failed\n"
+        )
+
+        # Create data dir for state
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+
+        config = {
+            "error_reporter": {
+                "enabled": True,
+                "log_directory": str(log_dir),
+                "github_owner": "test",
+                "github_repo": "test",
+                "github_token_env": "FAKE_TOKEN",
+                "dedup_cooldown_hours": 24,
+                "max_issues_per_day": 3,
+                "max_critical_issues_per_day": 5,
+                "daily_summary_threshold": 5,
+            }
+        }
+
+        # Patch __file__ in the error_reporter module so project_root resolves to tmp_path
+        import error_reporter
+        fake_script = tmp_path / "scripts" / "error_reporter.py"
+        fake_script.parent.mkdir(parents=True, exist_ok=True)
+        fake_script.touch()
+        monkeypatch.setattr(error_reporter, "__file__", str(fake_script))
+
+        result = run_pipeline(config, dry_run=True)
+        # Dry run returns 0 issues created
+        assert result == 0
+
+
+class TestRecordIssueCreated:
+    def test_records_normal_issue(self):
+        state = {"reported_signatures": {}, "daily_counters": {}}
+        record_issue_created(state, "fp1", "ib_connection", 42, 24, is_critical=False)
+        assert "fp1" in state["reported_signatures"]
+        assert state["reported_signatures"]["fp1"]["issue_number"] == 42
+        assert state["daily_counters"]["issues_created"] == 1
+        assert state["daily_counters"]["critical_issues_created"] == 0
+
+    def test_records_critical_issue(self):
+        state = {"reported_signatures": {}, "daily_counters": {}}
+        record_issue_created(state, "fp1", "trading_execution", 99, 24, is_critical=True)
+        assert state["daily_counters"]["critical_issues_created"] == 1
+        assert state["daily_counters"]["issues_created"] == 0
+
+
+import urllib.error


### PR DESCRIPTION
## Summary

- **New `claude-fix.yml` workflow** — triggers when `claude-fix` label is added to an issue, uses `anthropics/claude-code-action@v1` to autonomously fix the issue and open a PR. Includes `claude-fix-attempted` guard label to prevent re-triggers and a 30-minute timeout.
- **Updated `issue-triage.yml`** — auto-adds `claude-fix` label after triage so the full pipeline is hands-off. Also adds a hint in the triage comment and makes the triage model configurable via `config.json`.
- **New `scripts/error_reporter.py`** — standalone cron job that scans logs for ERROR/CRITICAL entries, classifies/deduplicates them, sanitizes sensitive data, and creates GitHub issues. Includes 58 tests.
- **Updated `deploy.sh`** — installs cron job for 15-minute error reporter runs.
- **Updated `CLAUDE.md`** — documents the automated issue-to-PR pipeline.

### Full pipeline
```
Logs → error_reporter.py → GitHub Issue
                              ↓
Manual issue creation ──→ issue-triage.yml (labels + auto-adds claude-fix)
                              ↓
                         claude-fix.yml → PR created → review & merge
```

## Test plan

- [x] `pytest tests/test_error_reporter.py` — 58/58 passed
- [x] `pytest tests/` — 504/504 passed, 0 failures
- [ ] Create a test issue, verify triage adds `claude-fix` label
- [ ] Verify `claude-fix.yml` triggers and creates a PR
- [ ] Verify `claude-fix-attempted` label prevents re-triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)