### PR TITLE
Add prompt traceability system for LLM call provenance

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -4799,6 +4799,7 @@ async def main(commodity_ticker: str = None):
     from trading_bot.brier_reconciliation import set_data_dir as set_brier_recon_dir
     from trading_bot.router_metrics import set_data_dir as set_router_metrics_dir
     from trading_bot.agents import set_data_dir as set_agents_dir
+    from trading_bot.prompt_trace import set_data_dir as set_prompt_trace_dir
 
     StateManager.set_data_dir(data_dir)
     set_tracker_dir(data_dir)
@@ -4813,6 +4814,7 @@ async def main(commodity_ticker: str = None):
     set_brier_recon_dir(data_dir)
     set_router_metrics_dir(data_dir)
     set_agents_dir(data_dir)
+    set_prompt_trace_dir(data_dir)
 
     # E.1: Portfolio VaR — shared data dir (NOT per-commodity)
     from trading_bot.var_calculator import set_var_data_dir

--- a/tests/test_prompt_trace.py
+++ b/tests/test_prompt_trace.py
@@ -1,0 +1,261 @@
+"""Tests for trading_bot/prompt_trace.py"""
+
+import csv
+import pytest
+import pandas as pd
+from unittest.mock import patch
+
+from trading_bot.prompt_trace import (
+    hash_persona,
+    PromptTraceRecord,
+    PromptTraceCollector,
+    get_prompt_trace_df,
+    set_data_dir,
+    SCHEMA_COLUMNS,
+)
+
+
+class TestHashPersona:
+    def test_deterministic(self):
+        """Same input always produces same hash."""
+        assert hash_persona("test") == hash_persona("test")
+
+    def test_length(self):
+        """Hash is always 12 characters."""
+        assert len(hash_persona("")) == 12
+        assert len(hash_persona("x" * 10000)) == 12
+
+    def test_empty_input(self):
+        """Empty string produces a valid hex hash."""
+        result = hash_persona("")
+        assert len(result) == 12
+        assert all(c in '0123456789abcdef' for c in result)
+
+    def test_different_inputs(self):
+        """Different inputs produce different hashes."""
+        assert hash_persona("persona A") != hash_persona("persona B")
+
+
+class TestPromptTraceRecord:
+    def test_defaults(self):
+        """All fields have sensible defaults."""
+        rec = PromptTraceRecord()
+        assert rec.phase == ""
+        assert rec.prompt_source == "legacy"
+        assert rec.demo_count == 0
+        assert rec.reflexion_applied is False
+        assert rec.latency_ms == 0.0
+
+    def test_custom_values(self):
+        rec = PromptTraceRecord(
+            phase="research",
+            agent="agronomist",
+            prompt_source="dspy_optimized",
+            demo_count=3,
+        )
+        assert rec.phase == "research"
+        assert rec.agent == "agronomist"
+        assert rec.demo_count == 3
+
+
+class TestPromptTraceCollector:
+    def test_record_and_flush(self, tmp_path):
+        """Records are written to CSV on flush."""
+        csv_path = tmp_path / "prompt_trace.csv"
+        with patch('trading_bot.prompt_trace.PROMPT_TRACE_PATH', str(csv_path)):
+            collector = PromptTraceCollector(cycle_id="KC-abc123", commodity="KC", contract="KCN6")
+            collector.record(PromptTraceRecord(phase="research", agent="agronomist"))
+            count = collector.flush()
+
+        assert count == 1
+        assert csv_path.exists()
+        df = pd.read_csv(csv_path)
+        assert len(df) == 1
+        assert df.iloc[0]['phase'] == 'research'
+        assert df.iloc[0]['agent'] == 'agronomist'
+        assert df.iloc[0]['cycle_id'] == 'KC-abc123'
+        assert df.iloc[0]['commodity'] == 'KC'
+
+    def test_cycle_field_injection(self, tmp_path):
+        """Collector injects cycle_id, commodity, contract if not set on record."""
+        csv_path = tmp_path / "prompt_trace.csv"
+        with patch('trading_bot.prompt_trace.PROMPT_TRACE_PATH', str(csv_path)):
+            collector = PromptTraceCollector(cycle_id="KC-xyz789", commodity="KC", contract="KCH6")
+            rec = PromptTraceRecord(phase="debate", agent="permabear")
+            collector.record(rec)
+            collector.flush()
+
+        df = pd.read_csv(csv_path)
+        assert df.iloc[0]['cycle_id'] == 'KC-xyz789'
+        assert df.iloc[0]['commodity'] == 'KC'
+        assert df.iloc[0]['contract'] == 'KCH6'
+
+    def test_empty_flush(self, tmp_path):
+        """Flushing with no records returns 0 and doesn't create file."""
+        csv_path = tmp_path / "prompt_trace.csv"
+        with patch('trading_bot.prompt_trace.PROMPT_TRACE_PATH', str(csv_path)):
+            collector = PromptTraceCollector()
+            count = collector.flush()
+
+        assert count == 0
+        assert not csv_path.exists()
+
+    def test_multi_phase(self, tmp_path):
+        """Multiple records from different phases are all written."""
+        csv_path = tmp_path / "prompt_trace.csv"
+        with patch('trading_bot.prompt_trace.PROMPT_TRACE_PATH', str(csv_path)):
+            collector = PromptTraceCollector(cycle_id="KC-multi", commodity="KC")
+            collector.record(PromptTraceRecord(phase="research", agent="agronomist"))
+            collector.record(PromptTraceRecord(phase="debate", agent="permabear"))
+            collector.record(PromptTraceRecord(phase="decision", agent="master"))
+            count = collector.flush()
+
+        assert count == 3
+        df = pd.read_csv(csv_path)
+        assert list(df['phase']) == ['research', 'debate', 'decision']
+
+    def test_schema_columns(self, tmp_path):
+        """CSV has all 20 schema columns."""
+        csv_path = tmp_path / "prompt_trace.csv"
+        with patch('trading_bot.prompt_trace.PROMPT_TRACE_PATH', str(csv_path)):
+            collector = PromptTraceCollector(cycle_id="KC-schema")
+            collector.record(PromptTraceRecord(phase="research", agent="test"))
+            collector.flush()
+
+        df = pd.read_csv(csv_path)
+        assert len(SCHEMA_COLUMNS) == 20
+        for col in SCHEMA_COLUMNS:
+            assert col in df.columns, f"Missing column: {col}"
+
+    def test_nan_defaults(self, tmp_path):
+        """Numeric fields default to 0, not NaN."""
+        csv_path = tmp_path / "prompt_trace.csv"
+        with patch('trading_bot.prompt_trace.PROMPT_TRACE_PATH', str(csv_path)):
+            collector = PromptTraceCollector()
+            collector.record(PromptTraceRecord(phase="test"))
+            collector.flush()
+
+        df = pd.read_csv(csv_path)
+        assert df.iloc[0]['demo_count'] == 0
+        assert df.iloc[0]['prompt_tokens'] == 0
+        assert df.iloc[0]['latency_ms'] == 0.0
+
+    def test_concurrent_collectors(self, tmp_path):
+        """Two collectors writing to the same file don't corrupt it."""
+        csv_path = tmp_path / "prompt_trace.csv"
+        with patch('trading_bot.prompt_trace.PROMPT_TRACE_PATH', str(csv_path)):
+            c1 = PromptTraceCollector(cycle_id="KC-c1", commodity="KC")
+            c2 = PromptTraceCollector(cycle_id="KC-c2", commodity="KC")
+            c1.record(PromptTraceRecord(phase="research", agent="agronomist"))
+            c2.record(PromptTraceRecord(phase="debate", agent="permabear"))
+            c1.flush()
+            c2.flush()
+
+        df = pd.read_csv(csv_path)
+        assert len(df) == 2
+        assert set(df['cycle_id']) == {'KC-c1', 'KC-c2'}
+
+    def test_append_mode(self, tmp_path):
+        """Subsequent flushes append to existing file."""
+        csv_path = tmp_path / "prompt_trace.csv"
+        with patch('trading_bot.prompt_trace.PROMPT_TRACE_PATH', str(csv_path)):
+            c1 = PromptTraceCollector(cycle_id="KC-first")
+            c1.record(PromptTraceRecord(phase="research"))
+            c1.flush()
+
+            c2 = PromptTraceCollector(cycle_id="KC-second")
+            c2.record(PromptTraceRecord(phase="debate"))
+            c2.flush()
+
+        df = pd.read_csv(csv_path)
+        assert len(df) == 2
+
+    def test_flush_clears_buffer(self, tmp_path):
+        """After flush, buffer is empty."""
+        csv_path = tmp_path / "prompt_trace.csv"
+        with patch('trading_bot.prompt_trace.PROMPT_TRACE_PATH', str(csv_path)):
+            collector = PromptTraceCollector()
+            collector.record(PromptTraceRecord(phase="research"))
+            assert collector.flush() == 1
+            assert collector.flush() == 0  # Second flush has nothing
+
+    def test_record_preserves_explicit_fields(self, tmp_path):
+        """Fields explicitly set on the record are not overwritten by collector defaults."""
+        csv_path = tmp_path / "prompt_trace.csv"
+        with patch('trading_bot.prompt_trace.PROMPT_TRACE_PATH', str(csv_path)):
+            collector = PromptTraceCollector(cycle_id="KC-default", commodity="KC")
+            rec = PromptTraceRecord(phase="research", cycle_id="KC-explicit", commodity="CC")
+            collector.record(rec)
+            collector.flush()
+
+        df = pd.read_csv(csv_path)
+        assert df.iloc[0]['cycle_id'] == 'KC-explicit'
+        assert df.iloc[0]['commodity'] == 'CC'
+
+
+class TestGetPromptTraceDf:
+    def test_missing_file(self, tmp_path):
+        """Returns empty DataFrame when file doesn't exist."""
+        with patch('trading_bot.prompt_trace.PROMPT_TRACE_PATH', str(tmp_path / "nope.csv")):
+            df = get_prompt_trace_df()
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 0
+        assert list(df.columns) == SCHEMA_COLUMNS
+
+    def test_commodity_filter(self, tmp_path):
+        """Filters by commodity when specified."""
+        csv_path = tmp_path / "prompt_trace.csv"
+        with patch('trading_bot.prompt_trace.PROMPT_TRACE_PATH', str(csv_path)):
+            collector = PromptTraceCollector()
+            collector.record(PromptTraceRecord(phase="research", commodity="KC"))
+            collector.record(PromptTraceRecord(phase="research", commodity="CC"))
+            collector.flush()
+
+            df = get_prompt_trace_df(commodity="KC")
+
+        assert len(df) == 1
+        assert df.iloc[0]['commodity'] == 'KC'
+
+    def test_forward_compat(self, tmp_path):
+        """Old schema files (missing columns) get defaults added."""
+        csv_path = tmp_path / "prompt_trace.csv"
+        # Write a CSV with only a few columns
+        with open(csv_path, 'w', newline='') as f:
+            writer = csv.DictWriter(f, fieldnames=['timestamp', 'cycle_id', 'phase'])
+            writer.writeheader()
+            writer.writerow({'timestamp': '2026-02-22T00:00:00Z', 'cycle_id': 'KC-old', 'phase': 'research'})
+
+        with patch('trading_bot.prompt_trace.PROMPT_TRACE_PATH', str(csv_path)):
+            df = get_prompt_trace_df()
+
+        assert 'model_provider' in df.columns
+        assert 'latency_ms' in df.columns
+        assert len(df) == 1
+
+    def test_set_data_dir(self, tmp_path):
+        """set_data_dir updates the file path."""
+        import trading_bot.prompt_trace as pt
+        original = pt.PROMPT_TRACE_PATH
+        try:
+            set_data_dir(str(tmp_path))
+            assert pt.PROMPT_TRACE_PATH == str(tmp_path / "prompt_trace.csv")
+        finally:
+            pt.PROMPT_TRACE_PATH = original
+
+
+class TestDashboardNaN:
+    def test_numeric_fields_not_nan(self, tmp_path):
+        """Numeric fields should not be NaN when loaded for dashboard display."""
+        csv_path = tmp_path / "prompt_trace.csv"
+        with patch('trading_bot.prompt_trace.PROMPT_TRACE_PATH', str(csv_path)):
+            collector = PromptTraceCollector()
+            collector.record(PromptTraceRecord(phase="research"))
+            collector.flush()
+
+            df = get_prompt_trace_df()
+
+        numeric_cols = ['demo_count', 'tms_context_count', 'grounded_freshness_hours',
+                        'prompt_tokens', 'completion_tokens', 'latency_ms']
+        for col in numeric_cols:
+            assert not df[col].isna().any(), f"{col} has NaN values"

--- a/tests/test_signal_flow.py
+++ b/tests/test_signal_flow.py
@@ -50,7 +50,7 @@ async def test_neutral_direction_triggers_volatility_signal_low():
         # Setup Council Mock
         council_instance = council_cls_mock.return_value
 
-        async def research_side_effect(agent, instruction):
+        async def research_side_effect(agent, instruction, **kwargs):
             if agent == 'volatility':
                 return {'data': '[SENTIMENT: BEARISH] Vol is expensive', 'confidence': 0.8, 'sentiment': 'BEARISH'}
             return {'data': 'Neutral report', 'confidence': 0.5, 'sentiment': 'NEUTRAL'}
@@ -122,7 +122,7 @@ async def test_neutral_direction_triggers_volatility_signal_high():
 
         council_instance = council_cls_mock.return_value
 
-        async def research_side_effect(agent, instruction):
+        async def research_side_effect(agent, instruction, **kwargs):
             if agent == 'agronomist': return "[SENTIMENT: BULLISH] Rain delay."
             if agent == 'macro': return "[SENTIMENT: BEARISH] BRL tanking."
             if agent == 'technical': return "[SENTIMENT: BULLISH] Support held."

--- a/trading_bot/compliance.py
+++ b/trading_bot/compliance.py
@@ -700,7 +700,7 @@ class ComplianceGuardian:
             logger.error(f"Compliance review failed: {e}")
             return False, f"Compliance Error: {e}"
 
-    async def audit_decision(self, reports: dict, market_context: str, decision: dict, master_persona: str, ib=None, debate_summary: str = "") -> dict:
+    async def audit_decision(self, reports: dict, market_context: str, decision: dict, master_persona: str, ib=None, debate_summary: str = "", route_info: dict = None) -> dict:
         """
         Audits the Master Strategist's decision.
         """
@@ -784,7 +784,8 @@ class ComplianceGuardian:
             response = await self.router.route(
                 AgentRole.COMPLIANCE_OFFICER,
                 prompt,
-                response_json=True
+                response_json=True,
+                route_info=route_info
             )
 
             if not response or not response.strip():

--- a/trading_bot/prompt_trace.py
+++ b/trading_bot/prompt_trace.py
@@ -1,0 +1,207 @@
+"""Prompt Trace Logger — Records prompt stack and model routing per LLM call.
+
+WHY THIS EXISTS:
+The trading council assembles prompts from 5+ layers across 8 agents per cycle,
+routed to 4 LLM providers with fallback logic. No record exists of which prompt
+stack was used, which model actually handled requests after fallbacks, or whether
+DSPy-optimized prompts were active. This blocks DSPy A/B testing, anomaly
+debugging, and model performance attribution.
+
+SCHEMA (20 columns):
+    timestamp              — UTC ISO8601
+    cycle_id               — FK to council_history
+    commodity              — Ticker (KC, CC)
+    contract               — Contract month (KCN6)
+    phase                  — research/debate/decision/compliance/devils_advocate
+    agent                  — Canonical agent name
+    prompt_source          — legacy/commodity_profile/dspy_optimized
+    model_provider         — Actual provider used (after fallbacks)
+    model_name             — Actual model ID used
+    assigned_provider      — Intended provider from assignments
+    assigned_model         — Intended model from assignments
+    persona_hash           — SHA256[:12] of persona text
+    dspy_version           — ISO8601 mtime of DSPy file, empty if N/A
+    demo_count             — Few-shot examples injected
+    tms_context_count      — TMS documents retrieved
+    grounded_freshness_hours — Hours since grounded data gathered
+    reflexion_applied      — Whether reflexion block was injected
+    prompt_tokens          — Input tokens (0 if direct Gemini fallback)
+    completion_tokens      — Output tokens (0 if direct Gemini fallback)
+    latency_ms             — Wall-clock time of the LLM call
+
+USAGE:
+    from trading_bot.prompt_trace import PromptTraceCollector, PromptTraceRecord
+
+    collector = PromptTraceCollector(cycle_id="KC-a1b2c3d4", commodity="KC", contract="KCN6")
+    collector.record(PromptTraceRecord(phase="research", agent="agronomist", ...))
+    collector.flush()  # Writes to prompt_trace.csv
+
+    # For dashboard / reports:
+    from trading_bot.prompt_trace import get_prompt_trace_df
+    df = get_prompt_trace_df(commodity="KC")
+"""
+
+import os
+import csv
+import hashlib
+import logging
+import threading
+from dataclasses import dataclass, asdict
+from typing import Optional, List
+
+import pandas as pd
+from trading_bot.timestamps import format_ts, parse_ts_column
+
+logger = logging.getLogger(__name__)
+
+# File lives alongside other CSV data files
+_BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PROMPT_TRACE_PATH = os.path.join(_BASE_DIR, 'prompt_trace.csv')
+
+
+def set_data_dir(data_dir: str):
+    """Configure prompt trace path for a commodity-specific data directory."""
+    global PROMPT_TRACE_PATH
+    PROMPT_TRACE_PATH = os.path.join(data_dir, 'prompt_trace.csv')
+    logger.info(f"PromptTrace data_dir set to: {data_dir}")
+
+
+# Canonical schema — order matters for CSV columns
+SCHEMA_COLUMNS = [
+    'timestamp',
+    'cycle_id',
+    'commodity',
+    'contract',
+    'phase',
+    'agent',
+    'prompt_source',
+    'model_provider',
+    'model_name',
+    'assigned_provider',
+    'assigned_model',
+    'persona_hash',
+    'dspy_version',
+    'demo_count',
+    'tms_context_count',
+    'grounded_freshness_hours',
+    'reflexion_applied',
+    'prompt_tokens',
+    'completion_tokens',
+    'latency_ms',
+]
+
+# String columns get empty string default, numeric get 0
+_STRING_COLUMNS = {
+    'timestamp', 'cycle_id', 'commodity', 'contract', 'phase', 'agent',
+    'prompt_source', 'model_provider', 'model_name', 'assigned_provider',
+    'assigned_model', 'persona_hash', 'dspy_version',
+}
+
+
+def hash_persona(text: str) -> str:
+    """SHA256[:12] of persona text for drift detection."""
+    if not text:
+        return hashlib.sha256(b'').hexdigest()[:12]
+    return hashlib.sha256(text.encode('utf-8')).hexdigest()[:12]
+
+
+@dataclass
+class PromptTraceRecord:
+    """One row in prompt_trace.csv."""
+    timestamp: str = ""
+    cycle_id: str = ""
+    commodity: str = ""
+    contract: str = ""
+    phase: str = ""
+    agent: str = ""
+    prompt_source: str = "legacy"
+    model_provider: str = ""
+    model_name: str = ""
+    assigned_provider: str = ""
+    assigned_model: str = ""
+    persona_hash: str = ""
+    dspy_version: str = ""
+    demo_count: int = 0
+    tms_context_count: int = 0
+    grounded_freshness_hours: float = 0.0
+    reflexion_applied: bool = False
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    latency_ms: float = 0.0
+
+
+class PromptTraceCollector:
+    """Buffers trace records for a single cycle, then flushes to CSV."""
+
+    def __init__(self, cycle_id: str = "", commodity: str = "", contract: str = ""):
+        self._records: List[PromptTraceRecord] = []
+        self._lock = threading.Lock()
+        self.cycle_id = cycle_id
+        self.commodity = commodity
+        self.contract = contract
+
+    def record(self, rec: PromptTraceRecord):
+        """Add a trace record, injecting cycle-level fields if not set."""
+        if not rec.timestamp:
+            rec.timestamp = format_ts()
+        if not rec.cycle_id:
+            rec.cycle_id = self.cycle_id
+        if not rec.commodity:
+            rec.commodity = self.commodity
+        if not rec.contract:
+            rec.contract = self.contract
+        with self._lock:
+            self._records.append(rec)
+
+    def flush(self) -> int:
+        """Write buffered records to CSV. Returns count written. Never raises."""
+        with self._lock:
+            records = list(self._records)
+            self._records.clear()
+
+        if not records:
+            return 0
+
+        try:
+            file_exists = os.path.exists(PROMPT_TRACE_PATH)
+            os.makedirs(os.path.dirname(PROMPT_TRACE_PATH), exist_ok=True)
+
+            with open(PROMPT_TRACE_PATH, 'a', newline='') as f:
+                writer = csv.DictWriter(f, fieldnames=SCHEMA_COLUMNS)
+                if not file_exists:
+                    writer.writeheader()
+                for rec in records:
+                    row = asdict(rec)
+                    writer.writerow({k: row.get(k, '') for k in SCHEMA_COLUMNS})
+
+            logger.info(f"Flushed {len(records)} prompt traces to {PROMPT_TRACE_PATH}")
+            return len(records)
+
+        except Exception as e:
+            logger.error(f"Failed to flush prompt traces: {e}", exc_info=True)
+            return 0
+
+
+def get_prompt_trace_df(commodity: Optional[str] = None) -> pd.DataFrame:
+    """
+    Read prompt_trace.csv into a DataFrame with parsed timestamps.
+    Returns empty DataFrame if file doesn't exist.
+    """
+    if not os.path.exists(PROMPT_TRACE_PATH):
+        return pd.DataFrame(columns=SCHEMA_COLUMNS)
+
+    try:
+        df = pd.read_csv(PROMPT_TRACE_PATH)
+        # Forward-compat: add missing columns with appropriate defaults
+        for col in SCHEMA_COLUMNS:
+            if col not in df.columns:
+                df[col] = '' if col in _STRING_COLUMNS else 0
+        if 'timestamp' in df.columns:
+            df['timestamp'] = parse_ts_column(df['timestamp'])
+        if commodity:
+            df = df[df['commodity'] == commodity]
+        return df
+
+    except Exception as e:
+        logger.error(f"Failed to read prompt_trace.csv: {e}")
+        return pd.DataFrame(columns=SCHEMA_COLUMNS)


### PR DESCRIPTION
## Summary
- Adds a **Prompt Traceability System** that records which prompt stack (legacy/commodity_profile/dspy_optimized), actual vs assigned model provider, token usage, and latency for every LLM call across the trading council pipeline
- Enables DSPy A/B testing, fallback debugging, and model performance attribution — previously impossible since no record existed of which prompt/model combination handled each call
- Non-invasive: all trace operations are wrapped in try/except and never block trading

## Changes

**New files:**
- `trading_bot/prompt_trace.py` — `PromptTraceRecord` dataclass (20-column CSV schema), `PromptTraceCollector` (per-cycle buffer + atomic flush), `hash_persona()` for drift detection, `get_prompt_trace_df()` reader
- `tests/test_prompt_trace.py` — 21 tests covering hash stability, collector record/flush/injection/concurrent, DataFrame loading/filtering/forward-compat

**Modified files (8):**
- `heterogeneous_router.py` — `route()` accepts optional `route_info` dict, populated with actual provider/model/tokens/latency on primary success, fallback, and cache hit
- `agents.py` — `trace_collector` param threaded through `research_topic`, `research_topic_with_reflexion`, `run_debate`, `decide`, `run_devils_advocate`; prompt source tracking (legacy → commodity_profile → dspy_optimized)
- `compliance.py` — `route_info` param on `audit_decision()`, passed through to router
- `signal_generator.py` — Creates collector after cycle_id, passes to all council methods, emits compliance trace, flushes via `asyncio.to_thread` after Brier recording
- `orchestrator.py` — `prompt_trace.set_data_dir()` in data_dir init block
- `dashboard_utils.py` — `load_prompt_traces(ticker)` cached loader
- `pages/3_The_Council.py` — "Prompt Provenance" section with routing fidelity metrics, source distribution, persona drift detection
- `tests/test_signal_flow.py` — Fixed mock side_effect signatures for new kwargs

## Test plan
- [x] 21 new prompt trace tests pass
- [x] All 6 critical regression suites pass (agents, prompt_security, budget_guard_wiring, grounded_research, compliance, compliance_var)
- [x] Full suite: **593 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)