### PR TITLE
Skip equity staleness check for non-primary engines

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1168,6 +1168,12 @@ async def check_and_recover_equity_data(config: dict) -> bool:
     from pathlib import Path
     import shutil
 
+    # Non-primary engines don't own equity data (account-wide metric).
+    # Skip staleness check to avoid spurious warnings.
+    is_primary = config.get('commodity', {}).get('is_primary', True)
+    if not is_primary:
+        return True
+
     data_dir = config.get('data_dir', 'data')
     equity_file = Path(os.path.join(data_dir, "daily_equity.csv"))
     max_staleness_hours = config.get('monitoring', {}).get('equity_max_staleness_hours', 24)


### PR DESCRIPTION
## Summary

- Add `is_primary` guard to `check_and_recover_equity_data()` in orchestrator.py — non-primary engines (CC, NG) no longer log spurious "Equity file missing" warnings since they don't own `daily_equity.csv`
- Deleted stale `data/CC/daily_equity.csv` and `data/NG/daily_equity.csv` from production (identical duplicates of KC's account-wide equity data, created before the `is_primary` guard in PR #1037)

## Post-deploy audit results

The council_history.csv "Expected 38 fields, saw 39" errors are **resolved** — both KC and CC CSVs now have 39 columns consistently with zero mismatched rows. The errors were pre-deploy artifacts from before the `dissent_acknowledged` column was added. No code changes needed.

## Test plan

- [x] Full test suite: 635 passed, 0 failed
- [x] Verified CC/NG equity files deleted from production
- [x] Verified no code paths break when CC/NG equity files are absent (dashboard returns empty DataFrame, performance_analyzer has is_primary guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)