### PR TITLE
Reload shared policy check file before interval guard

### DIFF
--- a/trading_bot/sentinels.py
+++ b/trading_bot/sentinels.py
@@ -2258,6 +2258,10 @@ class MacroContagionSentinel(Sentinel):
 
     async def check_fed_policy_shock(self) -> Optional[Dict]:
         now = datetime.now(timezone.utc)
+        # Reload from shared file — another commodity instance may have updated it
+        shared_ts = self._load_last_policy_check()
+        if shared_ts and (not self.last_policy_check or shared_ts > self.last_policy_check):
+            self.last_policy_check = shared_ts
         if self.last_policy_check and (now - self.last_policy_check).total_seconds() < self.policy_check_interval:
             return None
 


### PR DESCRIPTION
## Summary
Follow-up to PR #986. The shared persistence file was only read at `__init__` time. Both KC and CC initialized before the file existed, so both had `None` in memory and both called the LLM independently.

Now `check_fed_policy_shock()` re-reads the shared file on every invocation. KC writes it first; CC reads it ~20s later and skips the LLM call.

## Test plan
- [x] 571 tests pass
- [ ] Deploy and confirm only ONE MacroContagionSentinel notification fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)