### PR TITLE
Allow Bash, Edit, Write tools in claude-fix workflow

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -43,7 +43,7 @@ jobs:
             - Run `pytest tests/` before committing to verify no regressions
             - Keep changes minimal and focused on the issue
             - Create the PR with "Closes #${{ github.event.issue.number }}" in the body
-          claude_args: "--max-turns 30"
+          claude_args: '--max-turns 30 --allowedTools "Bash(*)" "Edit(*)" "Write(*)"'
 
       - name: Mark as attempted
         if: always()


### PR DESCRIPTION
## Summary

- Claude Code ran 20 turns but every Bash and Edit call was denied (7 permission denials)
- Default permissions only include file reads and read-only git — no shell or edits
- Fix: add `--allowedTools "Bash(*)" "Edit(*)" "Write(*)"` so Claude can actually make changes and create PRs

## Test plan

- [ ] Create a test issue → verify Claude can run commands, edit files, and open a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)