### PR TITLE
Use Gemini Flash for grounded data to conserve Pro quota

### DIFF
--- a/trading_bot/heterogeneous_router.py
+++ b/trading_bot/heterogeneous_router.py
@@ -560,11 +560,14 @@ class HeterogeneousRouter:
         # TIER 2: DEEP ANALYSTS
         elif role in [AgentRole.AGRONOMIST, AgentRole.MACRO_ANALYST, AgentRole.SUPPLY_CHAIN_ANALYST, AgentRole.GEOPOLITICAL_ANALYST, AgentRole.INVENTORY_ANALYST, AgentRole.VOLATILITY_ANALYST]:
             gem_pro = get_model('gemini', 'pro', 'gemini-3-pro-preview')
+            gem_flash = get_model('gemini', 'flash', 'gemini-3-flash-preview')
             oai_pro = get_model('openai', 'pro', 'gpt-5.2')
             anth_pro = get_model('anthropic', 'pro', 'claude-opus-4-6')
 
             if primary_provider == ModelProvider.GEMINI:
+                # Gemini Pro exhausted → try Flash (same provider, free tier) → then OpenAI
                 return [
+                    (ModelProvider.GEMINI, gem_flash),
                     (ModelProvider.OPENAI, oai_pro),
                     (ModelProvider.ANTHROPIC, anth_pro)
                 ]


### PR DESCRIPTION
## Summary
- Switch grounded data gathering (web search + summarization) from `gemini-3-pro-preview` to `gemini-3-flash-preview` to stay within Pro's 250 RPD daily limit
- Add Gemini Flash as intermediate fallback for Tier 2 analysts before falling back to OpenAI

## Context
`gemini-3-pro-preview` has a 250 requests/day limit. Grounded data gathering alone was consuming ~100 calls/day (8 agents × multiple cycles), leaving insufficient quota for the reasoning tasks that actually benefit from Pro's capabilities. Once exhausted, ALL Gemini calls fail with `RESOURCE_EXHAUSTED limit: 0`, forcing every agent to OpenAI and defeating LLM heterogeneity.

## Changes
- **`agents.py`**: Load `grounded_data_model` from `model_registry.gemini.flash`, use it in `_gather_grounded_data()` instead of `master_model_name`
- **`heterogeneous_router.py`**: Tier 2 analysts with Gemini Pro primary now fall back to Flash before OpenAI

## Impact
- ~100 daily Pro RPD freed up for reasoning tasks
- Flash has a free tier — no additional cost
- Flash supports Google Search grounding — no capability loss for data gathering
- Pro quota reserved for Tier 2 analyst reasoning + Tier 3 decision maker fallback

## Test plan
- [x] 504 tests pass
- [ ] Verify grounded data calls use Flash model in orchestrator logs
- [ ] Verify Pro quota lasts through full trading day
- [ ] Verify Tier 2 fallback chain: Pro → Flash → OpenAI

🤖 Generated with [Claude Code](https://claude.com/claude-code)