### PR TITLE
Fix dashboard showing KC data when running as CC

### DIFF
--- a/pages/2_The_Scorecard.py
+++ b/pages/2_The_Scorecard.py
@@ -20,7 +20,8 @@ from dashboard_utils import (
     calculate_confusion_matrix,
     calculate_agent_scores,
     fetch_live_dashboard_data,
-    get_config
+    get_config,
+    _resolve_data_path
 )
 
 def create_process_outcome_matrix(df: pd.DataFrame):
@@ -374,10 +375,7 @@ st.markdown("---")
 # === FEEDBACK LOOP HEALTH ===
 st.subheader("🔄 Feedback Loop Health")
 
-# Locate data directory relative to this file
-base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-data_dir = os.path.join(base_dir, 'data')
-structured_file = os.path.join(data_dir, "agent_accuracy_structured.csv")
+structured_file = _resolve_data_path("agent_accuracy_structured.csv")
 
 if os.path.exists(structured_file):
     struct_df = pd.read_csv(structured_file)

--- a/pages/6_Signal_Overlay.py
+++ b/pages/6_Signal_Overlay.py
@@ -316,20 +316,22 @@ def get_contract_display_name(contract: str) -> str:
     Examples:
         'FRONT_MONTH' -> '📊 Front Month (Continuous)'
         'KCH26' -> 'KCH26 (Mar 2026)'
-        'KCH6 (202603)' -> 'KCH26 (Mar 2026)'
+        'CCK26' -> 'CCK26 (May 2026)'
     """
+    _tk_len = len(profile.contract.symbol)  # 2 for KC/CC
+    _expected_len = _tk_len + 3  # ticker + month_code + 2-digit year
+
     if contract == 'FRONT_MONTH':
         _, resolved_symbol = resolve_front_month_ticker()
         if resolved_symbol and resolved_symbol != 'FRONT_MONTH':
-            # Show which contract is actually being used
             month_names = {
                 'F': 'Jan', 'G': 'Feb', 'H': 'Mar', 'J': 'Apr',
                 'K': 'May', 'M': 'Jun', 'N': 'Jul', 'Q': 'Aug',
                 'U': 'Sep', 'V': 'Oct', 'X': 'Nov', 'Z': 'Dec'
             }
-            if len(resolved_symbol) == 5:
-                mc = resolved_symbol[2]
-                yr = resolved_symbol[3:5]
+            if len(resolved_symbol) == _expected_len:
+                mc = resolved_symbol[_tk_len]
+                yr = resolved_symbol[_tk_len + 1:_tk_len + 3]
                 mn = month_names.get(mc, '???')
                 return f'📊 Front Month ({resolved_symbol} · {mn} 20{yr})'
         return '📊 Front Month (Continuous)'
@@ -341,9 +343,9 @@ def get_contract_display_name(contract: str) -> str:
     }
 
     clean_symbol = clean_contract_symbol(contract)
-    if clean_symbol and len(clean_symbol) == 5:
-        month_code = clean_symbol[2]
-        year = clean_symbol[3:5]
+    if clean_symbol and len(clean_symbol) == _expected_len:
+        month_code = clean_symbol[_tk_len]
+        year = clean_symbol[_tk_len + 1:_tk_len + 3]
         month_name = month_names.get(month_code, '???')
         return f"{clean_symbol} ({month_name} 20{year})"
 
@@ -1112,12 +1114,12 @@ if price_df is not None and not price_df.empty:
         # Add 5% buffer on each side, with minimum buffer to prevent zero-range issues
         y_buffer = max(y_range * 0.05, 0.5)
         fig.update_yaxes(
-            title_text="Price (¢/lb)",
+            title_text=f"Price ({profile.name})",
             range=[y_min - y_buffer, y_max + y_buffer],
             row=1, col=1
         )
     else:
-        fig.update_yaxes(title_text="Price (¢/lb)", row=1, col=1)
+        fig.update_yaxes(title_text=f"Price ({profile.name})", row=1, col=1)
 
     # Row 2 Y-axis (Volume)
     fig.update_yaxes(


### PR DESCRIPTION
## Summary
The CC dashboard was showing KC price data and using Coffee-specific labels because the dashboard never injected `COMMODITY_TICKER` into the config. Every page calling `get_active_profile(config)` got KC regardless of which commodity dashboard was running.

**Root cause:** `get_config()` loads `config.json` which hardcodes `"symbol": "KC"`. The orchestrator overrides this in `main()` with `config['symbol'] = ticker`, but the dashboard never did this.

## Fixes
- **`dashboard_utils.get_config()`**: Inject `COMMODITY_TICKER` env var into `config['symbol']`, `config['commodity']['ticker']`, and `config['data_dir']` — mirrors what the orchestrator does in `main()`
- **`dashboard_utils` import-time init**: Call `set_signals_dir()` so `decision_signals.csv` reads from the correct `data/{ticker}/` directory
- **`dashboard_utils.get_commodity_profile()`**: Derive defaults from `CommodityProfile` dataclass instead of hardcoding KC price ranges (stop_parse_range, typical_price_range)
- **`pages/2_The_Scorecard.py`**: Replace hardcoded `data/agent_accuracy_structured.csv` path with `_resolve_data_path()`
- **`pages/6_Signal_Overlay.py`**: Use `profile.name` for Y-axis label instead of hardcoded `"Price (¢/lb)"`
- **`pages/6_Signal_Overlay.py`**: Use profile-based ticker length in `get_contract_display_name()` instead of hardcoded `len==5`

## Test plan
- [x] `pytest tests/` — 504 passed, 0 failures
- [x] Verified `get_active_profile({'symbol': 'CC'})` returns Cocoa profile
- [ ] Verify CC dashboard on port 8502 shows Cocoa price data after deploy
- [ ] Verify KC dashboard on port 8501 is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)