### PR TITLE
Switch Anthropic from Opus 4.6 to Sonnet 4.5

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
       "flash": "gemini-3-flash-preview"
     },
     "anthropic": {
-      "pro": "claude-opus-4-6"
+      "pro": "claude-sonnet-4-5-20250929"
     },
     "openai": {
       "pro": "gpt-5.2",

--- a/trading_bot/heterogeneous_router.py
+++ b/trading_bot/heterogeneous_router.py
@@ -490,8 +490,8 @@ class HeterogeneousRouter:
 
             # --- TIER 3: DECISION MAKERS (Safety & Debate) ---
             AgentRole.PERMABULL: (ModelProvider.XAI, xai_pro),             # Contrarian
-            AgentRole.PERMABEAR: (ModelProvider.ANTHROPIC, anth_pro),      # Safety (Opus)
-            AgentRole.COMPLIANCE_OFFICER: (ModelProvider.ANTHROPIC, anth_pro), # Veto (Opus)
+            AgentRole.PERMABEAR: (ModelProvider.ANTHROPIC, anth_pro),      # Safety (Sonnet)
+            AgentRole.COMPLIANCE_OFFICER: (ModelProvider.ANTHROPIC, anth_pro), # Veto (Sonnet)
 
             AgentRole.MASTER_STRATEGIST: (ModelProvider.OPENAI, oai_pro),  # Synthesis
         }


### PR DESCRIPTION
## Summary
- PROD hit the monthly Anthropic spending cap (locked until March 1)
- Switches `anthropic.pro` from `claude-opus-4-6` to `claude-sonnet-4-5-20250929`
- Sonnet 4.5 uses a **separate rate pool** from Opus and is **40% cheaper** ($3/$15 vs $5/$25 per MTok)
- Affects `permabear` and `compliance` roles (both use Anthropic as primary provider)

## Test plan
- [x] 504 tests pass
- [ ] Verify permabear and compliance roles produce valid analyses with Sonnet 4.5
- [ ] Monitor PROD API costs after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)