### PR TITLE
🎨 Palette: Enhanced Portfolio Risk Tooltips

### DIFF
--- a/pages/1_Cockpit.py
+++ b/pages/1_Cockpit.py
@@ -260,19 +260,34 @@ def render_portfolio_risk_summary(live_data: dict):
 
     with cols[2]:
         import math
+        pnl_help = "Real-time Profit & Loss for the current trading session (reset daily)."
         if daily_pnl is None or (isinstance(daily_pnl, float) and math.isnan(daily_pnl)):
-            st.metric("Daily P&L", "$0", delta="No data", delta_color="off")
+            st.metric("Daily P&L", "$0", delta="No data", delta_color="off", help=pnl_help)
         else:
             st.metric(
                 "Daily P&L",
                 f"${daily_pnl:+,.0f}",
                 delta=f"${daily_pnl:+,.0f}",
                 delta_color="normal",
+                help=pnl_help
             )
 
     with cols[3]:
-        pos_count = len([p for p in live_data.get('open_positions', []) if p.position != 0])
-        st.metric("Open Positions", pos_count)
+        open_positions = [p for p in live_data.get('open_positions', []) if p.position != 0]
+        pos_count = len(open_positions)
+
+        # Generate detailed tooltip for active positions
+        if open_positions:
+            details = ["**Active Positions:**"]
+            for p in open_positions:
+                symbol = p.contract.localSymbol if p.contract else "Unknown"
+                qty = p.position
+                details.append(f"• **{symbol}**: {qty}")
+            pos_help = "\n".join(details)
+        else:
+            pos_help = "No active positions currently held."
+
+        st.metric("Open Positions", pos_count, help=pos_help)
 
 
 def render_prediction_markets():

--- a/tests/test_palette_ux.py
+++ b/tests/test_palette_ux.py
@@ -1,0 +1,53 @@
+import ast
+import os
+import unittest
+
+class TestPaletteUX(unittest.TestCase):
+    def test_portfolio_risk_tooltips(self):
+        """
+        Verify that render_portfolio_risk_summary in pages/1_Cockpit.py
+        has help tooltips for 'Open Positions' and 'Daily P&L' metrics.
+        """
+        file_path = os.path.join(os.path.dirname(__file__), '..', 'pages', '1_Cockpit.py')
+
+        with open(file_path, 'r') as f:
+            tree = ast.parse(f.read())
+
+        render_func = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == 'render_portfolio_risk_summary':
+                render_func = node
+                break
+
+        self.assertIsNotNone(render_func, "render_portfolio_risk_summary function not found")
+
+        # We need to find ALL occurrences and ensure they have help
+        open_pos_calls = []
+        daily_pnl_calls = []
+
+        for node in ast.walk(render_func):
+            if isinstance(node, ast.Call):
+                # Check for st.metric calls
+                if isinstance(node.func, ast.Attribute) and node.func.attr == 'metric':
+                    # Check first argument (label)
+                    label = None
+                    if node.args and isinstance(node.args[0], ast.Constant):
+                        label = node.args[0].value
+                    elif node.args and isinstance(node.args[0], ast.Str): # Python < 3.8 support
+                        label = node.args[0].s
+
+                    if label == "Open Positions":
+                        has_help = any(k.arg == 'help' for k in node.keywords)
+                        open_pos_calls.append(has_help)
+                    elif label == "Daily P&L":
+                        has_help = any(k.arg == 'help' for k in node.keywords)
+                        daily_pnl_calls.append(has_help)
+
+        self.assertTrue(len(open_pos_calls) > 0, "No 'Open Positions' metric found")
+        self.assertTrue(all(open_pos_calls), "All 'Open Positions' metrics must have a help tooltip")
+
+        self.assertTrue(len(daily_pnl_calls) > 0, "No 'Daily P&L' metric found")
+        self.assertTrue(all(daily_pnl_calls), "All 'Daily P&L' metrics must have a help tooltip")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
💡 What: Added context-aware tooltips to the "Daily P&L" and "Open Positions" metrics in the Cockpit dashboard.
🎯 Why: Users need to see details about open positions (symbols, quantities) and understand P&L reset behavior without leaving the high-level summary view.
📸 Verification: Verified via Playwright screenshot (`daily_pnl_tooltip.png`) and new AST-based regression test (`tests/test_palette_ux.py`).
♿ Accessibility: Tooltips provide necessary context for screen readers and curious users alike.

---
*PR created automatically by Jules for task [309737823454732030](https://jules.google.com/task/309737823454732030) started by @rozavala*