### PR TITLE
Multi-commodity dashboard: in-app switching, portfolio home, bug fixes

### DIFF
--- a/_commodity_selector.py
+++ b/_commodity_selector.py
@@ -1,0 +1,67 @@
+"""Shared commodity selector for dashboard pages 1-7.
+
+Renders a sidebar selectbox for commodity switching. On change:
+1. Updates st.session_state['commodity_ticker']
+2. Updates os.environ['COMMODITY_TICKER']
+3. Re-initializes module-level data directories
+4. Clears Streamlit data cache
+5. Triggers st.rerun()
+"""
+
+import streamlit as st
+import os
+
+
+_COMMODITY_LABELS = {
+    "KC": "\u2615 KC (Coffee)",
+    "CC": "\U0001f36b CC (Cocoa)",
+    "SB": "\U0001f36c SB (Sugar)",
+}
+
+
+def _reinit_data_dirs(ticker: str):
+    """Re-point module-level data directories for the selected commodity."""
+    data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', ticker)
+
+    from trading_bot.decision_signals import set_data_dir as set_signals_dir
+    set_signals_dir(data_dir)
+
+    from trading_bot.brier_bridge import set_data_dir as set_brier_bridge_dir
+    set_brier_bridge_dir(data_dir)
+
+
+def selected_commodity() -> str:
+    """Render commodity selector in sidebar and return the active ticker.
+
+    Call this at the top of each page (after st.set_page_config).
+    """
+    # Ensure session state is initialized
+    if 'commodity_ticker' not in st.session_state:
+        st.session_state['commodity_ticker'] = os.environ.get('COMMODITY_TICKER', 'KC')
+
+    current = st.session_state['commodity_ticker']
+
+    # Sync env var from session state (handles cross-page navigation)
+    if os.environ.get('COMMODITY_TICKER') != current:
+        os.environ['COMMODITY_TICKER'] = current
+        _reinit_data_dirs(current)
+
+    # Discover which commodities have data directories
+    from dashboard_utils import discover_active_commodities
+    available = discover_active_commodities()
+
+    selected = st.sidebar.selectbox(
+        "Commodity",
+        available,
+        index=available.index(current) if current in available else 0,
+        format_func=lambda x: _COMMODITY_LABELS.get(x, x),
+    )
+
+    if selected != current:
+        st.session_state['commodity_ticker'] = selected
+        os.environ['COMMODITY_TICKER'] = selected
+        _reinit_data_dirs(selected)
+        st.cache_data.clear()
+        st.rerun()
+
+    return selected

--- a/pages/1_Cockpit.py
+++ b/pages/1_Cockpit.py
@@ -481,6 +481,9 @@ def _relative_time(ts) -> str:
 
 st.set_page_config(layout="wide", page_title="Cockpit | Real Options")
 
+from _commodity_selector import selected_commodity
+ticker = selected_commodity()
+
 st.title("🦅 The Cockpit")
 st.caption("Situational Awareness - System health, capital safety, and emergency controls")
 
@@ -964,7 +967,7 @@ if config:
     st.markdown("---")
     st.subheader("📊 Rolling Win Rate (Last 20 Decisions)")
 
-    council_df = load_council_history()
+    council_df = load_council_history(ticker=ticker)
     if not council_df.empty:
         graded = grade_decision_quality(council_df)
         rolling = calculate_rolling_win_rate(graded, window=20)
@@ -1016,7 +1019,7 @@ if config:
                 st.dataframe(
                     _display_df,
                     hide_index=True,
-                    use_container_width=True,
+                    width="stretch",
                     column_config={
                         'Time': st.column_config.TextColumn(width='small'),
                         'Contract': st.column_config.TextColumn(width='medium'),
@@ -1187,7 +1190,7 @@ with st.expander("Recent Compliance Decisions"):
                             'Strategy': str(row.get('strategy_type', 'N/A')).replace('_', ' ').title(),
                             'Reason': str(row.get('reason', 'N/A'))[:80],
                         })
-                    st.dataframe(pd.DataFrame(_rej_rows), hide_index=True, use_container_width=True)
+                    st.dataframe(pd.DataFrame(_rej_rows), hide_index=True, width="stretch")
                 else:
                     st.info("No compliance rejections recorded")
             else:

--- a/pages/3_The_Council.py
+++ b/pages/3_The_Council.py
@@ -19,11 +19,14 @@ from dashboard_utils import load_council_history, get_status_color
 
 st.set_page_config(layout="wide", page_title="Council | Real Options")
 
+from _commodity_selector import selected_commodity
+ticker = selected_commodity()
+
 st.title("🧠 The Council Chamber")
 st.caption("Agent Explainability - Understand the reasoning behind every trade decision")
 
 # --- Load Data ---
-council_df = load_council_history()
+council_df = load_council_history(ticker=ticker)
 
 if council_df.empty:
     st.warning("No council history data available.")

--- a/pages/4_Financials.py
+++ b/pages/4_Financials.py
@@ -29,13 +29,16 @@ import numpy as np
 
 st.set_page_config(layout="wide", page_title="Financials | Real Options")
 
+from _commodity_selector import selected_commodity
+ticker = selected_commodity()
+
 st.title("📈 Financial Performance")
 st.caption("ROI & Audit - Institutional-grade reporting on actual dollars gained or lost")
 
 # --- Load Data ---
-equity_df = load_equity_data()
-trade_df = load_trade_data()
-council_df = load_council_history()
+equity_df = load_equity_data(ticker=ticker)
+trade_df = load_trade_data(ticker=ticker)
+council_df = load_council_history(ticker=ticker)
 config = get_config()
 
 # E4 FIX: Get starting capital from config/profile
@@ -309,7 +312,7 @@ if not council_df.empty and 'strategy_type' in council_df.columns and 'pnl_reali
                     legend=dict(orientation='h', yanchor='bottom', y=1.02, xanchor='right', x=1),
                     margin=dict(l=0, r=0, t=60, b=0)
                 )
-                st.plotly_chart(fig_roll, use_container_width=True)
+                st.plotly_chart(fig_roll, width='stretch')
 
                 for warning_msg in _declining:
                     st.warning(warning_msg)
@@ -353,7 +356,7 @@ st.caption("Calendar view of monthly performance - standard hedge fund reporting
 
 if not equity_df.empty:
     # Calculate monthly returns
-    equity_df['month'] = equity_df['timestamp'].dt.to_period('M')
+    equity_df['month'] = equity_df['timestamp'].dt.tz_localize(None).dt.to_period('M')
 
     monthly = equity_df.groupby('month').agg({
         'total_value_usd': ['first', 'last']

--- a/pages/5_Utilities.py
+++ b/pages/5_Utilities.py
@@ -24,6 +24,9 @@ config = get_config()
 
 st.set_page_config(layout="wide", page_title="Utilities | Real Options")
 
+from _commodity_selector import selected_commodity
+ticker = selected_commodity()
+
 st.title("🔧 Utilities")
 st.caption("System maintenance and operational tools")
 

--- a/pages/6_Signal_Overlay.py
+++ b/pages/6_Signal_Overlay.py
@@ -33,6 +33,9 @@ from dashboard_utils import get_config
 
 st.set_page_config(layout="wide", page_title="Signal Analysis | Real Options")
 
+from _commodity_selector import selected_commodity
+ticker = selected_commodity()
+
 # E1: Dynamic profile loading
 config = get_config()
 profile = get_active_profile(config)
@@ -400,7 +403,7 @@ with st.sidebar:
     st.header("📜 Contract")
 
     # Load council data early to get available contracts
-    council_df_for_contracts = load_council_history()
+    council_df_for_contracts = load_council_history(ticker=ticker)
     available_contracts = get_available_contracts(council_df_for_contracts)
 
     # Build options list: Front Month + specific contracts
@@ -748,7 +751,7 @@ with st.spinner(f"Loading {get_contract_display_name(selected_contract)} data...
     else:
         actual_ticker_display = get_contract_display_name(selected_contract)
 
-    council_df = load_council_history()
+    council_df = load_council_history(ticker=ticker)
 
 
 # === PLOTTING ===

--- a/pages/7_Brier_Analysis.py
+++ b/pages/7_Brier_Analysis.py
@@ -21,6 +21,10 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from dashboard_utils import _resolve_data_path
 
 st.set_page_config(layout="wide", page_title="Brier Analysis | Real Options")
+
+from _commodity_selector import selected_commodity
+ticker = selected_commodity()
+
 st.title("🎯 Brier Analysis")
 st.caption("Agent prediction quality, calibration curves, and learning feedback")
 
@@ -255,7 +259,7 @@ if enhanced_data and enhanced_data.get('calibration_buckets'):
                     bgcolor='rgba(255,255,255,0.8)',
                 )
 
-                st.plotly_chart(fig, use_container_width=True)
+                st.plotly_chart(fig, width="stretch")
 
                 with st.expander("Calibration Data"):
                     st.dataframe(cal_df, hide_index=True)
@@ -413,7 +417,7 @@ if not weight_df.empty and len(weight_df) >= 5:
         legend=dict(orientation='h', yanchor='bottom', y=1.02, xanchor='left', x=0),
     )
 
-    st.plotly_chart(fig, use_container_width=True)
+    st.plotly_chart(fig, width="stretch")
 
     # --- Agent trajectory summary: current vs 30 cycles ago ---
     summary_rows = []
@@ -459,7 +463,7 @@ if not weight_df.empty and len(weight_df) >= 5:
         return 'color: gray'
 
     styled = summary_df.style.map(_color_delta, subset=['Delta'])
-    st.dataframe(styled, hide_index=True, use_container_width=True)
+    st.dataframe(styled, hide_index=True, width="stretch")
 
 elif not weight_df.empty:
     st.info("Insufficient weight evolution data (need at least 5 rows). Data accumulates as trading cycles run.")
@@ -540,7 +544,7 @@ try:
                     return ''
 
             styled_regime = display_df.style.map(_color_accuracy)
-            st.dataframe(styled_regime, use_container_width=True)
+            st.dataframe(styled_regime, width="stretch")
 
             # Best agent per regime
             best_agents = []
@@ -570,7 +574,7 @@ try:
             ranking[['Agent', 'total', 'correct', 'accuracy']].rename(
                 columns={'total': 'Predictions', 'correct': 'Correct', 'accuracy': 'Accuracy %'}
             ),
-            hide_index=True, use_container_width=True,
+            hide_index=True, width="stretch",
         )
         st.caption("Regime-specific breakdown will appear when decision_signals.csv contains regime data.")
     else:

--- a/tests/test_dashboard_legacy_cache.py
+++ b/tests/test_dashboard_legacy_cache.py
@@ -51,9 +51,9 @@ def test_load_council_history_legacy_integration(tmp_path):
 """
     legacy2_csv.write_text(legacy2_content)
 
-    # Patch COUNCIL_HISTORY_PATH to point to our temp main file
-    # Note: We need to ensure os.path.dirname(COUNCIL_HISTORY_PATH) resolves to data_dir
-    with patch('dashboard_utils.COUNCIL_HISTORY_PATH', str(main_csv)):
+    # Patch _resolve_data_path_for to point to our temp main file
+    # os.path.dirname(council_path) resolves to data_dir for legacy file discovery
+    with patch('dashboard_utils._resolve_data_path_for', return_value=str(main_csv)):
 
         # 1. Test _load_legacy_council_history directly first
         legacy_df = _load_legacy_council_history(str(data_dir))

--- a/tests/test_dashboard_loading.py
+++ b/tests/test_dashboard_loading.py
@@ -44,7 +44,7 @@ def test_load_council_history_mixed_format(mixed_timestamp_csv):
             importlib.reload(sys.modules['dashboard_utils'])
         import dashboard_utils
 
-        with patch.object(dashboard_utils, 'COUNCIL_HISTORY_PATH', mixed_timestamp_csv), \
+        with patch.object(dashboard_utils, '_resolve_data_path_for', return_value=mixed_timestamp_csv), \
              patch.object(dashboard_utils, '_load_legacy_council_history', return_value=pd.DataFrame()):
 
             df = dashboard_utils.load_council_history()

--- a/tests/test_dashboard_state_caching.py
+++ b/tests/test_dashboard_state_caching.py
@@ -103,8 +103,8 @@ def test_shared_state_source_uses_statemanager():
             func_source = ast.get_source_segment(source, node)
             assert 'StateManager._load_raw_sync' in func_source, \
                 "_load_shared_state should call StateManager._load_raw_sync"
-            assert 'STATE_FILE_PATH' in func_source, \
-                "_load_shared_state should have a fallback using STATE_FILE_PATH"
+            assert '_get_state_file_path' in func_source, \
+                "_load_shared_state should have a fallback using _get_state_file_path()"
             return
 
     pytest.fail("_load_shared_state function not found in dashboard_utils.py")


### PR DESCRIPTION
## Summary

- **Architecture fix**: Dashboard commodity selector was broken by design — `dashboard_utils.py` computed paths at module import time, so switching commodities updated `os.environ` but all data reads still pointed to the original directory. Converted 6 frozen constants to dynamic getter functions and added `ticker` parameter to cached data loaders.
- **Portfolio home page**: `dashboard.py` rewritten as cross-commodity view with health status, financial summary (NLV + P&L + VaR), per-commodity cards, and merged activity feed. Commodity selector moved to pages 1-7 via shared `_commodity_selector.py`.
- **3 production bug fixes**: tz-naive/aware crash in Scorecard trade duration, PeriodArray tz warning in Financials heatmap, 15x `use_container_width` deprecation warnings across all pages.
- **Deploy consolidation**: Single dashboard instance on port 8501 instead of one per commodity.

## Test plan

- [x] All 571 tests pass (`pytest tests/ -x -q`)
- [x] All 14 modified files compile (`py_compile`)
- [x] `bash -n deploy.sh` passes
- [x] Zero remaining `use_container_width` occurrences
- [ ] Manual: visit each page, switch commodity KC→CC, verify data changes
- [ ] Manual: verify portfolio home page shows all active commodities

🤖 Generated with [Claude Code](https://claude.com/claude-code)