### PR TITLE
Always set data_dir in load_config() even without COMMODITY_TICKER

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -189,7 +189,10 @@ def load_config() -> dict | None:
     if commodity_ticker:
         config['symbol'] = commodity_ticker
         config.setdefault('commodity', {})['ticker'] = commodity_ticker
-        config['data_dir'] = os.path.join(base_dir, 'data', commodity_ticker)
+
+    # Always set data_dir based on the active symbol (env override or config default)
+    ticker = commodity_ticker or config.get('commodity', {}).get('ticker', config.get('symbol', 'KC'))
+    config['data_dir'] = os.path.join(base_dir, 'data', ticker)
 
     # Log successful load
     loaded_providers = [p for p in ['gemini', 'anthropic', 'openai', 'xai'] if config.get(p, {}).get('api_key')]


### PR DESCRIPTION
## Summary
During deploy verification, `COMMODITY_TICKER` env var is not set. This caused `load_config()` to skip setting `data_dir`, so modules like `PredictionMarketSentinel` fell back to `data/` (flat path) instead of `data/KC/` — couldn't find `discovered_topics.json` which was already migrated.

Fix: always compute `data_dir = data/{symbol}` from the config's symbol (default KC), regardless of whether `COMMODITY_TICKER` is set.

## Test plan
- [x] 504 tests pass
- [x] Without COMMODITY_TICKER: `data_dir = data/KC` (from config symbol)
- [x] With COMMODITY_TICKER=CC: `data_dir = data/CC` (env override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)