### PR TITLE
🎨 Palette: Color-coded Agent Summaries in The Council

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,7 @@ This journal records CRITICAL UX/accessibility learnings.
 ## 2026-02-22 - Contextual Clarity via Tooltips
 **Learning:** In data-dense trading dashboards, metrics and high-impact buttons can be ambiguous to new or stressed users. Using the `help` parameter in `st.metric` and `st.button` provides essential "just-in-time" documentation without cluttering the visual interface.
 **Action:** Always provide descriptive tooltips for system-level metrics (e.g., Python/Streamlit versions, UTC time) and high-stakes manual triggers (e.g., Force Generate) to reduce cognitive load and operational risk.
+
+## 2026-02-24 - Semantic Containers for Scannability
+**Learning:** Using `st.success`, `st.error`, and `st.info` as wrappers for text content (not just alerts) provides immediate, color-coded context that improves scannability for sentiment-heavy data.
+**Action:** Apply this pattern when displaying categorical data with strong positive/negative connotations (like Bullish/Bearish sentiment) to reduce cognitive load.

--- a/pages/3_The_Council.py
+++ b/pages/3_The_Council.py
@@ -648,7 +648,15 @@ for summary_col, (name, sentiment_col) in summary_cols.items():
 
     with st.expander(f"{icon} {name} ({sentiment})"):
         summary = row.get(summary_col, 'No summary available.')
-        st.write(summary)
+
+        # UX: Color-coded container based on sentiment
+        s_upper = str(sentiment).upper()
+        if 'BULL' in s_upper:
+            st.success(summary)
+        elif 'BEAR' in s_upper:
+            st.error(summary)
+        else:
+            st.info(summary)
 
 st.markdown("---")
 

--- a/tests/test_council_ux.py
+++ b/tests/test_council_ux.py
@@ -1,0 +1,48 @@
+import ast
+import os
+import unittest
+
+class TestCouncilUX(unittest.TestCase):
+    def test_agent_summaries_color_coding(self):
+        """
+        Verify that agent summaries in pages/3_The_Council.py are color-coded
+        using st.success, st.error, and st.info based on sentiment.
+        """
+        file_path = os.path.join(os.path.dirname(__file__), '..', 'pages', '3_The_Council.py')
+
+        with open(file_path, 'r') as f:
+            tree = ast.parse(f.read())
+
+        found_loop = False
+        found_success = False
+        found_error = False
+        found_info = False
+
+        for node in ast.walk(tree):
+            # Look for the loop iterating over summary_cols.items()
+            if isinstance(node, ast.For):
+                if (isinstance(node.iter, ast.Call) and
+                    isinstance(node.iter.func, ast.Attribute) and
+                    node.iter.func.attr == 'items' and
+                    isinstance(node.iter.func.value, ast.Name) and
+                    node.iter.func.value.id == 'summary_cols'):
+
+                    found_loop = True
+
+                    # Search inside the loop body for st.success, st.error, st.info
+                    for sub in ast.walk(node):
+                        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute):
+                            if sub.func.attr == 'success':
+                                found_success = True
+                            elif sub.func.attr == 'error':
+                                found_error = True
+                            elif sub.func.attr == 'info':
+                                found_info = True
+
+        self.assertTrue(found_loop, "Could not find the summary_cols loop in pages/3_The_Council.py")
+        self.assertTrue(found_success, "Did not find st.success() call (for BULLISH sentiment)")
+        self.assertTrue(found_error, "Did not find st.error() call (for BEARISH sentiment)")
+        self.assertTrue(found_info, "Did not find st.info() call (for NEUTRAL sentiment)")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR enhances the "Agent Analysis Summaries" section in `pages/3_The_Council.py` by using color-coded containers (Green/Red/Blue) to visually represent Bullish/Bearish/Neutral sentiment. This improves scannability and reduces cognitive load for users analyzing trade decisions.

### Changes
- **`pages/3_The_Council.py`**: Replaced plain `st.write` with `st.success`/`st.error`/`st.info` logic based on sentiment strings.
- **`tests/test_council_ux.py`**: Added a new test file to verify the implementation using AST parsing.
- **`.jules/palette.md`**: Added a journal entry for "Semantic Containers for Scannability".

### Verification
- **Frontend**: Verified locally using a Playwright script that generated a screenshot of the enhanced UI.
- **Tests**: Ran `tests/test_council_ux.py` and existing `tests/test_ui_ux.py`, both passed.

---
*PR created automatically by Jules for task [475729416943113006](https://jules.google.com/task/475729416943113006) started by @rozavala*