### PR TITLE
Fix cross-engine log contamination in --multi mode

### DIFF
--- a/trading_bot/commodity_engine.py
+++ b/trading_bot/commodity_engine.py
@@ -76,9 +76,13 @@ class CommodityEngine:
         # === 1. TASK-LOCAL DATA DIRECTORY — FIRST CALL ===
         set_engine_data_dir(self.data_dir)
 
-        # === 2. Per-commodity logging ===
-        from trading_bot.logging_config import setup_logging
-        setup_logging(log_file=f"logs/orchestrator_{self.ticker.lower()}.log")
+        # === 2. Per-commodity logging (only in single-engine mode) ===
+        # In --multi mode, __main__ already configured the unified orchestrator_multi.log.
+        # Calling setup_logging again would replace the root handler (force=True),
+        # causing cross-engine log contamination since all engines share one process.
+        if self.shared is None:
+            from trading_bot.logging_config import setup_logging
+            setup_logging(log_file=f"logs/orchestrator_{self.ticker.lower()}.log")
 
         self._logger.info("=============================================")
         self._logger.info(f"=== Starting CommodityEngine [{self.ticker}] ===")


### PR DESCRIPTION
## Summary
- In `--multi` mode, `CommodityEngine.start()` was calling `setup_logging(force=True)` per engine, replacing the root handler each time
- Since all engines share one process, log messages from KC bled into CC's log and vice versa
- Fix: skip `setup_logging` in CommodityEngine when `SharedContext` exists — the `__main__` block already configured the unified `orchestrator_multi.log`

## Test plan
- [x] 610 tests pass
- [ ] After deploy, verify `orchestrator_multi.log` has all messages from both engines
- [ ] Verify `orchestrator_kc.log` and `orchestrator_cc.log` stay empty (or are not created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)