### PR TITLE
Auto-sync systemd service file on deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -290,6 +290,16 @@ fi
 # =========================================================================
 echo "--- 9. Starting services... ---"
 
+# Sync service file if repo version differs from installed version
+REPO_SERVICE="scripts/trading-bot.service"
+LIVE_SERVICE="/etc/systemd/system/$SERVICE_NAME.service"
+if [ -f "$REPO_SERVICE" ]; then
+    if ! diff -q "$REPO_SERVICE" "$LIVE_SERVICE" >/dev/null 2>&1; then
+        echo "  Syncing service file (repo differs from installed)..."
+        sudo cp "$REPO_SERVICE" "$LIVE_SERVICE" || echo "  WARNING: Could not sync service file (check sudoers)"
+    fi
+fi
+
 # Reload systemd configuration (in case service file changed)
 echo "  Reloading systemd..."
 sudo systemctl daemon-reload


### PR DESCRIPTION
## Summary
- deploy.sh step 9 now diffs `scripts/trading-bot.service` against `/etc/systemd/system/trading-bot.service`
- Only copies when they differ, followed by `daemon-reload`
- Non-fatal (`|| echo WARNING`) if sudoers doesn't permit the `cp`

Fixes the duplicate log issue: the live service was appending stdout to `orchestrator.log` while Python logging writes to `orchestrator_multi.log`. The repo's service file uses `StandardOutput=journal` instead.

## Test plan
- [ ] After merge, verify `orchestrator.log` stops growing (systemd now sends to journal)
- [ ] Verify `orchestrator_multi.log` is the only active log
- [ ] If sudoers blocks the cp, deploy still succeeds with a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)