### PR TITLE
Fix start_orchestrator.sh to support --multi mode

### DIFF
--- a/scripts/start_orchestrator.sh
+++ b/scripts/start_orchestrator.sh
@@ -13,16 +13,21 @@ fi
 
 cd "$REPO_ROOT"
 
-# Commodity ticker (default: KC)
-COMMODITY="${1:-${COMMODITY_TICKER:-KC}}"
-export COMMODITY_TICKER="$COMMODITY"
+# Detect mode: LEGACY_MODE=true runs single-commodity, otherwise MasterOrchestrator
+LEGACY_MODE="${LEGACY_MODE:-false}"
 
 # Ensure log directory exists
 mkdir -p logs
 
-# Ensure data directory exists
-mkdir -p "data/$COMMODITY"
-
-# Start
-echo "Starting orchestrator from $REPO_ROOT for commodity $COMMODITY..."
-exec python -u orchestrator.py --commodity "$COMMODITY"
+if [ "$LEGACY_MODE" = "true" ]; then
+    # Legacy: single-commodity mode
+    COMMODITY="${1:-${COMMODITY_TICKER:-KC}}"
+    export COMMODITY_TICKER="$COMMODITY"
+    mkdir -p "data/$COMMODITY"
+    echo "Starting orchestrator from $REPO_ROOT for commodity $COMMODITY (legacy mode)..."
+    exec python -u orchestrator.py --commodity "$COMMODITY"
+else
+    # Default: MasterOrchestrator (all active commodities in one process)
+    echo "Starting MasterOrchestrator from $REPO_ROOT..."
+    exec python -u orchestrator.py
+fi


### PR DESCRIPTION
## Summary
- The systemd service on the server uses `scripts/start_orchestrator.sh` as its `ExecStart`, NOT the repo's `scripts/trading-bot.service` directly
- `start_orchestrator.sh` was hardcoding `--commodity $COMMODITY` (defaulting to KC), which overrode the new `--multi` default from PR #1012
- Now defaults to `python -u orchestrator.py` (MasterOrchestrator) unless `LEGACY_MODE=true`

Found during post-deploy log verification — KC was running in single-engine mode instead of `--multi`.

## Test plan
- [ ] Merge and restart: `sudo systemctl restart trading-bot`
- [ ] Verify `orchestrator_multi.log` has content (not `orchestrator_kc.log`)
- [ ] Verify both KC and CC engines start (check sentinels.log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)