### PR TITLE
Fix: guard service file sync to PROD only

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -290,13 +290,17 @@ fi
 # =========================================================================
 echo "--- 9. Starting services... ---"
 
-# Sync service file if repo version differs from installed version
-REPO_SERVICE="scripts/trading-bot.service"
-LIVE_SERVICE="/etc/systemd/system/$SERVICE_NAME.service"
-if [ -f "$REPO_SERVICE" ]; then
-    if ! diff -q "$REPO_SERVICE" "$LIVE_SERVICE" >/dev/null 2>&1; then
-        echo "  Syncing service file (repo differs from installed)..."
-        sudo cp "$REPO_SERVICE" "$LIVE_SERVICE" || echo "  WARNING: Could not sync service file (check sudoers)"
+# Sync service file if repo version differs from installed version.
+# Only on PROD — the repo service file has production paths (/opt/real_options, User=coffee-bot).
+# DEV servers manage their own service files manually.
+if [ "${ENV_NAME:-DEV}" = "PROD" ]; then
+    REPO_SERVICE="scripts/trading-bot.service"
+    LIVE_SERVICE="/etc/systemd/system/$SERVICE_NAME.service"
+    if [ -f "$REPO_SERVICE" ]; then
+        if ! diff -q "$REPO_SERVICE" "$LIVE_SERVICE" >/dev/null 2>&1; then
+            echo "  Syncing service file (repo differs from installed)..."
+            sudo cp "$REPO_SERVICE" "$LIVE_SERVICE" || echo "  WARNING: Could not sync service file (check sudoers)"
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Summary
- PR #1016 introduced auto-sync of the systemd service file, but `scripts/trading-bot.service` has production paths (`/opt/real_options`, `User=coffee-bot`)
- Deploying to DEV overwrote the live service file, causing `status=217/USER` crash loop
- Fix: only sync when `ENV_NAME=PROD`

**Action needed:** Restore the DEV service file on the server manually:
```bash
sudo tee /etc/systemd/system/trading-bot.service << 'SVCEOF'
[Unit]
Description=Real Options Trading Bot — MasterOrchestrator
After=network.target
Wants=network.target

[Service]
Type=simple
User=rodrigo
Group=rodrigo
WorkingDirectory=/home/rodrigo/real_options
ExecStart=/home/rodrigo/real_options/scripts/start_orchestrator.sh
Restart=on-failure
RestartSec=10
StandardOutput=journal
StandardError=journal
SyslogIdentifier=trading-bot
Environment="PATH=/home/rodrigo/real_options/venv/bin:/usr/local/bin:/usr/bin:/bin"
Environment=BOT_SERVICE_NAME=trading-bot

[Install]
WantedBy=multi-user.target
SVCEOF
sudo systemctl daemon-reload && sudo systemctl restart trading-bot
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)