### PR TITLE
Fix config symbol override and exchange for CC launch

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -4583,6 +4583,7 @@ async def main(commodity_ticker: str = None):
 
     # Inject data_dir and ticker into config for downstream modules
     config['data_dir'] = data_dir
+    config['symbol'] = ticker
     config.setdefault('commodity', {})['ticker'] = ticker
 
     # --- Initialize all path-dependent modules BEFORE anything else ---


### PR DESCRIPTION
## Summary
- Set `config['symbol'] = ticker` in `main()` — without this, CC would try to trade KC futures (symbol was hardcoded to "KC" in config.json and never overridden)

## Context
The orchestrator uses `config['exchange']` (from config.json: "NYBOT") and `config['symbol']` everywhere. The commodity profile's `exchange` field ("ICE") is metadata not consumed by the orchestrator, so left as-is.

## Test plan
- [x] `pytest tests/` — 504 passed, 0 failed
- [ ] Verify KC still works on DEV after deploy
- [ ] Test `--commodity CC` startup (paper trade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)