### PR TITLE
Soften Signal Overlay alignment diagnostic

### DIFF
--- a/pages/6_Signal_Overlay.py
+++ b/pages/6_Signal_Overlay.py
@@ -867,9 +867,9 @@ if price_df is not None and not price_df.empty:
             missing_dates = sorted(d for d in unmatched_dates if d not in price_dates)
             if missing_dates:
                 date_str = ', '.join(str(d) for d in missing_dates[:5])
-                st.warning(
-                    f"⚠️ {unmatched_count} of {len(signals)} signals could not align to price candles "
-                    f"(no price data for: {date_str}). Try a different timeframe or check yfinance data availability."
+                st.caption(
+                    f"ℹ️ {unmatched_count} signal(s) not shown — Yahoo Finance has no {timeframe} data for {date_str}. "
+                    f"Try the 1d timeframe to see them."
                 )
             else:
                 st.caption(f"ℹ️ {unmatched_count} signal(s) outside alignment tolerance ({_tol}) — not shown on chart.")


### PR DESCRIPTION
## Summary
- Changed alignment diagnostic from `st.warning` to `st.caption` — Yahoo Finance intraday data gaps are not our issue
- Suggests switching to 1d timeframe as a workaround

## Test plan
- [x] Visual: message now renders as subtle caption instead of orange warning box

🤖 Generated with [Claude Code](https://claude.com/claude-code)