### PR TITLE
Make --multi the default mode, finalize production deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,55 @@
+# =============================================================================
+# Real Options Trading Bot — Environment Variables
+# Copy to .env and fill in your values.
+# =============================================================================
+
+# --- Multi-Commodity Configuration ---
+# Comma-separated list of active commodity tickers (default: KC,CC)
+ACTIVE_COMMODITIES=KC,CC
+
+# Set to "true" to disable MasterOrchestrator and run single-commodity mode
+# LEGACY_MODE=true
+
+# When using LEGACY_MODE, which commodity to run
+# COMMODITY_TICKER=KC
+
+# --- Environment ---
+ENV_NAME=DEV   # DEV or PROD
+
+# --- Trading Configuration ---
+TRADING_MODE=LIVE       # LIVE or OFF (observation only)
+IB_PAPER=YES            # YES = paper trading, NO = real money
+STRATEGY_QTY=1          # Number of contracts per leg
+FORCE_DELAYED_DATA=1    # 1 = use delayed data (no market data subscription needed)
+INITIAL_CAPITAL=50000   # Your actual deposit amount (used for equity baseline)
+
+# --- Interactive Brokers ---
+IB_HOST=127.0.0.1
+IB_PORT=4002
+IB_CLIENT_ID=1
+
+# --- LLM API Keys ---
+GEMINI_API_KEY=
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+XAI_API_KEY=
+
+# --- IBKR Flex Reporting ---
+FLEX_TOKEN=
+FLEX_QUERY_ID=
+FLEX_POSITIONS_ID=
+FLEX_EQUITY_ID=
+
+# --- Notifications (Pushover) ---
+PUSHOVER_USER_KEY=
+PUSHOVER_API_TOKEN=
+
+# --- Data Providers ---
+FRED_API_KEY=
+NASDAQ_API_KEY=
+
+# --- Social Sentiment ---
+X_BEARER_TOKEN=
+
+# --- GitHub (error reporter auto-triage) ---
+GITHUB_ERROR_REPORTER_TOKEN=

--- a/README.md
+++ b/README.md
@@ -120,6 +120,46 @@ Specialized LLM personas that analyze grounded data.
 8.  **Execution:** The `OrderManager` (`trading_bot/order_manager.py`) constructs the order (e.g., Bull Call Spread) and submits it to `ib_interface.py`.
 9.  **Monitoring:** The system monitors the position for P&L triggers, regime shifts (via `check_iron_condor_theses`), or thesis invalidation.
 
+## Running
+
+### Prerequisites
+- Python 3.11+
+- Interactive Brokers Gateway (IB Gateway or TWS) running on configured port
+- API keys in `.env` (see `.env.example`)
+
+### Quick Start
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Default: MasterOrchestrator (all active commodities in one process)
+python orchestrator.py
+
+# Single commodity (legacy mode)
+python orchestrator.py --commodity KC
+
+# Force legacy mode via environment
+LEGACY_MODE=true python orchestrator.py
+
+# Dashboard
+streamlit run dashboard.py
+```
+
+### Configuration
+- **`config.json`**: Primary configuration (model registry, thresholds, sentinel intervals)
+- **`ACTIVE_COMMODITIES`**: Comma-separated list of tickers in `.env` (default: `KC,CC`)
+- **`LEGACY_MODE=true`**: Disables MasterOrchestrator, runs a single CommodityEngine per process
+- **`commodity_overrides`**: Per-commodity config overrides in `config.json` (e.g., `commodity_overrides.CC`)
+
+### Deployment
+```bash
+# DEV: Push to main → auto-deploys via GitHub Actions
+git push origin main
+
+# PROD: Push to production branch
+git push origin production
+```
+
 ## Tech Stack
 
 -   **Runtime:** Python 3.11+, `asyncio`
@@ -127,7 +167,7 @@ Specialized LLM personas that analyze grounded data.
 -   **AI:** Google Gemini (1.5 Pro/Flash), OpenAI (GPT-4o), Anthropic (Claude 3.5 Sonnet), xAI (Grok)
 -   **Memory:** ChromaDB (Vector Store)
 -   **Dashboard:** Streamlit
--   **Orchestration:** Custom Event Loop (`orchestrator.py`)
+-   **Orchestration:** MasterOrchestrator → CommodityEngine (`master_orchestrator.py`, `commodity_engine.py`)
 -   **Observability:** Custom logging + Pushover notifications
 
 ## License

--- a/dashboard.py
+++ b/dashboard.py
@@ -546,6 +546,8 @@ if hasattr(st, "page_link"):
                       help="How do signals align with price? Visual forensics", width="stretch")
         st.page_link("pages/8_LLM_Monitor.py", label="LLM Monitor", icon="\U0001f4b0",
                       help="API costs, budget utilization, provider health, latency", width="stretch")
+        st.page_link("pages/9_Portfolio.py", label="Portfolio", icon="\U0001f4ca",
+                      help="Account-wide risk status, cross-commodity positions, engine health", width="stretch")
 else:
     st.markdown("""
     Use the sidebar to navigate between pages:
@@ -560,6 +562,7 @@ else:
     | **Signal Overlay** | How do signals align with price? Visual forensics |
     | **Brier Analysis** | Which agents need tuning? Accuracy, calibration, learning |
     | **LLM Monitor** | API costs, budget utilization, provider health, latency |
+    | **Portfolio** | Account-wide risk status, cross-commodity positions, engine health |
     """)
 
 active_str = ", ".join(

--- a/equity_logger.py
+++ b/equity_logger.py
@@ -37,10 +37,6 @@ async def sync_equity_from_flex(config: dict):
 
     Only runs for the primary commodity (KC) since NetLiquidation is account-wide.
     """
-    if not config.get('commodity', {}).get('is_primary', True):
-        logger.info("Skipping equity sync — non-primary commodity (account equity tracked by primary)")
-        return
-
     logger.info("--- Starting Equity Synchronization from Flex Query ---")
 
     # Get the ID from the config (loaded from .env), or fallback to os.getenv just in case
@@ -143,10 +139,6 @@ async def log_equity_snapshot(config: dict):
 
     Only runs for the primary commodity (KC) since NetLiquidation is account-wide.
     """
-    if not config.get('commodity', {}).get('is_primary', True):
-        logger.info("Skipping equity snapshot — non-primary commodity (account equity tracked by primary)")
-        return
-
     logger.info("--- Starting Equity Snapshot Logging ---")
 
     data_dir = config.get('data_dir', 'data')

--- a/scripts/trading-bot.service
+++ b/scripts/trading-bot.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Real Options Trading Bot - Coffee (KC)
+Description=Real Options Trading Bot — MasterOrchestrator
 After=network.target
 Wants=network.target
 
@@ -8,10 +8,9 @@ Type=simple
 User=coffee-bot
 Group=coffee-bot
 WorkingDirectory=/opt/real_options
-Environment=COMMODITY_TICKER=KC
 Environment=ENV_NAME=PROD
 
-ExecStart=/opt/real_options/venv/bin/python -u orchestrator.py --commodity KC
+ExecStart=/opt/real_options/venv/bin/python -u orchestrator.py
 Restart=on-failure
 RestartSec=30
 StandardOutput=journal

--- a/trading_bot/master_orchestrator.py
+++ b/trading_bot/master_orchestrator.py
@@ -263,7 +263,6 @@ async def _post_close_service(shared: SharedContext, config: dict):
                 primary_config = config.copy()
                 primary_data_dir = os.path.join('data', shared.active_commodities[0])
                 primary_config['data_dir'] = primary_data_dir
-                primary_config.setdefault('commodity', {})['is_primary'] = True
                 await sync_equity_from_flex(primary_config)
                 await log_equity_snapshot(primary_config)
             except Exception as e:


### PR DESCRIPTION
## Summary
- **CLI default changed**: `python orchestrator.py` now runs MasterOrchestrator (`--multi`). Use `--commodity KC` or `LEGACY_MODE=true` for single-engine fallback.
- **Logging fix**: `setup_logging` is now conditional — skipped in multi-engine mode where the `__main__` block already configured the unified log.
- **is_primary cleanup**: Removed guards from `equity_logger.py` and `master_orchestrator.py`. MasterOrchestrator's equity/post-close services handle account-wide tasks. `performance_analyzer.py` intentionally unchanged.
- **deploy.sh rewrite**: `LEGACY_MODE`-aware stop/start/rollback. Commodity discovery from `data/` directories instead of systemd service files. Adds `orchestrator_multi.log` to log rotation.
- **verify_deploy.sh**: Discovers commodities from `data/` dirs, adds `[7/7]` MasterOrchestrator import check.
- **systemd service**: Stripped `COMMODITY_TICKER=KC` and `--commodity KC` from `ExecStart` — bare `python -u orchestrator.py` now defaults to `--multi`.
- **GLOBAL_* deprecation**: Added comments to `GLOBAL_BUDGET_GUARD`, `GLOBAL_DRAWDOWN_GUARD`, `GLOBAL_DEDUPLICATOR`, `EMERGENCY_LOCK`, `_INFLIGHT_TASKS` pointing to ContextVar accessors.
- **README + .env.example**: Running section with quick start, configuration, and deployment docs. New `.env.example` template with `ACTIVE_COMMODITIES` and `LEGACY_MODE`.

## Test plan
- [x] Full test suite: 610 passed, 0 failed
- [ ] Verify `python orchestrator.py` starts MasterOrchestrator (both KC+CC engines)
- [ ] Verify `python orchestrator.py --commodity KC` starts single-engine mode
- [ ] Verify `LEGACY_MODE=true python orchestrator.py` starts single-engine mode
- [ ] Verify deploy.sh stops/starts correctly in --multi mode
- [ ] Verify `scripts/verify_deploy.sh` passes with [7/7] checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)