### PR TITLE
Add id-token:write permission to claude-fix workflow

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   fix:


### PR DESCRIPTION
## Summary

- `anthropics/claude-code-action@v1` requires OIDC token access for authentication
- Workflow was failing with: `Could not fetch an OIDC token. Did you remember to add id-token: write?`
- One-line fix: add `id-token: write` to workflow permissions

## Test plan

- [ ] Create a test issue → triage adds `claude-fix` → workflow should get past authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)