### PR TITLE
Fix 11 production issues from DEV log analysis

### DIFF
--- a/config/commodity_profiles.py
+++ b/config/commodity_profiles.py
@@ -600,6 +600,17 @@ COCOA_PROFILE = CommodityProfile(
         "@CocoaBarometer", "@ICCOorg"
     ],
 
+    sentiment_search_queries=[
+        "cocoa futures",
+        "cocoa prices",
+        "CC futures",
+        "chocolate demand",
+        "ivory coast cocoa",
+        "ghana cocoa",
+        "cocoa supply chain",
+        "ICCO cocoa",
+    ],
+
     volatility_high_iv_rank=0.65,
     volatility_low_iv_rank=0.25,
     price_move_alert_pct=3.0,


### PR DESCRIPTION
## Summary

Systematic analysis and fix of 11 production issues identified from DEV orchestrator and sentinel logs (2026-02-19). These fixes address API waste, silent signal drops, safety violations, and missing notifications.

### Reliability & API Efficiency
- **API provider circuit breaker**: Stops hammering quota-exhausted providers (~192 wasted calls/day). Parses reset dates from error messages, auto-expires cooldowns.
- **Transient failure circuit breaker**: Tracks consecutive timeouts/503s, trips after 5 failures in 600s window with 5-min cooldown (~66 min/day wasted on unresponsive providers).
- **Quota error no-retry**: `with_retry()` breaks immediately on hard quota/billing errors instead of retrying 3x.

### Safety & Fail-Closed
- **Drawdown check fail-closed**: Order generation now blocks (was warn-and-continue) when drawdown guard is unreachable, with Pushover notification.
- **Emergency lock timeout deferral**: When `EMERGENCY_LOCK` times out, defers the trigger via `queue_deferred_trigger()` instead of silently dropping it. Priority-1 notification for severity >= 8.
- **Margin rejection notification**: Catches Error 201 margin rejections for catastrophe stops (not in `live_orders`) and sends priority-1 Pushover alert.

### Multi-Commodity (CC)
- **Cocoa sentiment queries**: Adds 8 search queries to `COCOA_PROFILE` for XSentimentSentinel.
- **Non-primary equity sharing**: CC copies equity data from KC's `daily_equity.csv` (account-wide metric) instead of using stale local data.

### LLM Quality
- **Hallucination cache invalidation**: Invalidates cached LLM response when hallucination detected during validation, preventing propagation.
- **Anti-hallucination prompt**: Tightens Master Strategist with explicit rules: only cite facts from evidence, don't invent frameworks.

### IB Connection
- **Client ID collision retry**: 3-attempt retry with different random IDs on Error 326, fixing position monitor crashes.

## Test plan

- [x] Full test suite: 505 passed, 0 failed
- [ ] Deploy to DEV, monitor logs for reduced API errors
- [ ] Verify Pushover notifications fire on margin rejection and lock timeout
- [ ] Confirm CC XSentimentSentinel produces results with new queries
- [ ] Monitor circuit breaker log messages to validate cooldown behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)