### PR TITLE
Fix self-healing monitor consuming deferred triggers

### DIFF
--- a/trading_bot/self_healing.py
+++ b/trading_bot/self_healing.py
@@ -106,7 +106,8 @@ class SelfHealingMonitor:
     def _check_stale_deferred_triggers(self):
         try:
             from trading_bot.state_manager import StateManager
-            deferred = StateManager.get_deferred_triggers()
+            # Use non-destructive read — get_deferred_triggers() clears the file!
+            deferred = StateManager._load_deferred_triggers()
             if len(deferred) > 10:
                 logger.warning(
                     f"SELF-HEAL: {len(deferred)} deferred triggers accumulated. "


### PR DESCRIPTION
## Summary
- `_check_stale_deferred_triggers()` in `self_healing.py` called `StateManager.get_deferred_triggers()` every 5 minutes to check the count of accumulated triggers
- `get_deferred_triggers()` is a destructive read — it atomically reads and **clears** the file
- This silently discarded deferred triggers before `process_deferred_triggers()` (the intended consumer) could act on them
- **Observed in production**: CC MacroContagionSentinel (severity=9) was queued at 17:14:51 UTC and consumed by the self-healing check at 17:18:32 UTC — the trigger was never processed

## Fix
Switch to `_load_deferred_triggers()` (non-destructive read) for the health check.

## Test plan
- [x] `pytest tests/test_deferred_triggers.py` — 6 passed
- [x] Full test suite — 508 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)