### PR TITLE
Eliminate all hardcoded data/KC paths for multi-commodity

### DIFF
--- a/backtesting/surrogate_models.py
+++ b/backtesting/surrogate_models.py
@@ -15,7 +15,7 @@ from sklearn.model_selection import train_test_split, cross_val_score
 from sklearn.preprocessing import StandardScaler
 from sklearn.metrics import classification_report, accuracy_score
 import joblib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 from pathlib import Path
 import logging
@@ -26,7 +26,13 @@ logger = logging.getLogger(__name__)
 @dataclass
 class SurrogateConfig:
     """Configuration for surrogate model training."""
-    model_dir: str = "./data/KC/surrogate_models"
+    model_dir: str = field(default=None)
+
+    def __post_init__(self):
+        if self.model_dir is None:
+            import os
+            ticker = os.environ.get("COMMODITY_TICKER", "KC")
+            self.model_dir = f"./data/{ticker}/surrogate_models"
     min_training_samples: int = 100
     test_size: float = 0.2
     random_state: int = 42

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -107,7 +107,9 @@ def _record_sentinel_health(name: str, status: str, interval_seconds: int, error
         logger.warning(f"Failed to record sentinel health for {name}: {e}")
 
 class TriggerDeduplicator:
-    def __init__(self, window_seconds: int = 7200, state_file="data/KC/deduplicator_state.json", critical_severity_threshold: int = 9):
+    def __init__(self, window_seconds: int = 7200, state_file=None, critical_severity_threshold: int = 9):
+        if state_file is None:
+            state_file = os.path.join("data", os.environ.get("COMMODITY_TICKER", "KC"), "deduplicator_state.json")
         self.state_file = state_file
         self.window = window_seconds
         self.critical_severity_threshold = critical_severity_threshold
@@ -3962,7 +3964,7 @@ async def run_brier_reconciliation(config: dict):
         global _brier_zero_resolution_streak
         try:
             import json
-            brier_path = os.path.join(os.path.dirname(__file__), 'data', 'enhanced_brier.json')
+            brier_path = os.path.join(config.get('data_dir', 'data'), 'enhanced_brier.json')
             if os.path.exists(brier_path):
                 with open(brier_path, 'r') as f:
                     brier_data = json.load(f)
@@ -4600,6 +4602,7 @@ async def main(commodity_ticker: str = None):
     from trading_bot.brier_bridge import set_data_dir as set_brier_bridge_dir
     from trading_bot.brier_scoring import set_data_dir as set_brier_scoring_dir
     from trading_bot.weighted_voting import set_data_dir as set_weighted_voting_dir
+    from trading_bot.brier_reconciliation import set_data_dir as set_brier_recon_dir
 
     StateManager.set_data_dir(data_dir)
     set_tracker_dir(data_dir)
@@ -4611,6 +4614,7 @@ async def main(commodity_ticker: str = None):
     set_brier_bridge_dir(data_dir)
     set_brier_scoring_dir(data_dir)
     set_weighted_voting_dir(data_dir)
+    set_brier_recon_dir(data_dir)
 
     global GLOBAL_DEDUPLICATOR
     GLOBAL_DEDUPLICATOR = TriggerDeduplicator(

--- a/trading_bot/brier_scoring.py
+++ b/trading_bot/brier_scoring.py
@@ -17,7 +17,10 @@ logger = logging.getLogger(__name__)
 class BrierScoreTracker:
     """Tracks agent prediction accuracy over time."""
 
-    def __init__(self, history_file: str = "data/KC/agent_accuracy.csv"):
+    def __init__(self, history_file: str = None):
+        if history_file is None:
+            ticker = os.environ.get("COMMODITY_TICKER", "KC")
+            history_file = f"data/{ticker}/agent_accuracy.csv"
         self.history_file = history_file
 
         # Ensure directory exists

--- a/trading_bot/observability.py
+++ b/trading_bot/observability.py
@@ -157,7 +157,10 @@ class HallucinationDetector:
         self.agent_flags: Dict[str, List[HallucinationFlag]] = {}
         self.quarantined_agents: Set[str] = set()
         import os as _os
-        self._state_file = _os.path.join(data_dir, "quarantine_state.json") if data_dir else "data/KC/quarantine_state.json"
+        if not data_dir:
+            _ticker = _os.environ.get("COMMODITY_TICKER", "KC")
+            data_dir = f"data/{_ticker}"
+        self._state_file = _os.path.join(data_dir, "quarantine_state.json")
         self._load_state()
 
         # DYNAMICALLY build known facts from the profile

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -47,7 +47,7 @@ _CAPITAL_LOCK = asyncio.Lock()
 from pathlib import Path
 import json
 
-CAPITAL_STATE_FILE = Path("data/KC/capital_state.json")
+CAPITAL_STATE_FILE = Path(os.path.join("data", os.environ.get("COMMODITY_TICKER", "KC"), "capital_state.json"))
 
 
 def set_capital_state_dir(data_dir: str):

--- a/trading_bot/reliability_scorer.py
+++ b/trading_bot/reliability_scorer.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 import logging
 
@@ -7,7 +8,10 @@ logger = logging.getLogger(__name__)
 class ReliabilityScorer:
     """Tracks and scores agent prediction accuracy using Brier scores."""
 
-    def __init__(self, scores_file: str = "./data/KC/agent_scores.json"):
+    def __init__(self, scores_file: str = None):
+        if scores_file is None:
+            ticker = os.environ.get("COMMODITY_TICKER", "KC")
+            scores_file = f"./data/{ticker}/agent_scores.json"
         self.scores_file = Path(scores_file)
         self.scores = self._load_scores()
 

--- a/trading_bot/self_healing.py
+++ b/trading_bot/self_healing.py
@@ -126,30 +126,33 @@ class SelfHealingMonitor:
             return
 
         try:
-            # Check if the root logger has any file handlers for orchestrator.log
+            # Derive per-commodity log filename
+            ticker = os.environ.get("COMMODITY_TICKER", "KC").lower()
+            log_name = f"orchestrator_{ticker}.log"
+
+            # Check if the root logger has any file handlers for this commodity's log
             root_logger = logging.getLogger()
             has_file_handler = False
 
             for handler in root_logger.handlers:
                 if isinstance(handler, logging.FileHandler):
-                    # Check if this handler's filename matches our log file
                     if hasattr(handler, 'baseFilename'):
-                        if 'orchestrator.log' in handler.baseFilename:
+                        if log_name in handler.baseFilename:
                             has_file_handler = True
                             break
 
             if not has_file_handler:
                 # Only warn if we're past initialization and the file exists
-                log_file = Path("logs/orchestrator.log")
+                log_file = Path(f"logs/{log_name}")
                 if log_file.exists():
                     logger.warning(
-                        "SELF-HEAL: orchestrator.log exists but no file handler attached. "
+                        f"SELF-HEAL: {log_name} exists but no file handler attached. "
                         "Logs may only be going to stdout. "
                         "Check logging_config.py for permission issues."
                     )
                 else:
                     logger.debug(
-                        "SELF-HEAL: orchestrator.log not found and no file handler. "
+                        f"SELF-HEAL: {log_name} not found and no file handler. "
                         "This may be expected in certain deployment modes."
                     )
         except Exception as e:

--- a/trading_bot/sentinel_stats.py
+++ b/trading_bot/sentinel_stats.py
@@ -6,13 +6,14 @@ v3.1: Tracks sentinel performance for dashboard display.
 
 import json
 import logging
+import os
 from pathlib import Path
 from datetime import datetime, timezone
 from collections import defaultdict
 
 logger = logging.getLogger(__name__)
 
-STATS_FILE = Path("data/KC/sentinel_stats.json")
+STATS_FILE = Path(os.path.join("data", os.environ.get("COMMODITY_TICKER", "KC"), "sentinel_stats.json"))
 
 
 def set_data_dir(data_dir: str):

--- a/trading_bot/sentinels.py
+++ b/trading_bot/sentinels.py
@@ -111,7 +111,7 @@ class SentinelTrigger:
 
 class Sentinel:
     """Base class for all sentinels."""
-    CACHE_DIR = "data/KC/sentinel_caches"
+    CACHE_DIR = os.path.join("data", os.environ.get("COMMODITY_TICKER", "KC"), "sentinel_caches")
 
     def __init__(self, config: dict):
         self.config = config
@@ -451,7 +451,7 @@ class WeatherSentinel(Sentinel):
     Monitors specific coffee-growing regions for frost or drought risks.
     Frequency: Every 4 Hours (24/7).
     """
-    ALERT_STATE_FILE = "data/KC/weather_sentinel_alerts.json"
+    ALERT_STATE_FILE = os.path.join("data", os.environ.get("COMMODITY_TICKER", "KC"), "weather_sentinel_alerts.json")
 
     def __init__(self, config: dict):
         super().__init__(config)

--- a/trading_bot/tms.py
+++ b/trading_bot/tms.py
@@ -43,7 +43,7 @@ CROSS_CUE_RULES = {
 
 
 # Default TMS path — overridden by set_data_dir() for multi-commodity
-_default_tms_path = "./data/KC/tms"
+_default_tms_path = os.path.join("./data", os.environ.get("COMMODITY_TICKER", "KC"), "tms")
 
 
 def set_data_dir(data_dir: str):

--- a/trading_bot/weighted_voting.py
+++ b/trading_bot/weighted_voting.py
@@ -639,7 +639,10 @@ async def calculate_weighted_decision(
             import csv
             from datetime import datetime, timezone
 
-            weight_csv = os.path.join(_data_dir or 'data/KC', 'weight_evolution.csv')
+            weight_csv = os.path.join(
+                _data_dir or os.path.join('data', os.environ.get('COMMODITY_TICKER', 'KC')),
+                'weight_evolution.csv'
+            )
             file_exists = os.path.exists(weight_csv)
 
             # Ensure directory exists


### PR DESCRIPTION
## Summary
- Sweeps 12 files to replace every remaining hardcoded `data/KC/` path with dynamic commodity-aware resolution
- Fixes 4 active bugs where CC would read/write KC data
- Hardens 8 additional default parameters that were fragile if `set_data_dir()` wasn't called

## Active bugs fixed
| File | Bug | Fix |
|------|-----|-----|
| `brier_reconciliation.py` | Module-level `DATA_DIR="data"` — reconciliation reads/writes KC CSVs for all commodities | Added `set_data_dir()` + `_get_paths()` with COMMODITY_TICKER fallback |
| `orchestrator.py:3965` | Brier stall check uses flat `data/enhanced_brier.json` | Changed to `config['data_dir']` |
| `self_healing.py` | Checks `logs/orchestrator.log` — doesn't match per-commodity log files | Changed to `logs/orchestrator_{ticker}.log` |
| `weighted_voting.py` | Fallback `'data/KC'` in weight CSV writer | Changed to env-derived path |

## Defensive hardening
All these now use `os.environ.get("COMMODITY_TICKER", "KC")` instead of hardcoded `"KC"`:
- `reliability_scorer.py` — agent_scores.json default
- `brier_scoring.py` — agent_accuracy.csv default  
- `observability.py` — quarantine_state.json fallback
- `surrogate_models.py` — model_dir default
- `sentinel_stats.py` — STATS_FILE module constant
- `order_manager.py` — CAPITAL_STATE_FILE module constant
- `tms.py` — _default_tms_path module constant
- `sentinels.py` — CACHE_DIR + ALERT_STATE_FILE class defaults
- `orchestrator.py` — TriggerDeduplicator default param

## Test plan
- [x] All 504 tests pass
- [ ] Deploy to DEV — verify KC continues working normally
- [ ] Check CC orchestrator logs for correct file paths (no more KC references)
- [ ] Verify self-healing no longer warns about missing log handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)