### PR TITLE
Move holding-time gate before council pipeline in emergency cycles

### DIFF
--- a/tests/test_emergency_improvements.py
+++ b/tests/test_emergency_improvements.py
@@ -108,7 +108,8 @@ async def test_emergency_cycle_runs_when_open():
                  }
 
                  # Mock get_active_futures to return empty so it exits early safely
-                 with patch('orchestrator.get_active_futures', return_value=[]):
+                 with patch('orchestrator.get_active_futures', return_value=[]), \
+                      patch('orchestrator.hours_until_weekly_close', return_value=float('inf')):
                      await run_emergency_cycle(trigger, config, mock_ib)
 
                  # Verify deferred trigger NOT queued


### PR DESCRIPTION
## Summary
- Moves the Friday/pre-holiday holding-time check to **before** the EMERGENCY_LOCK acquisition and council pipeline in `run_emergency_cycle()`
- Previously the gate ran **after** the full council (7 analysts + debate + compliance audit), wasting LLM API calls for decisions that could never result in orders
- Deferred triggers are queued for the next session, same as before

## Context
On Friday 2/20, CC generated 4 afternoon signals (11:52 AM–12:10 PM ET) after the 11:00 AM position close time. These went through the entire council pipeline but were blocked at order execution. With this fix, the cycle short-circuits immediately — no lock, no API calls.

The scheduled path (`order_manager.generate_and_execute_orders`) already had the gate before signal generation — this aligns the emergency path.

## Test plan
- [x] `test_emergency_cycle_runs_when_open` updated to mock `hours_until_weekly_close` (test validates open-market flow, not holding-time gate)
- [x] Full test suite: 571 passed, 0 failed
- [x] Existing `test_holding_time_gate.py` validates the `hours_until_weekly_close()` logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)