### PR TITLE
Use PAT to add claude-fix label so it triggers the fix workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -246,12 +246,11 @@ jobs:
               body: body,
             });
 
-            // Add labels
+            // Add triage labels (using default GITHUB_TOKEN)
             const labelsToAdd = [
               `priority:${p.priority}`,
               p.category,
-              'triaged',
-              'claude-fix'
+              'triaged'
             ];
 
             // Ensure labels exist, create if needed
@@ -275,7 +274,6 @@ jobs:
                   'docs': '0075ca',
                   'question': 'd876e3',
                   'triaged': 'c5def5',
-                  'claude-fix': '6f42c1',
                 };
                 await github.rest.issues.createLabel({
                   owner: context.repo.owner,
@@ -291,4 +289,37 @@ jobs:
               repo: context.repo.repo,
               issue_number: issueNumber,
               labels: labelsToAdd,
+            });
+
+      # Add claude-fix label using PAT so the labeled event triggers claude-fix.yml
+      # (events from GITHUB_TOKEN don't trigger other workflows)
+      - name: Add claude-fix label
+        if: steps.triage.outputs.triage != ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const issueNumber = parseInt('${{ steps.issue.outputs.number }}');
+
+            // Ensure label exists
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'claude-fix',
+              });
+            } catch {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'claude-fix',
+                color: '6f42c1',
+              });
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['claude-fix'],
             });


### PR DESCRIPTION
## Summary

- Events created by the default `GITHUB_TOKEN` don't trigger other workflows (GitHub security feature)
- The triage workflow was adding `claude-fix` via `GITHUB_TOKEN`, so `claude-fix.yml` never fired
- Fix: split into two steps — triage labels use `GITHUB_TOKEN`, `claude-fix` label uses `PAT_TOKEN`
- The `labeled` event from the PAT is visible to `claude-fix.yml`, completing the pipeline

## Test plan

- [ ] Merge this PR
- [ ] Create a test issue
- [ ] Verify triage adds labels including `claude-fix`
- [ ] Verify `claude-fix.yml` triggers and Claude attempts a fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)