### PR TITLE
Fix weight_evolution.csv path for commodity isolation

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -4595,6 +4595,7 @@ async def main(commodity_ticker: str = None):
     from trading_bot.tms import set_data_dir as set_tms_dir
     from trading_bot.brier_bridge import set_data_dir as set_brier_bridge_dir
     from trading_bot.brier_scoring import set_data_dir as set_brier_scoring_dir
+    from trading_bot.weighted_voting import set_data_dir as set_weighted_voting_dir
 
     StateManager.set_data_dir(data_dir)
     set_tracker_dir(data_dir)
@@ -4605,6 +4606,7 @@ async def main(commodity_ticker: str = None):
     set_tms_dir(data_dir)
     set_brier_bridge_dir(data_dir)
     set_brier_scoring_dir(data_dir)
+    set_weighted_voting_dir(data_dir)
 
     global GLOBAL_DEDUPLICATOR
     GLOBAL_DEDUPLICATOR = TriggerDeduplicator(

--- a/pages/7_Brier_Analysis.py
+++ b/pages/7_Brier_Analysis.py
@@ -16,6 +16,7 @@ import json
 from datetime import datetime, timezone, timedelta
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from dashboard_utils import _resolve_data_path
 
 st.set_page_config(layout="wide", page_title="Brier Analysis | Real Options")
 st.title("🎯 Brier Analysis")
@@ -306,7 +307,7 @@ except Exception as e:
 st.markdown("---")
 st.subheader("📈 Weight Evolution")
 
-weight_csv = os.path.join('data', 'weight_evolution.csv')
+weight_csv = _resolve_data_path('weight_evolution.csv')
 if os.path.exists(weight_csv):
     try:
         weight_df = pd.read_csv(weight_csv, parse_dates=['timestamp'])

--- a/scripts/migrate_data_dirs.py
+++ b/scripts/migrate_data_dirs.py
@@ -50,6 +50,7 @@ DATA_FILES = [
     'trade_journal.json',
     'discovered_topics.json',
     'fundamental_regime.json',
+    'weight_evolution.csv',
 ]
 
 # Directories to move from data/ to data/KC/

--- a/trading_bot/weighted_voting.py
+++ b/trading_bot/weighted_voting.py
@@ -21,6 +21,16 @@ from trading_bot.agent_names import DEPRECATED_AGENTS
 
 logger = logging.getLogger(__name__)
 
+# Mutable data directory — set by orchestrator via set_data_dir()
+_data_dir: Optional[str] = None
+
+
+def set_data_dir(data_dir: str):
+    """Configure data directory for weight evolution CSV."""
+    global _data_dir
+    _data_dir = data_dir
+    logger.info(f"WeightedVoting data_dir set to: {data_dir}")
+
 
 class TriggerType(Enum):
     """Classification of decision trigger."""
@@ -629,7 +639,7 @@ async def calculate_weighted_decision(
             import csv
             from datetime import datetime, timezone
 
-            weight_csv = os.path.join('data', 'weight_evolution.csv')
+            weight_csv = os.path.join(_data_dir or 'data/KC', 'weight_evolution.csv')
             file_exists = os.path.exists(weight_csv)
 
             # Ensure directory exists


### PR DESCRIPTION
## Summary
- Add `set_data_dir()` to `weighted_voting.py` — last remaining hardcoded `data/` path in the codebase
- Wire it into orchestrator init sequence alongside the other 10 setters
- Update `pages/7_Brier_Analysis.py` to use `_resolve_data_path()` for dashboard reads
- Add `weight_evolution.csv` to migration script

## Test plan
- [x] `pytest tests/` — 504 passed, 0 failed
- [x] File manually moved on DEV (`data/weight_evolution.csv` → `data/KC/weight_evolution.csv`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)