### PR TITLE
Fix issue-triage.yml heredoc EOF delimiter error

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -60,18 +60,17 @@ jobs:
         id: context
         run: |
           # Gather key file list for Claude to understand the project
-          {
-            echo 'FILES<<EOF'
-            echo "## Key Project Files"
-            echo "Architecture: See CLAUDE.md for full details"
-            echo ""
-            echo "### Recent changes (last 10 commits):"
-            git log --oneline -10
-            echo ""
-            echo "### Open branches:"
-            git branch -r --sort=-committerdate | head -10
-            EOF
-          } >> "$GITHUB_OUTPUT"
+          # Use delimiter on its own unindented line for GITHUB_OUTPUT
+          echo 'FILES<<CTXEOF' >> "$GITHUB_OUTPUT"
+          echo "## Key Project Files" >> "$GITHUB_OUTPUT"
+          echo "Architecture: See CLAUDE.md for full details" >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          echo "### Recent changes (last 10 commits):" >> "$GITHUB_OUTPUT"
+          git log --oneline -10 >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          echo "### Open branches:" >> "$GITHUB_OUTPUT"
+          git branch -r --sort=-committerdate | head -10 >> "$GITHUB_OUTPUT"
+          echo 'CTXEOF' >> "$GITHUB_OUTPUT"
 
       - name: Read triage model from config
         id: model


### PR DESCRIPTION
## Summary

- The `EOF` closing delimiter inside a `{ ... } >> "$GITHUB_OUTPUT"` block was indented, so bash treated `EOF` as a command name → `exit code 127` ("command not found")
- GitHub Actions multiline output also failed: `Invalid value. Matching delimiter not found 'EOF'`
- Fix: switch to explicit per-line `>> "$GITHUB_OUTPUT"` appends with a unique `CTXEOF` delimiter, avoiding the indentation issue entirely

## Test plan

- [ ] Create a test issue → triage workflow should pass the "Read project context" step
- [ ] Triage comment should appear on the issue with correct labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)