### PR TITLE
Fix compliance guardian empty LLM response crash

### DIFF
--- a/trading_bot/compliance.py
+++ b/trading_bot/compliance.py
@@ -683,10 +683,21 @@ class ComplianceGuardian:
                 prompt,
                 response_json=True
             )
+
+            if not response or not response.strip():
+                logger.error("Compliance Audit received empty LLM response (fail-closed)")
+                return {'approved': False, 'flagged_reason': 'Empty LLM response (fail-closed)'}
+
             text = response.strip()
             if text.startswith("```json"): text = text[7:]
             if text.startswith("```"): text = text[3:]
             if text.endswith("```"): text = text[:-3]
+            text = text.strip()
+
+            if not text:
+                logger.error("Compliance Audit: response was only markdown fences (fail-closed)")
+                return {'approved': False, 'flagged_reason': 'Empty LLM response after stripping markdown (fail-closed)'}
+
             return json.loads(text)
         except Exception as e:
             logger.error(f"Compliance Audit failed: {e}")


### PR DESCRIPTION
## Summary
- **Root cause**: `audit_decision()` in `compliance.py` did raw `json.loads()` on LLM responses without checking for empty strings. When Anthropic returned 529 overload errors and fallback providers (OpenAI) returned empty responses, `json.loads("")` threw `JSONDecodeError: Expecting value: line 1 column 1 (char 0)`.
- **Impact**: Both PROD and DEV unable to trade — 11 of 14 compliance audit calls failed today, blocking every potential trade despite 15+ BEARISH council decisions with PLAUSIBLE conviction.
- **Fix**: Three-layer defense-in-depth:
  - **Client layer** (`heterogeneous_router.py`): Added empty response validation to OpenAI, Gemini, and xAI clients (matching existing Anthropic pattern). Empty responses now raise `ValueError`, triggering retry (3x) then fallback chain.
  - **Router layer** (`heterogeneous_router.py` `route()`): Added validation after `generate()` returns in both primary and fallback paths as a catch-all.
  - **Consumer layer** (`compliance.py` `audit_decision()`): Added explicit empty check before `json.loads()` + check after stripping markdown fences. Returns clean fail-closed result matching the pattern already used by `review_order()` via `ComplianceDecision.from_llm_response()`.

## Test plan
- [x] `pytest tests/` — 504 passed, 0 failed
- [ ] Deploy to DEV — verify compliance calls produce parseable JSON or clean fail-closed messages instead of JSONDecodeError stack traces
- [ ] Confirm fallback chain activates on empty primary response (check logs for "Empty response from" warnings)
- [ ] Monitor next trading session for successful order generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)