### PR TITLE
Fix trade journal data quality: thesis context, metadata, schedule labels

### DIFF
--- a/scripts/backfill_trade_journal.py
+++ b/scripts/backfill_trade_journal.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Backfill trade journal entries with metadata from council_history.csv.
+
+One-shot migration script that:
+1. Enriches journal entries with thesis_strength, primary_catalyst, dissent_acknowledged
+   from council_history.csv (matched by position_id = cycle_id)
+2. Infers schedule_id from entry timestamp for scheduled triggers
+3. Optionally re-runs LLM narratives for entries flagged as truncation-affected
+
+Usage:
+    python scripts/backfill_trade_journal.py --data-dir data/KC
+    python scripts/backfill_trade_journal.py --data-dir data/KC --dry-run
+    python scripts/backfill_trade_journal.py --data-dir data/KC --regen-narratives
+"""
+
+import argparse
+import csv
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime
+
+# Add project root to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def load_council_history(data_dir: str) -> dict:
+    """Load council_history.csv and index by cycle_id."""
+    csv_path = os.path.join(data_dir, "council_history.csv")
+    if not os.path.exists(csv_path):
+        print(f"  WARNING: {csv_path} not found")
+        return {}
+
+    indexed = {}
+    with open(csv_path, 'r', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            cycle_id = row.get('cycle_id', '').strip()
+            if cycle_id:
+                indexed[cycle_id] = row
+    print(f"  Loaded {len(indexed)} council_history rows (indexed by cycle_id)")
+    return indexed
+
+
+def infer_schedule_id(timestamp_str: str) -> str:
+    """Infer schedule_id from entry timestamp (ET-based schedule windows).
+
+    Schedule windows (from orchestrator default schedule):
+      08:30-10:30 ET → signal_early
+      10:30-12:00 ET → signal_euro
+      12:00-14:00 ET → signal_us_open
+      14:00-16:00 ET → signal_peak
+      16:00-18:00 ET → signal_settlement
+    """
+    try:
+        # Parse ISO timestamp (UTC)
+        if timestamp_str.endswith('Z'):
+            timestamp_str = timestamp_str[:-1] + '+00:00'
+        dt = datetime.fromisoformat(timestamp_str)
+
+        # Convert to ET (UTC-5 / UTC-4 depending on DST)
+        # Simple heuristic: March-November is EDT (UTC-4), else EST (UTC-5)
+        month = dt.month
+        offset_hours = 4 if 3 <= month <= 11 else 5
+        et_hour = dt.hour - offset_hours
+        if et_hour < 0:
+            et_hour += 24
+
+        if 8 <= et_hour < 10 or (et_hour == 10 and dt.minute < 30):
+            return "signal_early"
+        elif (et_hour == 10 and dt.minute >= 30) or et_hour == 11:
+            return "signal_euro"
+        elif 12 <= et_hour < 14:
+            return "signal_us_open"
+        elif 14 <= et_hour < 16:
+            return "signal_peak"
+        elif 16 <= et_hour < 18:
+            return "signal_settlement"
+        else:
+            return ""
+    except Exception:
+        return ""
+
+
+def backfill_metadata(entries: list, council_index: dict) -> dict:
+    """Backfill thesis_strength, primary_catalyst, dissent_acknowledged, schedule_id."""
+    stats = {'matched': 0, 'unmatched': 0, 'schedule_inferred': 0}
+
+    for entry in entries:
+        position_id = entry.get('position_id', '')
+        row = council_index.get(position_id)
+
+        if row:
+            stats['matched'] += 1
+            # Backfill from CSV if not already present
+            if not entry.get('thesis_strength'):
+                entry['thesis_strength'] = row.get('thesis_strength', '')
+            if not entry.get('primary_catalyst'):
+                entry['primary_catalyst'] = row.get('primary_catalyst', '')
+            if not entry.get('dissent_acknowledged'):
+                entry['dissent_acknowledged'] = row.get('dissent_acknowledged', '')
+            if not entry.get('schedule_id') and row.get('schedule_id'):
+                entry['schedule_id'] = row.get('schedule_id', '')
+        else:
+            stats['unmatched'] += 1
+
+        # Infer schedule_id from timestamp for scheduled triggers
+        trigger = entry.get('trigger_type', '').lower()
+        if not entry.get('schedule_id') and 'scheduled' in trigger:
+            inferred = infer_schedule_id(entry.get('timestamp', ''))
+            if inferred:
+                entry['schedule_id'] = inferred
+                stats['schedule_inferred'] += 1
+
+    return stats
+
+
+def find_truncation_affected(entries: list) -> list:
+    """Find entries whose narratives mention truncation/incomplete thesis."""
+    affected = []
+    for i, entry in enumerate(entries):
+        narrative = entry.get('narrative', {})
+        if isinstance(narrative, dict):
+            wrong = narrative.get('what_went_wrong', [])
+            text = json.dumps(wrong).lower() if wrong else ''
+        elif isinstance(narrative, str):
+            text = narrative.lower()
+        else:
+            continue
+
+        if 'truncat' in text or 'incomplete' in text:
+            affected.append(i)
+    return affected
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Backfill trade journal metadata')
+    parser.add_argument('--data-dir', required=True, help='Path to data directory (e.g., data/KC)')
+    parser.add_argument('--dry-run', action='store_true', help='Preview changes without writing')
+    parser.add_argument('--regen-narratives', action='store_true',
+                        help='Re-run LLM narratives for truncation-affected entries (requires API keys)')
+    args = parser.parse_args()
+
+    journal_path = os.path.join(args.data_dir, "trade_journal.json")
+    if not os.path.exists(journal_path):
+        print(f"ERROR: {journal_path} not found")
+        sys.exit(1)
+
+    # Load journal
+    with open(journal_path, 'r') as f:
+        entries = json.load(f)
+    print(f"Loaded {len(entries)} journal entries from {journal_path}")
+
+    # Load council history
+    council_index = load_council_history(args.data_dir)
+
+    # Step 1: Backfill metadata
+    print("\n--- Step 1: Backfill metadata ---")
+    stats = backfill_metadata(entries, council_index)
+    print(f"  Matched: {stats['matched']}, Unmatched: {stats['unmatched']}")
+    print(f"  Schedule IDs inferred from timestamp: {stats['schedule_inferred']}")
+
+    # Step 2: Identify truncation-affected entries
+    affected_indices = find_truncation_affected(entries)
+    print(f"\n--- Step 2: Truncation-affected entries ---")
+    print(f"  Found {len(affected_indices)} entries with truncation/incomplete flags")
+
+    if args.regen_narratives and affected_indices:
+        print("  Re-generating LLM narratives (requires running environment)...")
+        try:
+            import asyncio
+            from dotenv import load_dotenv
+            load_dotenv()
+            from config_loader import load_config
+            from trading_bot.heterogeneous_router import HeterogeneousRouter
+
+            config = load_config()
+            config['data_dir'] = args.data_dir
+            router = HeterogeneousRouter(config)
+
+            from trading_bot.trade_journal import TradeJournal
+            journal = TradeJournal(config, router=router)
+
+            regen_count = 0
+            for idx in affected_indices:
+                entry = entries[idx]
+                try:
+                    narrative = asyncio.run(journal._generate_llm_narrative(entry, {}))
+                    entry['narrative'] = narrative
+                    entry['key_lesson'] = narrative.get('lesson', 'No lesson extracted')
+                    regen_count += 1
+                    print(f"    Regenerated narrative for {entry.get('position_id', idx)}")
+                    import time
+                    time.sleep(1)  # Rate limiting
+                except Exception as e:
+                    print(f"    FAILED for {entry.get('position_id', idx)}: {e}")
+
+            print(f"  Regenerated {regen_count}/{len(affected_indices)} narratives")
+        except ImportError as e:
+            print(f"  SKIPPED narrative regen (missing dependency: {e})")
+            print("  Run with full environment to regenerate narratives.")
+    elif affected_indices:
+        print("  Use --regen-narratives to re-run LLM narratives for these entries")
+
+    # Step 3: Save
+    if args.dry_run:
+        print(f"\n--- DRY RUN: Would update {journal_path} ---")
+        # Show a sample entry
+        if entries:
+            sample = entries[0]
+            print(f"  Sample entry fields: {list(sample.keys())}")
+            print(f"  thesis_strength: {sample.get('thesis_strength', '(empty)')}")
+            print(f"  primary_catalyst: {sample.get('primary_catalyst', '(empty)')}")
+            print(f"  schedule_id: {sample.get('schedule_id', '(empty)')}")
+    else:
+        print(f"\n--- Step 3: Saving to {journal_path} ---")
+        # Atomic write
+        dir_name = os.path.dirname(journal_path) or '.'
+        fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix='.json')
+        try:
+            with os.fdopen(fd, 'w') as f:
+                json.dump(entries, f, indent=2, default=str)
+            os.replace(tmp_path, journal_path)
+            print(f"  Saved {len(entries)} entries")
+        except Exception:
+            os.unlink(tmp_path)
+            raise
+
+    print("\nDone.")
+
+
+if __name__ == '__main__':
+    main()

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -256,7 +256,7 @@ def _describe_bag(contract) -> str:
     return ticker
 
 
-async def generate_and_execute_orders(config: dict, connection_purpose: str = "orchestrator_orders", shutdown_check=None, trigger_type=None):
+async def generate_and_execute_orders(config: dict, connection_purpose: str = "orchestrator_orders", shutdown_check=None, trigger_type=None, schedule_id: str = None):
     """
     Generates, queues, and immediately places orders.
     This ensures that order placement isn't skipped if generation takes
@@ -294,7 +294,7 @@ async def generate_and_execute_orders(config: dict, connection_purpose: str = "o
         return
 
     logger.info(">>> Starting combined task: Generate and Execute Orders <<<")
-    await generate_and_queue_orders(config, connection_purpose=connection_purpose, shutdown_check=shutdown_check, trigger_type=trigger_type)
+    await generate_and_queue_orders(config, connection_purpose=connection_purpose, shutdown_check=shutdown_check, trigger_type=trigger_type, schedule_id=schedule_id)
 
     # Only proceed to placement if orders were actually queued
     if not ORDER_QUEUE.is_empty():
@@ -304,7 +304,7 @@ async def generate_and_execute_orders(config: dict, connection_purpose: str = "o
     logger.info(">>> Combined task 'Generate and Execute Orders' complete <<<")
 
 
-async def generate_and_queue_orders(config: dict, connection_purpose: str = "orchestrator_orders", shutdown_check=None, trigger_type=None):
+async def generate_and_queue_orders(config: dict, connection_purpose: str = "orchestrator_orders", shutdown_check=None, trigger_type=None, schedule_id: str = None):
     """
     Generates trading strategies based on market data and API predictions,
     and queues them for later execution.
@@ -321,7 +321,7 @@ async def generate_and_queue_orders(config: dict, connection_purpose: str = "orc
             logger.info(f"Connected to IB for signal generation (purpose: {connection_purpose}).")
 
             logger.info("Step 1: Generating structured signals via Council...")
-            signals = await generate_signals(ib, config, shutdown_check=shutdown_check, trigger_type=trigger_type)
+            signals = await generate_signals(ib, config, shutdown_check=shutdown_check, trigger_type=trigger_type, schedule_id=schedule_id)
             logger.info(f"Generated {len(signals)} signals: {signals}")
 
             futures = await get_active_futures(ib, config['symbol'], config['exchange'], count=5)

--- a/trading_bot/reconciliation.py
+++ b/trading_bot/reconciliation.py
@@ -539,6 +539,10 @@ async def _process_reconciliation(ib: IB, df: pd.DataFrame, config: dict, file_p
                     'confidence': float(row.get('master_confidence', 0.0) or 0.0),
                     'strategy_type': row.get('strategy_type', ''),
                     'trigger_type': row.get('trigger_type', ''),
+                    'schedule_id': row.get('schedule_id', ''),
+                    'thesis_strength': row.get('thesis_strength', ''),
+                    'primary_catalyst': row.get('primary_catalyst', ''),
+                    'dissent_acknowledged': row.get('dissent_acknowledged', ''),
                 }
 
                 # Construct exit data

--- a/trading_bot/signal_generator.py
+++ b/trading_bot/signal_generator.py
@@ -32,7 +32,7 @@ from trading_bot.strategy_router import (
 
 logger = logging.getLogger(__name__)
 
-async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_type=None) -> list:
+async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_type=None, schedule_id: str = None) -> list:
     """
     Generates trading signals via the Council's multi-agent analysis.
 
@@ -104,7 +104,7 @@ async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_ty
     sem = asyncio.Semaphore(3)
 
     # 4. Define the async processor for a single contract
-    async def process_contract(contract, market_ctx, trigger_type=trigger_type):
+    async def process_contract(contract, market_ctx, trigger_type=trigger_type, schedule_id=schedule_id):
         contract_name = f"{contract.localSymbol} ({contract.lastTradeDateOrContractMonth[:6]})"
 
         # Skip contracts with no live price — avoids wasting LLM spend on NaN data
@@ -727,6 +727,7 @@ async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_ty
                         "dominant_agent": weighted_result.get('dominant_agent', 'Unknown'),
                         "weighted_score": weighted_result.get('weighted_score', 0.0),
                         "trigger_type": weighted_result.get('trigger_type', 'scheduled'),
+                        "schedule_id": schedule_id or '',
 
                         # [E.1] VaR observability
                         "var_utilization": round(var_utilization, 3) if var_utilization else None,

--- a/trading_bot/trade_journal.py
+++ b/trading_bot/trade_journal.py
@@ -61,6 +61,10 @@ class TradeJournal:
                 "entry_confidence": entry_decision.get('confidence', 0.0),
                 "entry_strategy": entry_decision.get('strategy_type', 'Unknown'),
                 "trigger_type": entry_decision.get('trigger_type', 'Unknown'),
+                "schedule_id": entry_decision.get('schedule_id', ''),
+                "thesis_strength": entry_decision.get('thesis_strength', ''),
+                "primary_catalyst": entry_decision.get('primary_catalyst', ''),
+                "dissent_acknowledged": entry_decision.get('dissent_acknowledged', ''),
             }
 
             # Generate narrative (LLM if available, template if not)
@@ -118,6 +122,10 @@ class TradeJournal:
         """Use LLM to generate structured narrative."""
         from trading_bot.heterogeneous_router import AgentRole
 
+        trigger_display = entry['trigger_type']
+        if entry.get('schedule_id'):
+            trigger_display += f" ({entry['schedule_id']})"
+
         prompt = f"""Analyze this closed trade and generate a structured post-mortem.
 
 TRADE DETAILS:
@@ -125,9 +133,12 @@ TRADE DETAILS:
 - Direction: {entry['entry_direction']}
 - Strategy: {entry['entry_strategy']}
 - Entry Confidence: {entry['entry_confidence']}
-- Trigger: {entry['trigger_type']}
+- Thesis Strength: {entry.get('thesis_strength') or 'Unknown'}
+- Primary Catalyst: {entry.get('primary_catalyst') or 'Unknown'}
+- Trigger: {trigger_display}
+- Dissent Acknowledged: {entry.get('dissent_acknowledged') or 'N/A'}
 - P&L: ${entry['pnl']:.2f} ({'WIN' if entry['pnl'] > 0 else 'LOSS'})
-- Original Thesis: {entry['entry_thesis'][:500]}
+- Original Thesis: {entry['entry_thesis'][:2000]}
 
 Generate a JSON object with:
 1. "summary": One-sentence summary of what happened
@@ -160,7 +171,7 @@ Generate a JSON object with:
             f"({entry['entry_strategy']}) with confidence {entry['entry_confidence']:.2f}. "
             f"Triggered by {entry['trigger_type']}. "
             f"Trade {outcome} with P&L ${entry['pnl']:.2f}. "
-            f"Original thesis: {entry['entry_thesis'][:200]}"
+            f"Original thesis: {entry['entry_thesis'][:500]}"
         )
 
     def get_recent_entries(self, n: int = 10) -> list:

--- a/trading_bot/utils.py
+++ b/trading_bot/utils.py
@@ -664,6 +664,7 @@ def log_council_decision(decision_data):
         "dominant_agent",     # Agent with highest contribution
         "weighted_score",     # Final weighted score (-1 to 1)
         "trigger_type",       # What triggered the decision (scheduled, weather, news, etc.)
+        "schedule_id",        # Schedule task ID (signal_early, signal_euro, etc.)
         # NEW COLUMNS (v3 — Judge & Jury Protocol)
         "thesis_strength",        # SPECULATIVE / PLAUSIBLE / PROVEN
         "primary_catalyst",       # Single most important driver


### PR DESCRIPTION
## Summary

- **Thesis truncation fix**: LLM prompt now sees up to 2000 chars of entry thesis (was 500), template fallback increased to 500 (was 200). Addresses 52% of entries flagging "truncated/incomplete" thesis
- **Metadata flow**: `thesis_strength`, `primary_catalyst`, `dissent_acknowledged` now flow from council_history.csv through reconciliation into trade journal entries and the LLM post-mortem prompt
- **Schedule context**: `schedule_id` (e.g., `signal_early`, `signal_euro`) threaded from scheduler dispatch through the full chain (orchestrator → order_manager → signal_generator → council_history CSV → reconciliation → trade journal). Scheduled triggers now show "scheduled (signal_early)" instead of just "scheduled"

## Files changed

| File | Change |
|------|--------|
| `trading_bot/trade_journal.py` | Increased truncation limits, added 4 new fields to entry dict, enriched LLM prompt |
| `trading_bot/reconciliation.py` | Extract thesis_strength, primary_catalyst, dissent_acknowledged, schedule_id from CSV |
| `orchestrator.py` | `schedule_id` param on `guarded_generate_orders`, scheduler dispatch passes `next_task.id` |
| `trading_bot/order_manager.py` | Thread `schedule_id` through `generate_and_execute_orders` → `generate_and_queue_orders` |
| `trading_bot/signal_generator.py` | Thread `schedule_id` through `generate_signals` → council history logging |
| `trading_bot/utils.py` | Add `schedule_id` column to council_history.csv schema |
| `scripts/backfill_trade_journal.py` | New: backfill existing entries from council_history, infer schedule_id from timestamps |

## Test plan

- [x] All 571 tests pass, 0 regressions
- [x] All modified files compile cleanly
- [ ] After deploy, verify new journal entries have `thesis_strength`, `primary_catalyst`, `schedule_id` populated
- [ ] Verify LLM narratives no longer flag "thesis truncated/incomplete"
- [ ] Run `python scripts/backfill_trade_journal.py --data-dir data/KC --dry-run` to preview backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)