### PR TITLE
Fix deploy.sh: use user crontab instead of /etc/cron.d

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -263,13 +263,12 @@ else
 fi
 
 # =========================================================================
-# STEP 11: Error reporter cron (every 15 min) — idempotent cron.d file
+# STEP 11: Error reporter cron (every 15 min) — user crontab (no root needed)
 # =========================================================================
 echo "--- 11. Setting up error reporter cron... ---"
-cat > /etc/cron.d/trading-bot-error-reporter << CRON_EOF
-*/15 * * * * rodrigo cd $REPO_ROOT && $REPO_ROOT/venv/bin/python scripts/error_reporter.py >> logs/error_reporter.log 2>&1
-CRON_EOF
-chmod 644 /etc/cron.d/trading-bot-error-reporter
+CRON_LINE="*/15 * * * * cd $REPO_ROOT && $REPO_ROOT/venv/bin/python scripts/error_reporter.py >> logs/error_reporter.log 2>&1"
+# Add to user crontab if not already present (idempotent)
+( crontab -l 2>/dev/null | grep -v 'error_reporter\.py'; echo "$CRON_LINE" ) | crontab -
 echo "  ✅ Error reporter cron installed"
 
 echo ""


### PR DESCRIPTION
## Summary

- Deploy script runs as `rodrigo`, not root, so writing to `/etc/cron.d/` fails with `Permission denied`
- Switches to user-level `crontab` which needs no root and is idempotent (strips old entry, adds fresh one)

## Test plan

- [ ] Deploy succeeds past step 11 without permission error
- [ ] `crontab -l` shows the error_reporter cron entry after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)