### PR TITLE
Fix multi-commodity dashboard issues from agent audit

### DIFF
--- a/_commodity_selector.py
+++ b/_commodity_selector.py
@@ -41,7 +41,11 @@ def _commodity_label(ticker: str) -> str:
 
 
 def _reinit_data_dirs(ticker: str):
-    """Re-point module-level data directories for the selected commodity."""
+    """Re-point module-level data directories for the selected commodity.
+
+    Must cover every module with a set_data_dir() that the dashboard reads.
+    Mirrors the orchestrator's init sequence (orchestrator.py L4926-4938).
+    """
     data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', ticker)
 
     from trading_bot.decision_signals import set_data_dir as set_signals_dir
@@ -49,6 +53,27 @@ def _reinit_data_dirs(ticker: str):
 
     from trading_bot.brier_bridge import set_data_dir as set_brier_bridge_dir
     set_brier_bridge_dir(data_dir)
+
+    from trading_bot.state_manager import StateManager
+    StateManager.set_data_dir(data_dir)
+
+    from trading_bot.sentinel_stats import set_data_dir as set_stats_dir
+    set_stats_dir(data_dir)
+
+    from trading_bot.utils import set_data_dir as set_utils_dir
+    set_utils_dir(data_dir)
+
+    from trading_bot.brier_scoring import set_data_dir as set_brier_scoring_dir
+    set_brier_scoring_dir(data_dir)
+
+    from trading_bot.prompt_trace import set_data_dir as set_prompt_trace_dir
+    set_prompt_trace_dir(data_dir)
+
+    from trading_bot.router_metrics import set_data_dir as set_router_metrics_dir
+    set_router_metrics_dir(data_dir)
+
+    from trading_bot.task_tracker import set_data_dir as set_tracker_dir
+    set_tracker_dir(data_dir)
 
 
 def selected_commodity() -> str:

--- a/dashboard_utils.py
+++ b/dashboard_utils.py
@@ -1,5 +1,5 @@
 """
-Shared utilities for the Coffee Bot Real Options dashboard.
+Shared utilities for the Real Options Portfolio dashboard.
 Contains data loading, caching, and decision grading logic.
 """
 
@@ -167,14 +167,18 @@ def get_starting_capital(config: dict) -> float:
         profile.default_starting_capital if hasattr(profile, 'default_starting_capital') else 50000.0
     )
 
-@st.cache_data
+@st.cache_data(ttl=60)
 def get_config():
-    """Loads and caches the application configuration."""
+    """Loads and caches the application configuration.
+
+    TTL=60s ensures config refreshes after commodity switch even if
+    st.cache_data.clear() doesn't fully propagate. The load_config()
+    call reads COMMODITY_TICKER env var for commodity overrides.
+    """
     config = load_config()
     if config is None:
         st.error("Fatal: Could not load config.json.")
         return {}
-    # COMMODITY_TICKER override is now handled in load_config() itself
     return config
 
 

--- a/pages/2_The_Scorecard.py
+++ b/pages/2_The_Scorecard.py
@@ -25,6 +25,7 @@ from dashboard_utils import (
     fetch_live_dashboard_data,
     get_config,
     _resolve_data_path,
+    _resolve_data_path_for,
     STRATEGY_ABBREVIATIONS
 )
 import numpy as np
@@ -135,7 +136,7 @@ strategy_filter = st.sidebar.multiselect(
 live_price = None
 if config:
     live_data = fetch_live_dashboard_data(config)
-    ticker = config.get('commodity', {}).get('ticker', config.get('symbol', 'KC'))
+    # Use page-level ticker from commodity selector (not config)
     live_price = live_data.get(f'{ticker}_Price')
 
 # Grade decisions
@@ -458,8 +459,8 @@ st.markdown("---")
 st.subheader("Regime-Specific Win Rate")
 st.caption("Does the system perform differently in different market conditions?")
 
-# Load decision_signals.csv for regime data
-_signals_path = _resolve_data_path("decision_signals.csv")
+# Load decision_signals.csv for regime data (explicit ticker for commodity-aware path)
+_signals_path = _resolve_data_path_for("decision_signals.csv", ticker)
 _regime_shown = False
 
 if os.path.exists(_signals_path):
@@ -800,7 +801,7 @@ st.markdown("---")
 # === FEEDBACK LOOP HEALTH ===
 st.subheader("🔄 Feedback Loop Health")
 
-structured_file = _resolve_data_path("agent_accuracy_structured.csv")
+structured_file = _resolve_data_path_for("agent_accuracy_structured.csv", ticker)
 
 if os.path.exists(structured_file):
     struct_df = pd.read_csv(structured_file)

--- a/pages/6_Signal_Overlay.py
+++ b/pages/6_Signal_Overlay.py
@@ -71,12 +71,19 @@ COLOR_MAP = {
     'NEUTRAL': '#888888', 'HOLD': '#888888',
 }
 
-# New constant for Month-specific colors (perpetual)
+# Month-specific colors for all 12 contract months (F-Z)
 MONTH_COLORS = {
-    'H': '#00CC96',  # March - Green
+    'F': '#19D3F3',  # Jan - Cyan
+    'G': '#B6E880',  # Feb - Lime
+    'H': '#00CC96',  # Mar - Green
+    'J': '#FF6692',  # Apr - Pink
     'K': '#636EFA',  # May - Blue
-    'N': '#EF553B',  # July - Red
+    'M': '#FECB52',  # Jun - Yellow
+    'N': '#EF553B',  # Jul - Red
+    'Q': '#FF97FF',  # Aug - Magenta
     'U': '#AB63FA',  # Sep - Purple
+    'V': '#00B5F7',  # Oct - Sky blue
+    'X': '#72B7B2',  # Nov - Teal
     'Z': '#FFA15A',  # Dec - Orange
 }
 
@@ -370,8 +377,9 @@ def get_contract_color(contract: str, default_color: str) -> str:
         return default_color
 
     clean = clean_contract_symbol(contract)
-    if clean and len(clean) >= 3:
-        month_code = clean[2]
+    sym_len = len(profile.contract.symbol)  # 2 for KC/CC/NG, dynamic for future tickers
+    if clean and len(clean) > sym_len:
+        month_code = clean[sym_len]
         return MONTH_COLORS.get(month_code, default_color)
 
     return default_color

--- a/pages/7_Brier_Analysis.py
+++ b/pages/7_Brier_Analysis.py
@@ -18,7 +18,7 @@ import plotly.graph_objects as go
 from datetime import datetime, timezone, timedelta
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from dashboard_utils import _resolve_data_path
+from dashboard_utils import _resolve_data_path_for
 
 st.set_page_config(layout="wide", page_title="Brier Analysis | Real Options")
 
@@ -32,9 +32,9 @@ st.caption("Agent prediction quality, calibration curves, and learning feedback"
 # === DATA LOADING ===
 
 @st.cache_data(ttl=120)
-def load_enhanced_brier():
+def load_enhanced_brier(ticker: str = "KC"):
     """Load enhanced Brier data from JSON."""
-    path = _resolve_data_path("enhanced_brier.json")
+    path = _resolve_data_path_for("enhanced_brier.json", ticker)
     if not os.path.exists(path):
         return None
     try:
@@ -45,9 +45,9 @@ def load_enhanced_brier():
 
 
 @st.cache_data(ttl=120)
-def load_structured_predictions():
+def load_structured_predictions(ticker: str = "KC"):
     """Load structured prediction CSV."""
-    path = _resolve_data_path("agent_accuracy_structured.csv")
+    path = _resolve_data_path_for("agent_accuracy_structured.csv", ticker)
     if not os.path.exists(path):
         return pd.DataFrame()
     try:
@@ -60,9 +60,9 @@ def load_structured_predictions():
 
 
 @st.cache_data(ttl=120)
-def load_legacy_accuracy():
+def load_legacy_accuracy(ticker: str = "KC"):
     """Load legacy accuracy CSV."""
-    path = _resolve_data_path("agent_accuracy.csv")
+    path = _resolve_data_path_for("agent_accuracy.csv", ticker)
     if not os.path.exists(path):
         return pd.DataFrame()
     try:
@@ -72,9 +72,9 @@ def load_legacy_accuracy():
 
 
 @st.cache_data(ttl=120)
-def load_weight_evolution():
+def load_weight_evolution(ticker: str = "KC"):
     """Load weight evolution CSV."""
-    path = _resolve_data_path('weight_evolution.csv')
+    path = _resolve_data_path_for('weight_evolution.csv', ticker)
     if not os.path.exists(path):
         return pd.DataFrame()
     try:
@@ -84,9 +84,9 @@ def load_weight_evolution():
 
 
 @st.cache_data(ttl=120)
-def load_decision_signals():
+def load_decision_signals(ticker: str = "KC"):
     """Load decision signals CSV for regime context."""
-    path = _resolve_data_path('decision_signals.csv')
+    path = _resolve_data_path_for('decision_signals.csv', ticker)
     if not os.path.exists(path):
         return pd.DataFrame()
     try:
@@ -108,9 +108,9 @@ except ImportError:
 # === SECTION 1: System Health Overview ===
 st.subheader("📊 Feedback Loop Overview")
 
-enhanced_data = load_enhanced_brier()
-struct_df = load_structured_predictions()
-legacy_df = load_legacy_accuracy()
+enhanced_data = load_enhanced_brier(ticker)
+struct_df = load_structured_predictions(ticker)
+legacy_df = load_legacy_accuracy(ticker)
 
 # Primary metrics
 if enhanced_data:
@@ -370,7 +370,7 @@ st.markdown("---")
 st.subheader("📈 Agent Influence Over Time")
 st.caption("Agents above 1.0 have earned more influence through accurate predictions. Below 1.0 means the system trusts them less.")
 
-weight_df = load_weight_evolution()
+weight_df = load_weight_evolution(ticker)
 
 if not weight_df.empty and len(weight_df) >= 5:
     available_agents = sorted(weight_df['agent'].unique())
@@ -477,8 +477,8 @@ st.subheader("🏆 Agent Accuracy by Market Regime")
 st.caption("Which agents perform best in each market condition?")
 
 try:
-    accuracy_df = load_legacy_accuracy()
-    signals_df = load_decision_signals()
+    accuracy_df = load_legacy_accuracy(ticker)
+    signals_df = load_decision_signals(ticker)
 
     _have_accuracy = not accuracy_df.empty and 'agent' in accuracy_df.columns and 'correct' in accuracy_df.columns
     _have_signals = not signals_df.empty and 'regime' in signals_df.columns


### PR DESCRIPTION
## Summary

Comprehensive audit of all 9 dashboard pages by 4 specialized agents identified 42 findings across infrastructure, per-page code, and data files. This PR fixes the **14 highest-priority issues** (all P0/P1).

### Fixes by file

**`_commodity_selector.py` — Expand `_reinit_data_dirs()` (P0)**
- Was only reinitializing 2 of 13 modules on commodity switch
- Now covers 9 modules: + state_manager, sentinel_stats, utils, brier_scoring, prompt_trace, router_metrics, task_tracker
- Prevents stale data from the previous commodity leaking through module-level globals

**`pages/1_Cockpit.py` — Market Clock & benchmarks (P0)**
- Market Clock was hardcoded to ICE/KC hours (03:30-14:00) and `exchange='ICE'`
- Now loads trading hours and exchange from the selected commodity's profile
- NG (NYMEX) and CC (ICE, different hours) now show correct market status
- Fixed ticker variable shadowing at benchmark display (L975)
- Widened `stop_parse_range` fallback from [80,800] (KC-only) to [0,100000]

**`pages/2_The_Scorecard.py` — Ticker & path fixes (P1)**
- Removed ticker override from config that shadowed the commodity selector
- Changed regime and feedback data paths to use `_resolve_data_path_for(file, ticker)`

**`pages/7_Brier_Analysis.py` — Cache-key commodity awareness (P0)**
- All 5 data loading functions had no `ticker` parameter — cache keys were identical across commodities
- Added `ticker` param to `load_enhanced_brier`, `load_structured_predictions`, `load_legacy_accuracy`, `load_weight_evolution`, `load_decision_signals`
- Cache now properly differentiates by commodity

**`pages/6_Signal_Overlay.py` — NG month support (P1)**
- Added all 12 month codes (F-Z) to `MONTH_COLORS` — NG has monthly contracts vs KC/CC's 5
- Fixed hardcoded index `2` in `get_contract_color` to use `len(profile.contract.symbol)`

**`dashboard_utils.py` — Config cache TTL (P1)**
- Added `ttl=60` to `get_config()` cache — was cached forever with no TTL

### Not in scope (P2/P3, lower priority)
- Utilities page subprocess commodity passing (works via env var inheritance)
- Hardcoded volatility threshold labels in Scorecard (cosmetic)
- `COFFEE_BOT_ENV` env var in Utilities (unused)

## Test plan
- [x] Full test suite: 635 passed, 0 failures
- [ ] Manual: Switch KC→CC→NG in dashboard sidebar, verify Market Clock shows correct hours
- [ ] Manual: Verify Brier Analysis page shows commodity-specific data after switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)