### PR TITLE
Add missing files to data migration script

### DIFF
--- a/scripts/migrate_data_dirs.py
+++ b/scripts/migrate_data_dirs.py
@@ -47,6 +47,9 @@ DATA_FILES = [
     'sentinel_stats.json',
     'quarantine_state.json',
     'weather_sentinel_alerts.json',
+    'trade_journal.json',
+    'discovered_topics.json',
+    'fundamental_regime.json',
 ]
 
 # Directories to move from data/ to data/KC/
@@ -54,6 +57,7 @@ DATA_DIRS = [
     'sentinel_caches',
     'tms',
     'dspy_optimized',
+    'surrogate_models',
 ]
 
 # Files to move from project root to data/KC/


### PR DESCRIPTION
## Summary
- Adds 3 files and 1 directory to `migrate_data_dirs.py` that were missed: `trade_journal.json`, `discovered_topics.json`, `fundamental_regime.json`, `surrogate_models/`
- Dry run on DEV shows 10 items to migrate, correctly skips 5 already in `data/KC/`

## Next steps (after merge)
1. SSH to DEV, stop service: `sudo systemctl stop trading-bot`
2. Run: `python scripts/migrate_data_dirs.py --dry-run` (verify)
3. Run: `python scripts/migrate_data_dirs.py` (execute)
4. Start service: `sudo systemctl start trading-bot`
5. Repeat on PROD

🤖 Generated with [Claude Code](https://claude.com/claude-code)