### PR TITLE
Revert Claude's direct push to main (market status fix)

### DIFF
--- a/pages/1_Cockpit.py
+++ b/pages/1_Cockpit.py
@@ -31,7 +31,6 @@ from dashboard_utils import (
     get_commodity_profile,
     load_task_schedule_status
 )
-from trading_bot.calendars import is_trading_day
 
 def load_deduplicator_metrics() -> dict:
     """Load trigger deduplication metrics."""
@@ -458,27 +457,15 @@ utc_now = datetime.now(timezone.utc)
 ny_tz = pytz.timezone('America/New_York')
 ny_now = utc_now.astimezone(ny_tz)
 
-# Determine Market Status (check hours, weekday, AND holidays)
+# Determine Market Status (using same logic as Utils but for display)
 market_open_ny = ny_now.replace(hour=3, minute=30, second=0, microsecond=0)
 market_close_ny = ny_now.replace(hour=14, minute=0, second=0, microsecond=0)
-is_weekday = ny_now.weekday() < 5
-is_within_hours = market_open_ny <= ny_now <= market_close_ny
-is_trading = is_trading_day(ny_now.date(), exchange='ICE')
-
-is_open = is_weekday and is_within_hours and is_trading
+is_open = market_open_ny <= ny_now <= market_close_ny and ny_now.weekday() < 5
 
 status_color = "🟢" if is_open else "🔴"
 status_text = "OPEN" if is_open else "CLOSED"
 
-# Add specific reason for closure if applicable
-if not is_open:
-    if not is_weekday:
-        status_text += " (Weekend)"
-    elif not is_trading:
-        status_text += " (Holiday)"
-    elif not is_within_hours:
-        status_text += " (After Hours)"
-elif is_open:
+if is_open:
     delta = market_close_ny - ny_now
     # Ensure non-negative duration
     if delta.total_seconds() > 0:

--- a/trading_bot/calendars.py
+++ b/trading_bot/calendars.py
@@ -2,7 +2,7 @@
 
 from pandas.tseries.holiday import (
     AbstractHolidayCalendar, Holiday, nearest_workday,
-    USMemorialDay, USLaborDay, USThanksgivingDay, USPresidentsDay, USFederalHolidayCalendar
+    USMemorialDay, USLaborDay, USThanksgivingDay, USFederalHolidayCalendar
 )
 from pandas.tseries.offsets import DateOffset, Easter
 from datetime import date, timedelta
@@ -10,10 +10,9 @@ import pandas as pd
 
 
 class ICEHolidayCalendar(AbstractHolidayCalendar):
-    """ICE US trading calendar (includes Good Friday and Presidents' Day)."""
+    """ICE US trading calendar (includes Good Friday)."""
     rules = [
         Holiday('New Year', month=1, day=1, observance=nearest_workday),
-        USPresidentsDay,
         USMemorialDay,
         Holiday('Independence Day', month=7, day=4, observance=nearest_workday),
         USLaborDay,


### PR DESCRIPTION
## Summary

- Reverts commit `a283bde` where Claude pushed directly to `main` without a PR
- The fix itself (Presidents' Day in calendar + holiday check in Cockpit) was reasonable but was never reviewed or tested
- Issue #898 will be reopened so the fix can go through proper review via the now-fixed `claude-fix` pipeline

## Test plan

- [x] Revert is clean, restores original `calendars.py` and `1_Cockpit.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)