### PR TITLE
Improve data migration and add to deploy pipeline

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -121,7 +121,7 @@ send_pushover_notification({}, 'DEPLOY ROLLBACK', 'Deploy of $CURR_COMMIT failed
 # =========================================================================
 echo "--- 1. Stopping old processes... ---"
 
-# Stop ALL commodity services (passwordless sudo configured in /etc/sudoers.d/coffee-bot)
+# Stop ALL commodity services (passwordless sudo configured in /etc/sudoers.d/trading-bot)
 for _t in "${ALL_TICKERS[@]}"; do
     _tl=$(echo "$_t" | tr '[:upper:]' '[:lower:]')
     if [ "$_t" = "KC" ]; then _svc="$SERVICE_NAME"; else _svc="trading-bot-${_tl}"; fi
@@ -214,6 +214,16 @@ for _t in "${ALL_TICKERS[@]}"; do
     mkdir -p "data/$_t"           # Per-commodity data directory
 done
 echo "  Directories OK"
+
+# =========================================================================
+# STEP 6: Data migration (idempotent — moves legacy flat paths to data/KC/)
+# =========================================================================
+echo "--- 6. Running data migration... ---"
+if [ -f "scripts/migrate_data_dirs.py" ]; then
+    python scripts/migrate_data_dirs.py --force || echo "  Migration encountered an issue (non-blocking)"
+else
+    echo "  No migration script found, skipping"
+fi
 
 # =========================================================================
 # STEP 7: Sync equity data (only for primary commodity — is_primary handles this)


### PR DESCRIPTION
## Summary
- **Migration script** rewritten to handle real-world state where `data/KC/` already exists with smaller post-migration files while `data/` has larger historical files:
  - Files: keeps the larger version (historical > fresh), removes the stale copy
  - Directories: merges contents instead of skipping when destination exists
  - Handles symlinks (stale `data/tms -> /old/path`)
  - `--force` flag to skip orchestrator check (needed when other deployments share the machine)
  - Added missing files: `compliance_decisions.csv`, `router_metrics.json`, `error_reporter_state.json`, `research_provenance.log`
  - Cleans stale CC data (KC trades leaked before commodity filter PR #937)
- **deploy.sh**: Added step 6 to run migration automatically during deployment, ensuring PROD gets migrated on next deploy
- **Sudoers comment** fix: `coffee-bot` → `trading-bot`

## Manual actions already done on DEV
- Moved `archive_ledger/` from root to `data/KC/archive_ledger/` (5 historical snapshots)
- Moved flat `data/` files to `data/KC/` (council_history, daily_equity, enhanced_brier, etc.)
- Removed stale KC missing trades from `data/CC/archive_ledger/`
- Created `data/CC/`

## Test plan
- [x] 504 tests pass
- [x] DEV migration completed manually — verified all files in `data/KC/`
- [ ] PROD migration will run automatically on deploy (step 6)
- [ ] Verify PROD `data/KC/archive_ledger/` has historical snapshots after deploy
- [ ] Verify PROD `data/CC/archive_ledger/` is clean after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)