### PR TITLE
Fix hardcoded .NYB suffix in Signal Overlay for NG

### DIFF
--- a/pages/6_Signal_Overlay.py
+++ b/pages/6_Signal_Overlay.py
@@ -264,7 +264,10 @@ def resolve_front_month_ticker(config_path: str = "config.json") -> tuple[str, s
             # Sort by DTE ascending — first one is the trading front month
             candidates.sort(key=lambda x: x[0])
             front_symbol = candidates[0][1]
-            yf_ticker = f"{front_symbol}.NYB"
+            # Use exchange-specific suffix (NYB for ICE/NYBOT, NYM for NYMEX, etc.)
+            suffix_map = {'ICE': 'NYB', 'NYBOT': 'NYB', 'NYMEX': 'NYM', 'COMEX': 'CMX', 'CME': 'CME'}
+            suffix = suffix_map.get(profile.contract.exchange, 'NYB')
+            yf_ticker = f"{front_symbol}.{suffix}"
             return (yf_ticker, front_symbol)
 
     except Exception as e:


### PR DESCRIPTION
## Summary

`resolve_front_month_ticker()` in Signal Overlay hardcoded the yfinance suffix as `.NYB` (ICE/NYBOT), which is correct for KC and CC but wrong for NG (NYMEX → `.NYM`). This caused the chart to show:

> ⚠️ No price data for `NGH26.NYB`. Falling back to `NG=F`.

The fix uses the same exchange-based `suffix_map` that `contract_to_yfinance_ticker()` already uses correctly (line 315), ensuring NG resolves to `NGH26.NYM`.

## Test plan

- [x] Full test suite: 635 passed, 0 failed
- [ ] Verify in dashboard: Signal Overlay for NG shows `NGH26.NYM` price data without fallback warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)