### PR TITLE
Fix COMMODITY_TICKER override at the source: load_config()

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -181,6 +181,16 @@ def load_config() -> dict | None:
     if trading_mode == "OFF":
         logger.warning("*** TRADING MODE OFF — No real orders will be placed ***")
 
+    # 10. COMMODITY TICKER: Override symbol from environment
+    # This ensures dashboards and any caller of load_config() get the correct commodity
+    # without needing to duplicate the override logic. The orchestrator also sets this
+    # from --commodity CLI arg in main(), but the env var covers all other callers.
+    commodity_ticker = os.getenv("COMMODITY_TICKER")
+    if commodity_ticker:
+        config['symbol'] = commodity_ticker
+        config.setdefault('commodity', {})['ticker'] = commodity_ticker
+        config['data_dir'] = os.path.join(base_dir, 'data', commodity_ticker)
+
     # Log successful load
     loaded_providers = [p for p in ['gemini', 'anthropic', 'openai', 'xai'] if config.get(p, {}).get('api_key')]
     logger.info(f"Config loaded successfully. Mode: {trading_mode}. Providers: {', '.join(loaded_providers)}")

--- a/dashboard_utils.py
+++ b/dashboard_utils.py
@@ -102,11 +102,7 @@ def get_config():
     if config is None:
         st.error("Fatal: Could not load config.json.")
         return {}
-    # Inject active commodity ticker (matches orchestrator's main() override)
-    ticker = os.environ.get("COMMODITY_TICKER", "KC")
-    config['symbol'] = ticker
-    config.setdefault('commodity', {})['ticker'] = ticker
-    config['data_dir'] = os.path.join('data', ticker)
+    # COMMODITY_TICKER override is now handled in load_config() itself
     return config
 
 


### PR DESCRIPTION
## Summary
PR #942 only fixed `dashboard_utils.get_config()`, but **5 other callers** call `load_config()` directly and still got `symbol="KC"` from config.json:

- `pages/6_Signal_Overlay.py:210` — `resolve_front_month_ticker()` builds KC contracts
- `pages/1_Cockpit.py:401` — prediction markets rendering
- `pages/7_Brier_Analysis.py:365` — profile loading
- `pages/5_Utilities.py:768` — config loading
- `dashboard.py:18` — module-level config

**Root cause:** The commodity ticker override was applied too late — in a dashboard-specific wrapper function instead of at the source where config is loaded.

## Fix
Move the `COMMODITY_TICKER` env var override into `config_loader.load_config()` itself (step 10, after trading mode). Now every caller gets the correct commodity symbol, data_dir, and ticker automatically.

Removed the now-redundant duplicate override from `dashboard_utils.get_config()`.

## Verification
```python
os.environ['COMMODITY_TICKER'] = 'CC'
cfg = load_config()
cfg['symbol']  # 'CC'
get_active_profile(cfg).name  # 'Cocoa'
get_active_profile(cfg).contract.symbol  # 'CC'
```

## Test plan
- [x] `pytest tests/` — 504 passed, 0 failures
- [x] Verified `load_config()` returns CC profile when `COMMODITY_TICKER=CC`
- [ ] Verify CC Signal Overlay shows Cocoa contracts after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)