### PR TITLE
Fix provenance log path isolation and clean up migration list

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -4610,6 +4610,7 @@ async def main(commodity_ticker: str = None):
     from trading_bot.weighted_voting import set_data_dir as set_weighted_voting_dir
     from trading_bot.brier_reconciliation import set_data_dir as set_brier_recon_dir
     from trading_bot.router_metrics import set_data_dir as set_router_metrics_dir
+    from trading_bot.agents import set_data_dir as set_agents_dir
 
     StateManager.set_data_dir(data_dir)
     set_tracker_dir(data_dir)
@@ -4623,6 +4624,7 @@ async def main(commodity_ticker: str = None):
     set_weighted_voting_dir(data_dir)
     set_brier_recon_dir(data_dir)
     set_router_metrics_dir(data_dir)
+    set_agents_dir(data_dir)
 
     global GLOBAL_DEDUPLICATOR
     GLOBAL_DEDUPLICATOR = TriggerDeduplicator(

--- a/scripts/migrate_data_dirs.py
+++ b/scripts/migrate_data_dirs.py
@@ -52,9 +52,7 @@ DATA_FILES = [
     'discovered_topics.json',
     'fundamental_regime.json',
     'weight_evolution.csv',
-    'compliance_decisions.csv',
     'router_metrics.json',
-    'error_reporter_state.json',
     'research_provenance.log',
 ]
 


### PR DESCRIPTION
## Summary
- **`agents.py`**: Add `set_data_dir()` so `research_provenance.log` writes to `data/{ticker}/` instead of root `data/`. Without this, the orchestrator was recreating an empty log at `data/` root after every restart, bypassing commodity isolation.
- **`orchestrator.py`**: Wire `agents.set_data_dir(data_dir)` into the path-dependent module initialization block.
- **`migrate_data_dirs.py`**: Remove `error_reporter_state.json` (account-wide, not per-commodity) and `compliance_decisions.csv` (dead entry, nothing writes it) from DATA_FILES.

## Context
Found during post-migration audit on DEV: `data/research_provenance.log` (0 bytes, created today) was being recreated at root by the running orchestrator, while the real 336KB file sat in `data/KC/`. The `error_reporter_state.json` had the same symptom — migration moved it but the error reporter cron recreated it at root because it's account-wide.

## Test plan
- [x] `pytest tests/` — 505 passed, 0 failed
- [ ] Deploy to DEV, verify `data/research_provenance.log` is no longer created at root
- [ ] Verify `data/KC/research_provenance.log` receives new entries
- [ ] Run `python scripts/migrate_data_dirs.py --dry-run` — confirm removed entries no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)