### PR TITLE
Dashboard polish: multi-engine health, decision pipeline, CSV integrity

### DIFF
--- a/pages/2_The_Scorecard.py
+++ b/pages/2_The_Scorecard.py
@@ -338,7 +338,7 @@ if learning['has_data']:
             st.caption(f"{icon} Win rate {arrow}: {first_val:.0f}% → {last_val:.0f}% ({delta:+.0f}pp)")
 
     # --- Chart 3: Agent Accuracy Over Time (in expander) ---
-    with st.expander("Agent Accuracy Over Time", expanded=False):
+    with st.expander("Agent Accuracy Over Time", expanded=True):
         agent_window = st.select_slider(
             "Rolling window size",
             options=[10, 15, 20, 25, 30],
@@ -658,7 +658,7 @@ if not vol_df.empty:
             total_vol = wins + losses
             win_rate = wins/total_vol*100 if total_vol > 0 else 0
             st.metric("Win Rate", f"{win_rate:.1f}%")
-            st.caption(f"Wins when price moved >1.8%: {wins} | Losses: {losses}")
+            st.caption(f"Wins when price moved significantly: {wins} | Losses: {losses}")
         else:
             st.info("No Long Straddle trades.")
 
@@ -671,7 +671,7 @@ if not vol_df.empty:
             total_vol = wins + losses
             win_rate = wins/total_vol*100 if total_vol > 0 else 0
             st.metric("Win Rate", f"{win_rate:.1f}%")
-            st.caption(f"Wins when price stayed <2%: {wins} | Losses: {losses}")
+            st.caption(f"Wins when price stayed range-bound: {wins} | Losses: {losses}")
         else:
             st.info("No Iron Condor trades.")
 else:

--- a/pages/3_The_Council.py
+++ b/pages/3_The_Council.py
@@ -627,6 +627,18 @@ try:
 except Exception:
     pass  # Silently skip if data isn't available
 
+# --- Cross-page Navigation ---
+try:
+    _nav_cols = st.columns(3)
+    with _nav_cols[0]:
+        st.page_link("pages/2_The_Scorecard.py", label="View in Scorecard", icon="📊")
+    with _nav_cols[1]:
+        st.page_link("pages/6_Signal_Overlay.py", label="View Price Action", icon="📈")
+    with _nav_cols[2]:
+        st.page_link("pages/7_Brier_Analysis.py", label="Agent Accuracy", icon="🎯")
+except Exception:
+    pass  # st.page_link may not be available in older Streamlit versions
+
 st.markdown("---")
 
 # === SECTION 4: Agent Summaries ===
@@ -683,8 +695,15 @@ traces_df = load_prompt_traces(ticker=ticker)
 if traces_df.empty:
     st.info("No prompt trace data available yet. Traces are recorded during trading cycles.")
 else:
-    with st.expander("Agent Prompt Configuration (Latest Cycle)", expanded=False):
-        latest_cycle = traces_df['cycle_id'].iloc[-1] if 'cycle_id' in traces_df.columns and len(traces_df) > 0 else None
+    # Link prompt provenance to the SELECTED decision, not just the latest cycle
+    _selected_cycle_id = row.get('cycle_id', None) if 'row' in dir() else None
+    with st.expander("Agent Prompt Configuration", expanded=False):
+        latest_cycle = (
+            _selected_cycle_id
+            if (_selected_cycle_id and 'cycle_id' in traces_df.columns
+                and _selected_cycle_id in traces_df['cycle_id'].values)
+            else (traces_df['cycle_id'].iloc[-1] if 'cycle_id' in traces_df.columns and len(traces_df) > 0 else None)
+        )
         if latest_cycle:
             cycle_traces = traces_df[traces_df['cycle_id'] == latest_cycle]
             display_cols = ['agent', 'phase', 'prompt_source', 'model_provider', 'model_name',

--- a/trading_bot/utils.py
+++ b/trading_bot/utils.py
@@ -716,6 +716,11 @@ def log_council_decision(decision_data):
         "primary_catalyst",       # Single most important driver
         "conviction_multiplier",  # 0.5 / 0.75 / 1.0 from consensus sensor
         "dissent_acknowledged",   # Strongest counter-argument Master chose to override
+        # NEW COLUMNS (v4 — VaR & Compliance observability)
+        "compliance_reason",      # Why compliance approved/vetoed
+        "var_utilization",        # Portfolio VaR utilization at decision time
+        "var_dampener",           # VaR dampener multiplier applied
+        "risk_briefing_injected", # Whether risk briefing was injected into prompts
     ]
 
     # Free-text fields that may contain LLM output — sanitize for CSV formula injection


### PR DESCRIPTION
## Summary
- **P0: Fix 4 silently dropped CSV columns** in `council_history.csv` — `compliance_reason`, `var_utilization`, `var_dampener`, `risk_briefing_injected` were written by signal_generator but missing from DictWriter fieldnames, causing silent data loss via `extrasaction='ignore'`
- **P0: Multi-engine health banner** — Cockpit now checks ALL commodity engines (KC, CC, NG) and reports per-engine status instead of only the selected commodity
- **P1: All-commodity benchmarks** — Market Benchmarks section now shows SPY + all active commodities via `discover_active_commodities()`, not just the selected one
- **P1: Recent Decisions feed** — Replaces trade-only feed with full decision pipeline view: Trigger → Decision → Confidence → Strategy → Strength → Outcome (shows "Open" for pending trades)
- **P1: Prompt provenance linked to selection** — Council page now filters prompt traces by the selected decision's `cycle_id` instead of always showing the latest cycle
- **P1: Agent accuracy visibility** — Expanded by default (was hidden in collapsed expander)
- **P1: Commodity-agnostic threshold labels** — Scorecard volatility labels no longer hardcode "1.8%" / "2%" (KC-specific)
- **P1: Cross-page navigation** — Council page now links to Scorecard, Signal Overlay, and Brier Analysis

## Production Data Audit Findings (Informational)
Concurrent audit of `/home/rodrigo/real_options/data/` found:
- Empty `budget_state.json` for KC/CC (NG populated) — runtime issue, not code
- 232 unresolved Brier predictions (reconciliation stall)
- VaR state showing zero (may be normal if no open positions)
- KC `council_history.csv` has rows with variable column counts (embedded commas in agent summaries) — the CSV fieldnames fix in this PR prevents future column loss

## Test plan
- [x] Full test suite: 635 passed, 0 failures
- [ ] Verify Cockpit health banner shows engine count for all commodities
- [ ] Verify benchmark section shows KC, CC, NG prices
- [ ] Verify Council prompt provenance changes with decision selector
- [ ] Verify Scorecard agent accuracy chart is expanded by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)