### PR TITLE
Fix manual brier reconciliation script for multi-commodity

### DIFF
--- a/scripts/manual_brier_reconciliation.py
+++ b/scripts/manual_brier_reconciliation.py
@@ -34,6 +34,17 @@ async def main(dry_run: bool = False):
         logger.critical("Failed to load config.")
         return
 
+    # Initialize module-level data paths (same as orchestrator startup)
+    data_dir = config.get('data_dir')
+    if data_dir:
+        from trading_bot.brier_reconciliation import set_data_dir as set_brier_recon_dir
+        from trading_bot.brier_bridge import set_data_dir as set_brier_bridge_dir
+        from trading_bot.brier_scoring import set_data_dir as set_brier_scoring_dir
+        set_brier_recon_dir(data_dir)
+        set_brier_bridge_dir(data_dir)
+        set_brier_scoring_dir(data_dir)
+        logger.info(f"Data directory: {data_dir}")
+
     # --- Step 1: Council History Reconciliation (needs IB) ---
     logger.info("=" * 60)
     logger.info("STEP 1: Council History Reconciliation")


### PR DESCRIPTION
## Summary
- Initializes `set_data_dir()` for brier_reconciliation, brier_bridge, and brier_scoring before calling their functions
- Without this, the script relied on COMMODITY_TICKER env var fallback instead of the config-derived `data_dir`

Last item from the hardcoded-path sweep audit.

## Test plan
- [ ] `python scripts/manual_brier_reconciliation.py --dry-run` works for both KC and CC

🤖 Generated with [Claude Code](https://claude.com/claude-code)