### PR TITLE
Fix deploy writing stale files to data/ instead of data/KC/

### DIFF
--- a/scripts/verify_deploy.sh
+++ b/scripts/verify_deploy.sh
@@ -40,8 +40,8 @@ REQUIRED_DIRS=(
     "trading_bot/prompts"
     "backtesting"
     "data"
-    "data/surrogate_models"
     "data/KC"              # Primary commodity data directory
+    "data/KC/surrogate_models"
     # "logs" # logs might not exist in fresh clone? but good to check
 )
 for dir in "${REQUIRED_DIRS[@]}"; do

--- a/trading_bot/state_manager.py
+++ b/trading_bot/state_manager.py
@@ -17,7 +17,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 # Default paths — overridden by set_data_dir() for multi-commodity isolation
-_BASE_DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data')
+_BASE_DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', 'KC')
 STATE_FILE = os.path.join(_BASE_DATA_DIR, 'state.json')
 
 def _validate_confidence(value: Any) -> float:
@@ -51,7 +51,7 @@ class StateManager:
     """
     _async_lock = asyncio.Lock()
     REPORT_TTL_SECONDS = 3600  # 1 hour staleness threshold
-    DEFERRED_TRIGGERS_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', 'deferred_triggers.json')
+    DEFERRED_TRIGGERS_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', 'KC', 'deferred_triggers.json')
 
     # Class-level path variables — overridden by set_data_dir() for multi-commodity
     _state_file = None  # When None, falls back to module-level STATE_FILE
@@ -133,11 +133,11 @@ class StateManager:
     # Single global lock file for ALL state writes to prevent cross-namespace races.
     # Previously used per-namespace locks (data/.state_{ns}.lock) which allowed
     # concurrent writes from different namespaces to clobber each other's data.
-    _STATE_LOCK_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', '.state_global.lock')
+    _STATE_LOCK_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', 'KC', '.state_global.lock')
 
     # Separate lock file for deferred triggers (prevents race between sentinel
     # queue_deferred_trigger and orchestrator get_deferred_triggers).
-    _DEFERRED_LOCK_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', '.deferred_triggers.lock')
+    _DEFERRED_LOCK_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', 'KC', '.deferred_triggers.lock')
 
     @classmethod
     def _with_state_lock(cls, fn):

--- a/verify_system_readiness.py
+++ b/verify_system_readiness.py
@@ -760,6 +760,9 @@ async def check_notifications(config: dict) -> CheckResult:
 async def check_state_manager() -> CheckResult:
     try:
         from trading_bot.state_manager import StateManager
+        ticker = os.environ.get("COMMODITY_TICKER", "KC")
+        data_dir = os.path.join('data', ticker)
+        StateManager.set_data_dir(data_dir)
         state = StateManager.load_state()
         StateManager.save_state({"_test": "ok"}, namespace="test")
         return CheckResult("State Manager", CheckStatus.PASS, f"Read/Write OK | {len(state)} keys")


### PR DESCRIPTION
## Summary
- `verify_system_readiness.py` was calling `StateManager.save_state()` without `set_data_dir()`, creating `data/state.json` and `data/.state_global.lock` at the old path during every deploy
- Updated StateManager class-level defaults from `data/` to `data/KC/` to match all other modules
- Updated `verify_deploy.sh` to check `data/KC/surrogate_models` instead of `data/surrogate_models`

## Root cause
Found during post-migration audit — files we cleaned up from `data/` kept reappearing after each deploy because `verify_deploy.sh` runs `verify_system_readiness.py` which imports StateManager (creating lock file at class-level default path) and writes a test entry.

## Test plan
- [x] `pytest tests/` — 504 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)