### PR TITLE
Rebalance LLM model assignments for quota and quality

### DIFF
--- a/trading_bot/budget_guard.py
+++ b/trading_bot/budget_guard.py
@@ -54,6 +54,7 @@ ROLE_PRIORITY = {
     'news_sentinel': CallPriority.LOW,
     'price_sentinel': CallPriority.LOW,
     'microstructure_sentinel': CallPriority.LOW,
+    'trade_analyst': CallPriority.LOW,  # Post-mortem utility, non-critical
 }
 
 

--- a/trading_bot/trade_journal.py
+++ b/trading_bot/trade_journal.py
@@ -139,7 +139,7 @@ Generate a JSON object with:
 """
 
         response = await self.router.route(
-            AgentRole.PERMABEAR, prompt, response_json=True
+            AgentRole.TRADE_ANALYST, prompt, response_json=True
         )
 
         # Parse JSON response (using robust regex extraction)


### PR DESCRIPTION
## Summary
- **Fixes Gemini Pro 250 RPD limit** by reducing from 4→1 analyst per cycle, spreading Inventory/Volatility/Supply Chain across Anthropic and xAI
- **Upgrades Sentiment Analyst** from xAI Flash (non-reasoning) to xAI Pro (reasoning) for COT/crowd analysis
- **Fixes MacroContagion Fed policy check** — was using Flash without web search tools (couldn't detect post-training-cutoff events); now uses Pro + Google Search
- **Fixes Trade Journal role misuse** — was routing post-mortems through PERMABEAR role; new dedicated `TRADE_ANALYST` role on OpenAI

### Provider distribution after change

| Provider | Tier 2 Analysts | Tier 3 Decision | Sentinels |
|---|---|---|---|
| Gemini | Agronomist (Pro) | — | Logistics, News (Flash), MacroContagion (Pro, 1x/day) |
| OpenAI | Macro, Geo, Technical | Master Strategist | — |
| xAI | Volatility, Supply Chain, Sentiment | Permabull | XSentiment |
| Anthropic | Inventory | Permabear, Compliance, DA | — |

### Gemini Pro budget impact
- Before: ~240 calls/day (4 analysts × ~60 cycles across KC+CC) → hitting 250 limit
- After: ~60 calls/day (1 analyst × ~60 cycles) + 1 sentinel/day + fallback duty

## Test plan
- [x] Full test suite: 505 passed, 0 failures
- [ ] Monitor Gemini Pro RPD usage in production for 24h
- [ ] Verify MacroContagion Fed policy check returns grounded results (not hallucinated)
- [ ] Verify Sentiment Analyst quality with reasoning model vs previous non-reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)