### PR TITLE
Let Claude create branch and PR itself, only block pushes to main

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -36,20 +36,20 @@ jobs:
             3. Understand the issue and root cause
             4. Make the fix — keep changes minimal and focused
             5. Run `pytest tests/` to verify no regressions
-            6. Stage and commit your changes with `git add` and `git commit`
+            6. Create a branch, commit, push, and open a PR:
+               - `git checkout -b claude/fix-issue-${{ github.event.issue.number }}`
+               - `git add <files>` and `git commit`
+               - `git push -u origin claude/fix-issue-${{ github.event.issue.number }}`
+               - `gh pr create` with "Closes #${{ github.event.issue.number }}" in the body
 
-            CRITICAL — DO NOT DO ANY OF THESE:
-            - Do NOT run `git push` — the action handles pushing and PR creation
-            - Do NOT run `gh pr create` — the action handles PR creation
-            - Do NOT push to any branch — just commit locally and stop
-            - Do NOT modify execution-path files (order_manager.py, ib_interface.py,
+            CRITICAL:
+            - NEVER push to main — always create a new branch
+            - NEVER modify execution-path files (order_manager.py, ib_interface.py,
               compliance.py) without extreme care
-
-            RULES:
             - This is a PRODUCTION TRADING SYSTEM that trades real money
             - All components must fail closed — if unsure, block rather than allow
             - Keep changes minimal and focused on the issue
-          claude_args: '--max-turns 30 --allowedTools "Bash(*)" "Edit(*)" "Write(*)" --disallowedTools "Bash(git push*)" "Bash(gh pr *)"'
+          claude_args: '--max-turns 30 --allowedTools "Bash(*)" "Edit(*)" "Write(*)" --disallowedTools "Bash(git push * main*)" "Bash(git push origin main*)"'
 
       - name: Mark as attempted
         if: always()


### PR DESCRIPTION
## Summary

The action's automatic branch/PR creation hasn't worked reliably. Switch approach:

- Claude now handles the full flow: create branch, commit, push, open PR
- Prompt gives explicit step-by-step instructions with the branch name
- Only `git push` to `main` is blocked via `--disallowedTools`
- All other git/gh commands are allowed so Claude can create PRs

## Test plan

- [ ] Remove `claude-fix-attempted` from issue #898, let the pipeline run
- [ ] Claude should create a `claude/fix-issue-898` branch and open a PR
- [ ] PR should appear for review — no direct pushes to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)