### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix parameter injection in PredictionMarketSentinel

### DIFF
--- a/trading_bot/sentinels.py
+++ b/trading_bot/sentinels.py
@@ -1843,10 +1843,15 @@ class PredictionMarketSentinel(Sentinel):
 
         Returns candidate dict or None if slug is invalid/closed/low-liquidity.
         """
-        url = f"{self.api_url}?slug={slug}&closed=false&active=true&limit=1"
+        params = {
+            "slug": slug,
+            "closed": "false",
+            "active": "true",
+            "limit": "1"
+        }
         try:
             session = await self._get_session()
-            async with session.get(url, timeout=aiohttp.ClientTimeout(total=15)) as response:
+            async with session.get(self.api_url, params=params, timeout=aiohttp.ClientTimeout(total=15)) as response:
                 if response.status != 200:
                     return None
                 data = await response.json()


### PR DESCRIPTION
**Vulnerability:** The `slug` parameter in `PredictionMarketSentinel._fetch_by_slug` was being interpolated directly into the URL string. This could allow a malicious slug (e.g., containing `&` or `=`) to alter the query parameters sent to the Polymarket API.

**Fix:** Changed the implementation to pass `slug` and other query parameters via the `params` argument of `session.get()`. `aiohttp` handles the encoding automatically.

**Verification:**
1. Created a reproduction script `tests/repro_slug_injection.py` which confirmed the vulnerability by mocking `session.get` and checking the URL.
2. Applied the fix.
3. Verified the fix using the same reproduction script (it now passes).
4. Ran existing tests `tests/test_prediction_market_sentinel.py` to ensure no regressions.

---
*PR created automatically by Jules for task [17603892600198465605](https://jules.google.com/task/17603892600198465605) started by @rozavala*