### PR TITLE
🛡️ Sentinel: Fix URL parameter injection in RSS sentinels

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `TradingCouncil` agents interpolated `search_instruction` (containing untrusted social media/news content) directly into prompt instructions without sanitization.
 **Learning:** Even "internal" task descriptions become attack vectors if they include data derived from external triggers (e.g. `SentinelTrigger.payload`).
 **Prevention:** Implemented `escape_xml` utility. Prompts now wrap untrusted task context in `<task>...</task>` tags with explicit instructions to treat the block as data/context only.
+
+## 2026-02-27 - URL Parameter Injection in Sentinels
+**Vulnerability:** `LogisticsSentinel` and `NewsSentinel` constructed Google News RSS URLs using string concatenation and `replace(' ', '+')` instead of proper URL encoding.
+**Learning:** Manual URL construction is brittle. Special characters (like `&` in "Port & Terminal" or `Coffee (Arabica)`) can break the URL structure or inject new parameters if not properly escaped.
+**Prevention:** Always use `urllib.parse.quote_plus` (or `urlencode`) when constructing query strings, even if the source data (like `profile.name`) comes from configuration.

--- a/trading_bot/sentinels.py
+++ b/trading_bot/sentinels.py
@@ -16,6 +16,7 @@ import pytz
 import aiohttp
 import json
 import re
+from urllib.parse import quote_plus
 from functools import wraps
 from notifications import send_pushover_notification
 from trading_bot.state_manager import StateManager
@@ -833,13 +834,13 @@ class LogisticsSentinel(Sentinel):
             return config_urls
 
         base = "https://news.google.com/rss/search?q="
-        commodity_name = self.profile.name.lower().replace(' ', '+')
+        commodity_name = quote_plus(self.profile.name.lower())
 
         urls = []
 
         # Monitor specific logistics hubs defined in profile
         for hub in self.profile.logistics_hubs:
-            hub_name = hub.name.replace(' ', '+')
+            hub_name = quote_plus(hub.name)
             urls.append(f"{base}{hub_name}+logistics+{commodity_name}")
 
         # General supply chain search
@@ -1017,14 +1018,14 @@ class NewsSentinel(Sentinel):
             return config_urls
 
         base = "https://news.google.com/rss/search?q="
-        commodity_name = self.profile.name.lower().replace(' ', '+')
+        commodity_name = quote_plus(self.profile.name.lower())
         keywords = self.profile.news_keywords or [commodity_name]
 
         urls = []
 
         # Core market feeds (site-restricted for quality)
         for source in ['reuters.com', 'bloomberg.com']:
-            primary_kw = keywords[0].replace(' ', '+')
+            primary_kw = quote_plus(keywords[0])
             urls.append(f"{base}{primary_kw}+markets+site:{source}")
 
         # Region-specific feeds (top 2 producing regions)
@@ -1032,11 +1033,11 @@ class NewsSentinel(Sentinel):
         top_regions = sorted_regions[:2]
 
         for region in top_regions:
-            region_name = region.name.replace(' ', '+')
+            region_name = quote_plus(region.name)
             urls.append(f"{base}{region_name}+{commodity_name}")
 
         # General sentiment feed
-        primary_kw = keywords[0].replace(' ', '+')
+        primary_kw = quote_plus(keywords[0])
         urls.append(f"{base}{primary_kw}+futures+market+sentiment")
 
         if not urls:
@@ -2466,7 +2467,7 @@ class FundamentalRegimeSentinel(Sentinel):
 
     async def check_news_sentiment(self) -> str:
         try:
-            commodity_q = self.profile.name.lower().replace(' ', '+')
+            commodity_q = quote_plus(self.profile.name.lower())
             surplus_url = f"https://news.google.com/rss/search?q={commodity_q}+market+surplus"
             deficit_url = f"https://news.google.com/rss/search?q={commodity_q}+market+deficit"
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Google News RSS URLs were constructed using unsafe string concatenation and manual space replacement, allowing special characters (like '&') to break the URL structure or inject parameters.
🎯 Impact: Search queries containing special characters (e.g., "Port & Terminal", "Côte d'Ivoire") would be malformed, potentially leading to incorrect search results or API errors.
🔧 Fix: Replaced manual `replace(' ', '+')` with `urllib.parse.quote_plus` in `LogisticsSentinel`, `NewsSentinel`, and `FundamentalRegimeSentinel`.
✅ Verification: Verified with `verify_url_encoding.py` (created and run during development) and existing regression tests.

---
*PR created automatically by Jules for task [13346739991183992491](https://jules.google.com/task/13346739991183992491) started by @rozavala*