### PR TITLE
Isolate account-wide equity data to primary commodity

### DIFF
--- a/equity_logger.py
+++ b/equity_logger.py
@@ -34,7 +34,13 @@ async def sync_equity_from_flex(config: dict):
     The Flex Query returns 'ReportDate' and 'Total'.
     This function normalizes the date to closing time (17:00 NY Time) and saves
     the file to ensure the local equity history matches the broker's official record.
+
+    Only runs for the primary commodity (KC) since NetLiquidation is account-wide.
     """
+    if not config.get('commodity', {}).get('is_primary', True):
+        logger.info("Skipping equity sync — non-primary commodity (account equity tracked by primary)")
+        return
+
     logger.info("--- Starting Equity Synchronization from Flex Query ---")
 
     # Get the ID from the config (loaded from .env), or fallback to os.getenv just in case
@@ -134,7 +140,13 @@ async def sync_equity_from_flex(config: dict):
 async def log_equity_snapshot(config: dict):
     """
     Connects to IB, fetches NetLiquidation, and logs it to data/{ticker}/daily_equity.csv.
+
+    Only runs for the primary commodity (KC) since NetLiquidation is account-wide.
     """
+    if not config.get('commodity', {}).get('is_primary', True):
+        logger.info("Skipping equity snapshot — non-primary commodity (account equity tracked by primary)")
+        return
+
     logger.info("--- Starting Equity Snapshot Logging ---")
 
     data_dir = config.get('data_dir', 'data')

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -4585,6 +4585,9 @@ async def main(commodity_ticker: str = None):
     config['data_dir'] = data_dir
     config['symbol'] = ticker
     config.setdefault('commodity', {})['ticker'] = ticker
+    # Primary commodity owns account-wide equity tracking (NetLiquidation).
+    # Non-primary commodities skip equity snapshots to avoid duplicate data.
+    config['commodity']['is_primary'] = (ticker == 'KC')
 
     # --- Initialize all path-dependent modules BEFORE anything else ---
     from trading_bot.state_manager import StateManager


### PR DESCRIPTION
## Summary
IBKR `NetLiquidation` is account-wide — it can't be split per commodity. Without this fix, both KC and CC record identical equity curves and report the same LTD P&L.

- **Primary commodity (KC)** owns equity tracking: snapshots, Flex sync, equity-based P&L
- **Non-primary (CC)** skips equity logging, reports P&L from trade ledger only
- **Portfolio & fills** filtered by commodity ticker so each commodity only sees its own positions in the EOD report

## What changed
- `orchestrator.py`: Set `config['commodity']['is_primary'] = (ticker == 'KC')`
- `equity_logger.py`: Early return in `log_equity_snapshot()` and `sync_equity_from_flex()` for non-primary
- `performance_analyzer.py`: Skip equity-based LTD P&L for non-primary; filter `live_portfolio` and `todays_fills` by ticker

## Design rationale
- Drawdown circuit breaker stays account-wide (intentional — margin is shared)
- Per-commodity realized P&L is always available from the trade ledger
- This is the simplest approach that avoids duplicate/misleading data

## Test plan
- [x] `pytest tests/` — 504 passed, 0 failed
- [ ] Verify KC EOD report unchanged
- [ ] Verify CC skips equity snapshot and sync in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)