### PR TITLE
Track all untracked LLM calls and X API usage

### DIFF
--- a/pages/8_LLM_Monitor.py
+++ b/pages/8_LLM_Monitor.py
@@ -92,6 +92,21 @@ else:
 
 
 # =====================================================================
+# SECTION 1b: X/Twitter API Usage
+# =====================================================================
+x_api_calls = budget.get('x_api_calls', 0) if budget else 0
+if x_api_calls > 0:
+    st.markdown("---")
+    st.subheader("X (Twitter) API Usage")
+    col1, col2 = st.columns(2)
+    col1.metric("API Calls Today", str(x_api_calls))
+    col2.caption(
+        "X API calls are counted but not included in the LLM budget. "
+        "These use the X Bearer Token (separate billing)."
+    )
+
+
+# =====================================================================
 # SECTION 2: Cost by Agent Role
 # =====================================================================
 st.markdown("---")

--- a/trading_bot/topic_discovery.py
+++ b/trading_bot/topic_discovery.py
@@ -489,6 +489,17 @@ Answer ONLY with a JSON object: {{"relevant": true/false, "score": 0-5, "reasoni
                     {"role": "user", "content": prompt}
                 ]
             )
+            if self._budget_guard and hasattr(message, 'usage') and message.usage:
+                try:
+                    from trading_bot.budget_guard import calculate_api_cost
+                    cost = calculate_api_cost(
+                        self.llm_model,
+                        message.usage.input_tokens or 0,
+                        message.usage.output_tokens or 0,
+                    )
+                    self._budget_guard.record_cost(cost, source="topic_discovery")
+                except Exception:
+                    pass
             return message.content[0].text
         except Exception as e:
             # Handle potential budget/rate limit errors


### PR DESCRIPTION
## Summary

- **5 direct LLM call sites** were bypassing cost tracking entirely — sentinels (Gemini), XSentimentSentinel (Grok), TradingCouncil grounded data (Gemini), and TopicDiscoveryAgent (Anthropic). All now record costs via the budget guard.
- **X/Twitter API usage** was completely invisible. Added a separate call counter to BudgetGuard and a new section on the LLM Monitor dashboard.
- All cost tracking is wrapped in `try/except` so it never breaks production trading operations.

## Files changed

| File | Change |
|------|--------|
| `trading_bot/sentinels.py` | `_record_sentinel_cost()` helper; track Gemini in 3 sentinels, Grok in XSentimentSentinel, X API calls in `_fetch_x_posts` |
| `trading_bot/agents.py` | Track Gemini grounded data costs in `_call_model()` |
| `trading_bot/topic_discovery.py` | Track Anthropic costs in `_call_anthropic()` |
| `trading_bot/budget_guard.py` | `_x_api_calls` counter, `record_x_api_call()`, state persistence, `get_status()` |
| `pages/8_LLM_Monitor.py` | X API usage section (shown when calls > 0) |

## Test plan

- [x] Full test suite passes (610 passed, 0 failed)
- [ ] Post-deploy: verify `budget_state.json` shows `cost_by_source` entries for sentinel/*, council/grounded_data, topic_discovery
- [ ] Post-deploy: verify `budget_state.json` has `x_api_calls` field
- [ ] Post-deploy: LLM Monitor page shows X API usage when XSentimentSentinel runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)