### PR TITLE
Include ticker in restart notification for multi-commodity

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -4845,9 +4845,10 @@ async def recover_missed_tasks(missed_tasks: list, config: dict):
     logger.info(summary)
 
     # Always send ONE notification on restart (even if nothing recovered)
+    ticker = config.get('symbol', config.get('commodity', {}).get('ticker', ''))
     send_pushover_notification(
         config.get('notifications', {}),
-        f"🔄 System Restart: {recovered} Tasks Recovered",
+        f"🔄 [{ticker}] Restart: {recovered} Tasks Recovered",
         summary
     )
 


### PR DESCRIPTION
## Summary
- Each CommodityEngine sends its own restart notification via `recover_missed_tasks()`
- In multi-commodity mode (KC + CC), this results in two identical Pushover notifications
- Now prefixes with `[KC]` / `[CC]` so they're distinguishable: `🔄 [KC] Restart: 6 Tasks Recovered`

## Other issues noted in logs (not addressed here)
- IB connection backoff during rapid recovery (audit_pre_close fails because audit_mid_session just ran)
- Rate limiter stampede: both sentinel arrays start simultaneously, 13 LLM requests queue up, xAI times out
- Per-engine logs empty (orchestrator_kc.log = 0 bytes) — all output goes to orchestrator_multi.log

## Test plan
- [x] 610 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)