### PR TITLE
Fix 3 production issues from Feb 23 trading session

### DIFF
--- a/dashboard_utils.py
+++ b/dashboard_utils.py
@@ -239,7 +239,7 @@ def _load_legacy_council_history(data_dir: str) -> pd.DataFrame:
         ]
         for legacy_file in legacy_files:
             try:
-                legacy_df = pd.read_csv(legacy_file)
+                legacy_df = pd.read_csv(legacy_file, on_bad_lines='warn')
                 if not legacy_df.empty:
                     legacy_dfs.append(legacy_df)
             except Exception as e:
@@ -268,7 +268,7 @@ def load_council_history(ticker: str = None):
 
         # Load main file
         if os.path.exists(council_path):
-            df = pd.read_csv(council_path)
+            df = pd.read_csv(council_path, on_bad_lines='warn')
             if not df.empty:
                 # OPTIMIZATION: Parse timestamps immediately for live data
                 if 'timestamp' in df.columns:
@@ -1992,7 +1992,7 @@ def get_current_market_regime() -> str:
         # Priority 1: Council history (most recent regime from actual decisions)
         council_path = _get_council_history_path()
         if os.path.exists(council_path):
-            df = pd.read_csv(council_path)
+            df = pd.read_csv(council_path, on_bad_lines='warn')
             if not df.empty and 'entry_regime' in df.columns:
                 recent_regimes = df['entry_regime'].dropna()
                 if not recent_regimes.empty:
@@ -2051,7 +2051,7 @@ def load_council_history_for_commodity(ticker: str) -> pd.DataFrame:
     if not os.path.exists(council_path):
         return pd.DataFrame()
     try:
-        df = pd.read_csv(council_path)
+        df = pd.read_csv(council_path, on_bad_lines='warn')
         if not df.empty:
             if 'timestamp' in df.columns:
                 df['timestamp'] = parse_ts_column(df['timestamp'])

--- a/tests/test_sentinel_loop.py
+++ b/tests/test_sentinel_loop.py
@@ -19,8 +19,9 @@ class TestSentinelLoop(unittest.IsolatedAsyncioTestCase):
     @patch('orchestrator.configure_market_data_type')
     @patch('orchestrator.GLOBAL_DEDUPLICATOR')
     @patch('orchestrator.get_active_futures', new_callable=AsyncMock)
+    @patch('orchestrator.process_deferred_triggers', new_callable=AsyncMock)
     async def test_run_sentinels_lazy_init_and_market_hours(
-        self, mock_get_futures, mock_dedup, mock_configure, mock_is_trading, mock_is_market_open,
+        self, mock_process_deferred, mock_get_futures, mock_dedup, mock_configure, mock_is_trading, mock_is_market_open,
         mock_micro_class, mock_macro_class, mock_prediction_class, mock_x_class, mock_news_class, mock_logistics_class,
         mock_weather_class, mock_price_class, mock_ib_pool
     ):

--- a/trading_bot/brier_scoring.py
+++ b/trading_bot/brier_scoring.py
@@ -425,7 +425,7 @@ def resolve_pending_predictions(council_history_path: str = None, data_dir: str 
 
     try:
         predictions_df = pd.read_csv(structured_file)
-        council_df = pd.read_csv(council_history_path)
+        council_df = pd.read_csv(council_history_path, on_bad_lines='warn')
 
         if predictions_df.empty or council_df.empty:
             logger.info("Empty dataframes — nothing to resolve")

--- a/trading_bot/enhanced_brier.py
+++ b/trading_bot/enhanced_brier.py
@@ -481,7 +481,7 @@ class EnhancedBrierTracker:
         resolved_from_ch = 0
         if os.path.exists(council_path):
             try:
-                ch_df = pd.read_csv(council_path)
+                ch_df = pd.read_csv(council_path, on_bad_lines='warn')
                 # Build cycle_id → actual_trend_direction lookup
                 ch_outcomes = {}
                 for _, row in ch_df.iterrows():

--- a/trading_bot/reconciliation.py
+++ b/trading_bot/reconciliation.py
@@ -69,7 +69,7 @@ async def reconcile_council_history(config: dict, ib: IB = None):
         return
 
     try:
-        df = pd.read_csv(file_path)
+        df = pd.read_csv(file_path, on_bad_lines='warn')
     except Exception as e:
         logger.error(f"Failed to read council_history.csv: {e}")
         return


### PR DESCRIPTION
## Summary

Fixes 3 issues identified from the Feb 23 production trading log (2,283 lines analyzed):

### 1. IB Client ID Collisions (CRITICAL)
- **Symptom**: 6 client ID collisions causing drawdown check, order generation, audit, and sentinel failures
- **Root cause**: `_resolve_purpose()` prefixes purpose with ticker (e.g., "sentinel" → "KC_sentinel") before client ID lookup, but `DEV_CLIENT_ID_BASE` has unprefixed keys. All purposes fell to default ID 80.
- **Fix**: Save unprefixed `purpose_base` before `_resolve_purpose()`, use it for `DEV_CLIENT_ID_BASE`/`CLIENT_ID_BASE` lookups

### 2. Deferred Triggers Never Processed
- **Symptom**: 26 KC + 19 CC deferred triggers accumulated but never processed throughout entire trading day
- **Root cause**: Scheduled task fires at 03:31 ET but coffee market opens at 04:15 ET. `is_market_open()` always returns False at 03:31.
- **Fix**: One-shot deferred trigger processing on first market-open transition in sentinel loop (resets daily)

### 3. council_history.csv Parse Error (27 occurrences)
- **Symptom**: Dashboard showing "Failed to load council_history.csv: Expected 38 fields in line 176, saw 39"
- **Root cause**: `schedule_id` column added to write schema (39 cols) but existing CSV header still had 38 cols
- **Fix**: (a) Migrated production CSV header to include `schedule_id`, (b) Added `on_bad_lines='warn'` to all 7 `pd.read_csv` call sites as defensive measure

## Test plan
- [x] Full test suite: 610 passed, 0 failed
- [x] `test_sentinel_loop.py` updated to mock `process_deferred_triggers`
- [ ] Verify client ID diversity in next trading session logs
- [ ] Verify deferred triggers processed after market open
- [ ] Verify no CSV parse errors in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)