### PR TITLE
Fix compliance non-JSON response from Anthropic

### DIFF
--- a/trading_bot/compliance.py
+++ b/trading_bot/compliance.py
@@ -699,6 +699,12 @@ class ComplianceGuardian:
                 return {'approved': False, 'flagged_reason': 'Empty LLM response after stripping markdown (fail-closed)'}
 
             return json.loads(text)
+        except json.JSONDecodeError as e:
+            logger.error(
+                f"Compliance Audit JSON parse failed: {e}. "
+                f"Raw response (first 300 chars): {response[:300]!r}"
+            )
+            return {'approved': False, 'flagged_reason': f"Audit Error: {str(e)}"}
         except Exception as e:
             logger.error(f"Compliance Audit failed: {e}")
             return {'approved': False, 'flagged_reason': f"Audit Error: {str(e)}"}


### PR DESCRIPTION
## Summary
- **Root cause**: The Anthropic client in `heterogeneous_router.py` ignored the `response_json=True` parameter. Unlike OpenAI (which sets `response_format: json_object`), Anthropic has no native JSON mode, so the model would return HTTP 200 with plain-text analysis instead of JSON. This caused `json.loads()` to fail even after PR #912's empty-response fix.
- **Evidence**: Live dashboard logs show `HTTP/1.1 200 OK` from Anthropic immediately followed by `Expecting value: line 1 column 1 (char 0)` — meaning Anthropic returned content but not JSON.
- **Fixes**:
  - **Anthropic client**: When `response_json=True`, prepend `"You MUST respond with valid JSON only"` instruction to system prompt
  - **xAI client**: Add `response_format: json_object` (xAI uses OpenAI-compatible API, was missing this)
  - **compliance.py**: Log first 300 chars of raw response on `JSONDecodeError` for future diagnosis

## Test plan
- [x] `pytest tests/` — 504 passed, 0 failed
- [ ] Deploy to DEV — verify compliance calls now return parseable JSON from Anthropic
- [ ] Check dashboard.log for "Raw response" diagnostic lines if any parse failures remain
- [ ] Monitor next manual order trigger through dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)