### PR TITLE
Add Natural Gas (NG) as 3rd commodity with P0 bug fixes

### DIFF
--- a/config.json
+++ b/config.json
@@ -502,7 +502,8 @@
       ],
 
       "intra_session_tasks": [
-        {"id": "audit_mid_session", "session_pct": 0.50, "function": "run_position_audit_cycle", "label": "Audit: Mid-Session"}
+        {"id": "audit_mid_session", "session_pct": 0.50, "function": "run_position_audit_cycle", "label": "Audit: Mid-Session"},
+        {"id": "eia_storage_signal", "session_pct": 0.29, "function": "guarded_generate_orders", "label": "Signal: EIA Storage Report", "commodity_filter": "NG"}
       ],
 
       "pre_close_tasks": [
@@ -594,7 +595,7 @@
     "notify_on_issue_created": true,
     "triage_model": "claude-sonnet-4-6"
   },
-  "active_commodities": ["KC", "CC"],
+  "active_commodities": ["KC", "CC", "NG"],
   "llm": {
     "max_concurrent_calls": 4
   },
@@ -603,6 +604,18 @@
       "commodity": {
         "ticker": "CC",
         "name": "Cocoa"
+      },
+      "strategy": {
+        "quantity": 1
+      },
+      "risk_management": {
+        "max_open_positions": 3
+      }
+    },
+    "NG": {
+      "commodity": {
+        "ticker": "NG",
+        "name": "Natural Gas"
       },
       "strategy": {
         "quantity": 1

--- a/config/commodity_profiles.py
+++ b/config/commodity_profiles.py
@@ -794,6 +794,15 @@ def _load_profile_from_json(path: str) -> CommodityProfile:
             'supply_chain': 0.05, 'research': 0.005, 'trade_journal': 0.01,
             'default': 0.05
         }),
+        # Risk/pricing fields (must match dataclass — JSON profiles need these)
+        straddle_risk_threshold=data.get('straddle_risk_threshold', 10000.0),
+        fallback_iv=data.get('fallback_iv', 0.35),
+        risk_free_rate=data.get('risk_free_rate', 0.04),
+        default_starting_capital=data.get('default_starting_capital', 50000.0),
+        min_dte=data.get('min_dte', 45),
+        max_dte=data.get('max_dte', 365),
+        stop_parse_range=data.get('stop_parse_range', [0.0, 9999.0]),
+        typical_price_range=data.get('typical_price_range', [0.0, 9999.0]),
         # Commodity-agnostic fields
         yfinance_ticker=data.get('yfinance_ticker', ''),
         research_prompts=data.get('research_prompts', {}),

--- a/config/profiles/ng.json
+++ b/config/profiles/ng.json
@@ -1,0 +1,171 @@
+{
+    "name": "Natural Gas (Henry Hub)",
+    "ticker": "NG",
+    "commodity_type": "energy",
+    "contract": {
+        "exchange": "NYMEX",
+        "symbol": "NG",
+        "contract_months": ["F", "G", "H", "J", "K", "M", "N", "Q", "U", "V", "X", "Z"],
+        "tick_size": 0.001,
+        "tick_value": 10.0,
+        "contract_size": 10000,
+        "unit": "$/mmBtu",
+        "trading_hours_et": "09:00-14:30",
+        "spot_month_limit": 0,
+        "all_months_limit": 0
+    },
+    "primary_regions": [
+        {
+            "name": "Permian Basin",
+            "country": "United States",
+            "latitude": 31.9,
+            "longitude": -102.1,
+            "weight": 0.30,
+            "frost_threshold_celsius": -5.0,
+            "drought_soil_moisture_pct": 5.0,
+            "flood_precip_mm_24h": 150.0,
+            "harvest_months": [],
+            "planting_months": []
+        },
+        {
+            "name": "Appalachian Basin (Marcellus/Utica)",
+            "country": "United States",
+            "latitude": 40.5,
+            "longitude": -79.5,
+            "weight": 0.35,
+            "frost_threshold_celsius": -15.0,
+            "drought_soil_moisture_pct": 5.0,
+            "flood_precip_mm_24h": 100.0,
+            "harvest_months": [],
+            "planting_months": []
+        },
+        {
+            "name": "Haynesville Shale",
+            "country": "United States",
+            "latitude": 32.5,
+            "longitude": -93.8,
+            "weight": 0.20,
+            "frost_threshold_celsius": -5.0,
+            "drought_soil_moisture_pct": 5.0,
+            "flood_precip_mm_24h": 150.0,
+            "harvest_months": [],
+            "planting_months": []
+        },
+        {
+            "name": "Gulf Coast LNG Export Zone",
+            "country": "United States",
+            "latitude": 29.7,
+            "longitude": -95.0,
+            "weight": 0.15,
+            "frost_threshold_celsius": -2.0,
+            "drought_soil_moisture_pct": 5.0,
+            "flood_precip_mm_24h": 200.0,
+            "harvest_months": [],
+            "planting_months": []
+        }
+    ],
+    "logistics_hubs": [
+        {
+            "name": "Henry Hub (Erath, LA)",
+            "hub_type": "pipeline_hub",
+            "country": "United States",
+            "latitude": 30.0,
+            "longitude": -92.1,
+            "congestion_vessel_threshold": 0,
+            "dwell_time_alert_days": 0
+        },
+        {
+            "name": "Sabine Pass LNG Terminal",
+            "hub_type": "lng_terminal",
+            "country": "United States",
+            "latitude": 29.7,
+            "longitude": -93.9,
+            "congestion_vessel_threshold": 15,
+            "dwell_time_alert_days": 3
+        },
+        {
+            "name": "Freeport LNG Terminal",
+            "hub_type": "lng_terminal",
+            "country": "United States",
+            "latitude": 28.9,
+            "longitude": -95.3,
+            "congestion_vessel_threshold": 10,
+            "dwell_time_alert_days": 3
+        }
+    ],
+    "inventory_sources": [
+        "EIA Weekly Natural Gas Storage Report",
+        "EIA Natural Gas Monthly",
+        "Baker Hughes Rig Count",
+        "Platts Gas Daily"
+    ],
+    "news_keywords": [
+        "natural gas", "henry hub", "LNG", "gas storage", "EIA storage",
+        "heating degree days", "cooling degree days", "polar vortex",
+        "pipeline capacity", "gas production", "shale gas", "marcellus",
+        "permian gas", "haynesville", "gas exports", "LNG exports",
+        "gas demand", "power generation gas", "gas rig count"
+    ],
+    "agronomy_context": "Not applicable for energy commodities. Natural gas production is driven by drilling activity (rig counts), well completion rates, and associated gas from oil production (especially Permian Basin). Key supply metrics: dry gas production (~105 Bcf/d US), storage levels vs 5-year average, and LNG export feed gas.",
+    "macro_context": "Natural gas prices are driven by weather (heating/cooling demand), LNG export capacity, pipeline constraints, coal-to-gas switching economics, and industrial demand. USD strength has limited direct impact since NG is domestically priced. Key macro indicators: GDP growth (industrial demand), electricity generation mix, and carbon policy. Interest rates affect drilling economics via E&P capex budgets.",
+    "supply_chain_context": "Henry Hub is the primary US pricing point. Key pipelines: Transco, Rockies Express, Gulf Coast laterals. LNG export terminals (Sabine Pass, Freeport, Cameron, Corpus Christi) create export demand floor. Storage operates on injection (Apr-Oct) and withdrawal (Nov-Mar) cycles. Underground storage capacity ~4.7 Tcf with ~3.5 Tcf typical peak. Freeze-offs in producing regions can sharply curtail supply during extreme cold.",
+    "social_accounts": [
+        "EIAgov", "PlattsGas", "RBNEnergy", "NGIntelligence"
+    ],
+    "sentiment_search_queries": [
+        "natural gas price", "henry hub", "LNG shipping", "gas storage report",
+        "heating degree days forecast", "polar vortex natural gas"
+    ],
+    "legitimate_data_sources": [
+        "eia.gov", "cmegroup.com", "platts.com", "naturalgasintel.com",
+        "rbnenergy.com", "weather.gov"
+    ],
+    "weather_apis": ["open-meteo"],
+    "volatility_high_iv_rank": 0.65,
+    "volatility_low_iv_rank": 0.25,
+    "price_move_alert_pct": 3.0,
+    "straddle_risk_threshold": 8000.0,
+    "fallback_iv": 0.55,
+    "risk_free_rate": 0.04,
+    "default_starting_capital": 50000.0,
+    "min_dte": 14,
+    "max_dte": 180,
+    "stop_parse_range": [0.5, 50.0],
+    "typical_price_range": [1.0, 20.0],
+    "yfinance_ticker": "NG=F",
+    "concentration_proxies": ["NG", "CL", "UNG", "XOP"],
+    "concentration_label": "US Energy",
+    "cross_commodity_basket": {
+        "crude_oil": "CL=F",
+        "heating_oil": "HO=F",
+        "rbob_gasoline": "RB=F",
+        "coal": "MTF=F",
+        "carbon": "GCL=F"
+    },
+    "tms_decay_rates": {
+        "weather": 0.25,
+        "logistics": 0.08,
+        "news": 0.10,
+        "sentiment": 0.10,
+        "price": 0.25,
+        "microstructure": 0.30,
+        "technical": 0.05,
+        "macro": 0.02,
+        "geopolitical": 0.03,
+        "inventory": 0.15,
+        "supply_chain": 0.05,
+        "research": 0.005,
+        "trade_journal": 0.01,
+        "default": 0.05
+    },
+    "research_prompts": {
+        "agronomist": "Analyze current US natural gas production trends, rig counts, well completion rates, and associated gas output from oil basins. Focus on supply-side factors affecting Henry Hub pricing.",
+        "macro": "Evaluate macroeconomic factors affecting natural gas demand: industrial activity, power generation fuel switching, LNG export demand, and seasonal weather patterns (heating/cooling degree days).",
+        "fundamentalist": "Review EIA storage data vs 5-year average, production vs consumption balance, LNG export feed gas volumes, and pipeline capacity utilization for supply/demand assessment.",
+        "technical": "Analyze NG futures price action, volume patterns, open interest changes, seasonal spread behavior, and key technical levels on the front-month and calendar spreads.",
+        "volatility": "Assess natural gas implied volatility levels, term structure (contango/backwardation), seasonal volatility patterns, and weather-driven vol spikes. NG is historically one of the most volatile commodity markets.",
+        "geopolitical": "Evaluate geopolitical factors: US LNG export policy, European gas supply dynamics (TTF spread), pipeline politics, sanctions on competing suppliers, and energy security concerns.",
+        "sentiment": "Gauge market sentiment from trader positioning (COT data), gas-focused social media, industry newsletters (RBN, NGI), and options market skew.",
+        "supply_chain": "Monitor pipeline maintenance schedules, LNG terminal utilization, storage injection/withdrawal rates, and regional basis differentials (Henry Hub vs other hubs)."
+    }
+}

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -4533,7 +4533,11 @@ def _build_session_schedule(config: dict) -> list:
         _add_task(sid, dt.time(), 'guarded_generate_orders', slbl)
 
     # 3. Intra-session tasks: open_time + (session_minutes * session_pct)
+    ticker = get_active_ticker(config)
     for entry in tmpl.get('intra_session_tasks', []):
+        cf = entry.get('commodity_filter', '')
+        if cf and cf != ticker:
+            continue
         dt = open_dt + timedelta(minutes=session_minutes * entry['session_pct'])
         _add_task(entry['id'], dt.time(), entry['function'], entry.get('label', entry['id']))
 

--- a/scripts/migrations/fix_cc_total_value.py
+++ b/scripts/migrations/fix_cc_total_value.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Migration: Fix CC (Cocoa) total_value_usd in trade_ledger.csv
+
+Problem: log_trade_to_ledger() was dividing all total_value by 100.0 (cents divisor),
+which is correct for KC (cents/lb) but wrong for CC ($/metric ton) and NG ($/mmBtu).
+CC values were recorded 100x too small.
+
+Fix: Multiply CC rows' total_value_usd by 100.0 to undo the erroneous division.
+
+This migration is idempotent: it writes a marker column 'migrated_cc_divisor' and
+skips rows that already have it set.
+
+Usage:
+    python scripts/migrations/fix_cc_total_value.py [--dry-run] [--data-dir data/CC]
+"""
+
+import argparse
+import csv
+import os
+import sys
+import shutil
+from datetime import datetime
+
+
+def fix_cc_total_value(data_dir: str, dry_run: bool = False) -> dict:
+    """Fix CC total_value_usd by multiplying by 100.
+
+    Returns:
+        dict with keys: rows_total, rows_fixed, rows_skipped, ledger_path
+    """
+    ledger_path = os.path.join(data_dir, 'trade_ledger.csv')
+    if not os.path.exists(ledger_path):
+        print(f"No ledger found at {ledger_path} — nothing to migrate.")
+        return {'rows_total': 0, 'rows_fixed': 0, 'rows_skipped': 0, 'ledger_path': ledger_path}
+
+    # Read all rows
+    with open(ledger_path, 'r', newline='') as f:
+        reader = csv.DictReader(f)
+        original_fieldnames = list(reader.fieldnames) if reader.fieldnames else []
+        rows = list(reader)
+
+    if not rows:
+        print(f"Ledger at {ledger_path} is empty — nothing to migrate.")
+        return {'rows_total': 0, 'rows_fixed': 0, 'rows_skipped': 0, 'ledger_path': ledger_path}
+
+    # Ensure marker column exists in fieldnames
+    marker_col = 'migrated_cc_divisor'
+    fieldnames = list(original_fieldnames)
+    if marker_col not in fieldnames:
+        fieldnames.append(marker_col)
+
+    rows_fixed = 0
+    rows_skipped = 0
+
+    for row in rows:
+        # Skip already-migrated rows
+        if row.get(marker_col):
+            rows_skipped += 1
+            continue
+
+        # Only fix rows with CC symbols
+        local_sym = row.get('local_symbol', '')
+        if not local_sym.startswith('CC'):
+            row[marker_col] = ''  # Not applicable, leave unmarked
+            continue
+
+        try:
+            old_val = float(row.get('total_value_usd', 0))
+            new_val = old_val * 100.0
+            if not dry_run:
+                row['total_value_usd'] = f"{new_val:.2f}"
+                row[marker_col] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+            rows_fixed += 1
+            print(f"  {'[DRY RUN] ' if dry_run else ''}Row {local_sym}: "
+                  f"${old_val:.2f} -> ${new_val:.2f}")
+        except (ValueError, TypeError) as e:
+            print(f"  WARNING: Could not convert total_value_usd for {local_sym}: {e}")
+
+    if not dry_run and rows_fixed > 0:
+        # Backup original
+        backup_path = ledger_path + f'.bak.{datetime.utcnow().strftime("%Y%m%dT%H%M%S")}'
+        shutil.copy2(ledger_path, backup_path)
+        print(f"Backup saved to {backup_path}")
+
+        # Write corrected file atomically
+        tmp_path = ledger_path + '.tmp'
+        with open(tmp_path, 'w', newline='') as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+        os.replace(tmp_path, ledger_path)
+
+    result = {
+        'rows_total': len(rows),
+        'rows_fixed': rows_fixed,
+        'rows_skipped': rows_skipped,
+        'ledger_path': ledger_path,
+    }
+    print(f"\nSummary: {rows_fixed} rows fixed, {rows_skipped} already migrated, "
+          f"{len(rows)} total rows in {ledger_path}")
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Fix CC total_value_usd in trade_ledger.csv')
+    parser.add_argument('--dry-run', action='store_true', help='Preview changes without writing')
+    parser.add_argument('--data-dir', default='data/CC', help='Path to CC data directory')
+    args = parser.parse_args()
+
+    print(f"{'[DRY RUN] ' if args.dry_run else ''}Fixing CC total_value_usd divisor bug...")
+    fix_cc_total_value(args.data_dir, dry_run=args.dry_run)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

- **Natural Gas (Henry Hub, NYMEX:NG)** integrated as the 3rd commodity — energy-sector with near-zero correlation to existing agricultural softs (KC, CC)
- **P0 fix:** `log_trade_to_ledger()` hardcoded `/100.0` cents divisor — correct for KC (cents/lb), wrong for CC ($/metric ton) and NG ($/mmBtu). Now derives commodity from fill contract and looks up unit dynamically
- **P2 fix:** `round_to_tick()` hardcoded 2-decimal precision — NG tick=0.001 needs 3 decimals. Now uses `math.log10`-based dynamic precision
- **EIA blackout window** in compliance: blocks NG orders Thu 10:25-10:35 ET during storage report release
- **`commodity_filter`** on intra-session tasks: EIA signal fires only for NG engine, not KC/CC
- **CC ledger migration** script to correct historical `total_value_usd` values (idempotent, with backup)
- **JSON profile loader** fix: 8 missing dataclass fields (`fallback_iv`, `min_dte`, `stop_parse_range`, etc.) now loaded from JSON profiles
- **12 new tests** (625 total, 0 failures)

## Files changed

| File | Type | Description |
|------|------|-------------|
| `config/profiles/ng.json` | NEW | Full NG commodity profile (NYMEX, 10k mmBtu, tick=0.001) |
| `config/commodity_profiles.py` | EDIT | +8 `.get()` lines in JSON loader |
| `trading_bot/utils.py` | EDIT | Commodity-aware divisor + dynamic tick precision |
| `scripts/migrations/fix_cc_total_value.py` | NEW | Idempotent CC ledger migration |
| `trading_bot/compliance.py` | EDIT | EIA blackout window + `_eia_now_et()` helper |
| `orchestrator.py` | EDIT | `commodity_filter` in intra-session tasks |
| `config.json` | EDIT | `active_commodities` +NG, overrides, EIA task |
| `tests/test_utils.py` | EDIT | +8 tests (tick precision, divisor, localSymbol) |
| `tests/test_session_schedule.py` | EDIT | +3 tests (commodity_filter) |
| `tests/test_compliance.py` | EDIT | +3 tests (EIA blackout) |

## Manual action needed

- Update `.env`: `ACTIVE_COMMODITIES=KC,CC` → `KC,CC,NG`

## Follow-ups

1. `dashboard_utils.py` hardcoded `stop_parse_range` is wrong for NG ($1.50-$15.00 range)
2. NG-specific systemd service file (`trading-bot-ng.service`)

## Test plan

- [x] NG profile loads correctly with all overridden fields (`fallback_iv=0.55`, `min_dte=14`, `tick_size=0.001`)
- [x] KC and CC profiles unchanged
- [x] `round_to_tick` produces correct precision per commodity (KC→2dp, NG→3dp, CC→0dp)
- [x] `round_to_tick` handles zero/negative tick_size without crash
- [x] NG fills use divisor=1.0 (not /100)
- [x] localSymbol parsing extracts ticker when `contract.symbol` is empty
- [x] EIA blackout rejects NG on Thu 10:30 ET, allows outside window, skips KC
- [x] `commodity_filter` skips NG-only tasks for KC engine, includes for NG engine
- [x] Full suite: 625 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)