### PR TITLE
Fix per-engine budget tracking and MacroContagionSentinel errors

### DIFF
--- a/config/profiles/ng.json
+++ b/config/profiles/ng.json
@@ -139,8 +139,8 @@
         "crude_oil": "CL=F",
         "heating_oil": "HO=F",
         "rbob_gasoline": "RB=F",
-        "coal": "MTF=F",
-        "carbon": "GCL=F"
+        "gold": "GC=F",
+        "wheat": "ZW=F"
     },
     "tms_decay_rates": {
         "weather": 0.25,

--- a/trading_bot/commodity_engine.py
+++ b/trading_bot/commodity_engine.py
@@ -130,7 +130,7 @@ class CommodityEngine:
         self._runtime = EngineRuntime(
             ticker=self.ticker,
             deduplicator=self._create_deduplicator(),
-            budget_guard=self.shared.budget_guard,
+            budget_guard=self._create_budget_guard(),
             drawdown_guard=self._create_drawdown_guard(),
             shared=self.shared,
         )
@@ -450,6 +450,11 @@ class CommodityEngine:
             'run_brier_reconciliation': orchestrator.run_brier_reconciliation,
             'sentinel_effectiveness_check': orchestrator.sentinel_effectiveness_check,
         }
+
+    def _create_budget_guard(self):
+        """Create a per-engine BudgetGuard that writes to data/{TICKER}/."""
+        from trading_bot.budget_guard import BudgetGuard
+        return BudgetGuard(self.config)
 
     def _create_deduplicator(self):
         """Create a per-engine TriggerDeduplicator."""


### PR DESCRIPTION
## Summary
- **CC budget tracking** showed $0 spend because a single BudgetGuard singleton wrote only to `data/KC/`. Each CommodityEngine now creates its own BudgetGuard, and `get_budget_guard()` is ContextVar-aware (per-engine first, singleton fallback for single-engine mode).
- **MacroContagionSentinel** had 3 production errors: yfinance NoneType crash on API failure, Gemini returning JSON arrays instead of objects, and contagion check aborting on any missing ticker. All three fixed defensively.
- **NG profile** had delisted tickers (`MTF=F`, `GCL=F`) replaced with working ones (`GC=F`, `ZW=F`).

## Test plan
- [x] 3 new budget guard tests: ContextVar preferred over singleton, singleton fallback, per-engine writes to own dir
- [x] 3 new sentinel tests: yfinance crash handling, JSON array unwrapping, contagion skipping missing tickers
- [x] Full suite: 635 passed, 0 failed (up from 629)

🤖 Generated with [Claude Code](https://claude.com/claude-code)