### PR TITLE
Fix CC dashboard: isolate Brier data, trade ledger, and price formatting

### DIFF
--- a/dashboard_utils.py
+++ b/dashboard_utils.py
@@ -44,10 +44,13 @@ from config_loader import load_config
 from trading_bot.utils import configure_market_data_type
 from trading_bot.timestamps import parse_ts_column
 
-# Set decision_signals path for the active commodity (dashboard doesn't go through orchestrator init)
+# Set module-level data paths for the active commodity (dashboard doesn't go through orchestrator init)
 _dashboard_ticker = os.environ.get("COMMODITY_TICKER", "KC")
 _dashboard_data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', _dashboard_ticker)
 set_signals_dir(_dashboard_data_dir)
+
+from trading_bot.brier_bridge import set_data_dir as set_brier_bridge_dir
+set_brier_bridge_dir(_dashboard_data_dir)
 
 # === MULTI-COMMODITY PATH RESOLUTION ===
 def _resolve_data_path(filename: str) -> str:

--- a/pages/6_Signal_Overlay.py
+++ b/pages/6_Signal_Overlay.py
@@ -37,6 +37,12 @@ st.set_page_config(layout="wide", page_title="Signal Analysis | Real Options")
 config = get_config()
 profile = get_active_profile(config)
 
+# Derive price display decimals from tick size (KC=0.05 → 2dp, CC=1.0 → 0dp)
+import math
+_tick = profile.contract.tick_size
+_price_decimals = max(0, -math.floor(math.log10(_tick))) if _tick < 1 else 0
+_price_fmt = f",.{_price_decimals}f"
+
 st.title("🎯 Signal Overlay Analysis")
 st.caption("Forensic analysis of Council decisions against futures price action")
 
@@ -906,11 +912,11 @@ if price_df is not None and not price_df.empty:
         with summary_cols[0]:
             st.metric("Period Change", f"{pct_change:+.2f}%")
         with summary_cols[1]:
-            st.metric("High", f"${high:.2f}")
+            st.metric("High", f"${high:{_price_fmt}}")
         with summary_cols[2]:
-            st.metric("Low", f"${low:.2f}")
+            st.metric("Low", f"${low:{_price_fmt}}")
         with summary_cols[3]:
-            st.metric("Range", f"${high - low:.2f}")
+            st.metric("Range", f"${high - low:{_price_fmt}}")
 
     # === DRAW CHARTS ===
     # CRITICAL: Plotly go.Candlestick fails to render in make_subplots when

--- a/performance_analyzer.py
+++ b/performance_analyzer.py
@@ -45,13 +45,13 @@ def _load_archive_file(filepath: str, mtime: float) -> pd.DataFrame:
 
 def get_trade_ledger_df(data_dir: str = None):
     """Reads and consolidates the main and archived trade ledgers for analysis."""
-    if data_dir:
-        ledger_path = os.path.join(data_dir, 'trade_ledger.csv')
-        archive_dir = os.path.join(data_dir, 'archive_ledger')
-    else:
+    if not data_dir:
+        # Derive from COMMODITY_TICKER env var (avoids loading legacy KC data for CC)
+        ticker = os.environ.get("COMMODITY_TICKER", "KC")
         base_dir = os.path.dirname(os.path.abspath(__file__))
-        ledger_path = os.path.join(base_dir, 'trade_ledger.csv')
-        archive_dir = os.path.join(base_dir, 'archive_ledger')
+        data_dir = os.path.join(base_dir, 'data', ticker)
+    ledger_path = os.path.join(data_dir, 'trade_ledger.csv')
+    archive_dir = os.path.join(data_dir, 'archive_ledger')
 
     dataframes = []
     logger.info("--- Consolidating Trade Ledgers ---")

--- a/trading_bot/enhanced_brier.py
+++ b/trading_bot/enhanced_brier.py
@@ -196,7 +196,10 @@ class EnhancedBrierTracker:
     - Dynamic weight multipliers
     """
 
-    def __init__(self, data_path: str = "./data/KC/enhanced_brier.json"):
+    def __init__(self, data_path: str = None):
+        if data_path is None:
+            ticker = os.environ.get("COMMODITY_TICKER", "KC")
+            data_path = f"./data/{ticker}/enhanced_brier.json"
         self.data_path = data_path
         self.predictions: List[ProbabilisticPrediction] = []
 


### PR DESCRIPTION
## Summary
- **Brier Analysis page** showing KC reliability multipliers when viewing CC dashboard — `brier_bridge` singleton was never initialized with CC data_dir in dashboard context. Added `set_brier_bridge_dir()` call in `dashboard_utils.py` module-level init.
- **Financials page** showing 46 KC trades on CC dashboard — `get_trade_ledger_df()` fallback path read from project root (legacy KC location). Now derives `data_dir` from `COMMODITY_TICKER` env var.
- **Enhanced Brier tracker** had hardcoded default `./data/KC/enhanced_brier.json` — now dynamic based on `COMMODITY_TICKER`.
- **Signal Overlay** price ribbon showed `$4365.00` for Cocoa — decimal places now derived from `profile.contract.tick_size` (KC=0.05 gets 2dp, CC=1.0 gets 0dp).

## Test plan
- [x] 504 tests pass
- [ ] CC dashboard Brier Analysis page shows empty/CC-specific reliability multipliers
- [ ] CC Financials page shows 0 trades (not 46 KC trades)
- [ ] CC Signal Overlay shows `$4365` not `$4365.00`
- [ ] KC dashboard unaffected (still shows 2 decimal places, correct Brier data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)