### PR TITLE
Prevent Claude from pushing directly to main in claude-fix workflow

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -30,21 +30,26 @@ jobs:
           prompt: |
             You are fixing issue #${{ github.event.issue.number }} in a production trading system.
 
-            IMPORTANT WORKFLOW:
+            WORKFLOW:
             1. Read CLAUDE.md for project conventions
             2. Run `git log --oneline -10` to see recent changes
             3. Understand the issue and root cause
             4. Make the fix — keep changes minimal and focused
             5. Run `pytest tests/` to verify no regressions
-            6. Commit your changes with `git commit` (the action handles branch and PR creation)
+            6. Stage and commit your changes with `git add` and `git commit`
+
+            CRITICAL — DO NOT DO ANY OF THESE:
+            - Do NOT run `git push` — the action handles pushing and PR creation
+            - Do NOT run `gh pr create` — the action handles PR creation
+            - Do NOT push to any branch — just commit locally and stop
+            - Do NOT modify execution-path files (order_manager.py, ib_interface.py,
+              compliance.py) without extreme care
 
             RULES:
             - This is a PRODUCTION TRADING SYSTEM that trades real money
-            - NEVER modify execution-path files (order_manager.py, ib_interface.py,
-              compliance.py) without extreme care
             - All components must fail closed — if unsure, block rather than allow
             - Keep changes minimal and focused on the issue
-          claude_args: '--max-turns 30 --allowedTools "Bash(*)" "Edit(*)" "Write(*)"'
+          claude_args: '--max-turns 30 --allowedTools "Bash(*)" "Edit(*)" "Write(*)" --disallowedTools "Bash(git push*)" "Bash(gh pr *)"'
 
       - name: Mark as attempted
         if: always()


### PR DESCRIPTION
## Summary

In the previous run, Claude pushed directly to `main` (`git push origin main`) instead of letting the action create a branch and PR for review. This bypasses the entire review workflow.

**Fixes:**
- Explicit "DO NOT `git push`" and "DO NOT `gh pr create`" instructions in the prompt
- Added `--disallowedTools "Bash(git push*)" "Bash(gh pr *)"` to hard-block push/PR commands
- Clarified that Claude should only stage + commit locally; the action handles branch creation, pushing, and PR

## Test plan

- [ ] Create a test issue → Claude should commit but NOT push
- [ ] Action should create a `claude/` branch and open a PR for review
- [ ] Verify no direct pushes to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)