### PR TITLE
Fix NG exchange misconfiguration (NYMEX not NYBOT)

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -664,7 +664,7 @@ async def _validate_iron_condor(thesis: dict, config: dict, ib: IB, active_futur
         underlying_contract = Future(
             symbol=underlying_symbol,
             lastTradeDateOrContractMonth=contract_month,
-            exchange=config.get('exchange', 'NYBOT')
+            exchange=config['exchange']
         )
         try:
             await asyncio.wait_for(ib.qualifyContractsAsync(underlying_contract), timeout=15)
@@ -755,7 +755,7 @@ async def _validate_long_straddle(thesis: dict, position, config: dict, ib: IB, 
                     underlying_contract = Future(
                         symbol=underlying_symbol,
                         lastTradeDateOrContractMonth=contract_month,
-                        exchange=config.get('exchange', 'NYBOT')
+                        exchange=config['exchange']
                     )
                     try:
                         await asyncio.wait_for(ib.qualifyContractsAsync(underlying_contract), timeout=15)
@@ -1713,7 +1713,7 @@ async def run_position_audit_cycle(config: dict, trigger_source: str = "Schedule
         active_futures_cache = {}
         try:
             symbol = config.get('symbol', 'KC')
-            exchange = config.get('exchange', 'NYBOT')
+            exchange = config['exchange']
 
             # === K1 FIX: Check cache validity before use ===
             cached_futures = active_futures_cache.get(symbol)
@@ -4914,6 +4914,9 @@ async def main(commodity_ticker: str = None):
     config['data_dir'] = data_dir
     config['symbol'] = ticker
     config.setdefault('commodity', {})['ticker'] = ticker
+    # Inject exchange from commodity profile (NG→NYMEX, KC/CC→NYBOT).
+    from trading_bot.utils import get_ibkr_exchange
+    config['exchange'] = get_ibkr_exchange(config)
     # is_primary is set by CommodityEngine._build_config() in multi-engine mode.
     # In legacy single-engine mode, it defaults to True (the guard default).
 

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -158,7 +158,7 @@ async def test_reconcile_council_history_pnl_calc(reconciliation_patches):
          patch('pandas.DataFrame.to_csv') as mock_to_csv, \
          patch('os.path.exists', side_effect=exists_side_effect):
 
-        await reconcile_council_history({'symbol': 'KC'}, ib=mock_ib)
+        await reconcile_council_history({'symbol': 'KC', 'exchange': 'NYBOT'}, ib=mock_ib)
 
         assert mock_csv_data.iloc[0]['exit_price'] == 145.0
         assert mock_csv_data.iloc[0]['pnl_realized'] == 5.0  # (150 - 145) for Short

--- a/tests/test_risk_management.py
+++ b/tests/test_risk_management.py
@@ -20,7 +20,7 @@ class TestRiskManagement(unittest.TestCase):
     def test_manage_misaligned_positions(self):
         async def run_test():
             ib = AsyncMock()
-            config = {'symbol': 'KC', 'strategy': {}}
+            config = {'symbol': 'KC', 'exchange': 'NYBOT', 'strategy': {}}
             signal = {'prediction_type': 'DIRECTIONAL', 'direction': 'BULLISH'}
             future_contract = Future(conId=100, symbol='KC', lastTradeDateOrContractMonth='202512')
             leg1 = ComboLeg(conId=1, ratio=1, action='BUY', exchange='NYBOT')
@@ -47,7 +47,7 @@ class TestRiskManagement(unittest.TestCase):
     def test_manage_aligned_positions(self):
         async def run_test():
             ib = AsyncMock()
-            config = {'symbol': 'KC'}
+            config = {'symbol': 'KC', 'exchange': 'NYBOT'}
             signal = {'prediction_type': 'DIRECTIONAL', 'direction': 'BULLISH'}
             future_contract = Future(conId=100, symbol='KC', lastTradeDateOrContractMonth='202512')
             leg1 = ComboLeg(conId=1, ratio=1, action='BUY', exchange='NYBOT')
@@ -87,6 +87,8 @@ class TestRiskManagement(unittest.TestCase):
             ib.placeOrder.return_value = mock_trade
 
             config = {
+                'symbol': 'KC',
+                'exchange': 'NYBOT',
                 'notifications': {},
                 'risk_management': {
                     'stop_loss_pct': 0.20,

--- a/tests/test_risk_management_edge_cases.py
+++ b/tests/test_risk_management_edge_cases.py
@@ -39,6 +39,7 @@ class TestRiskManagementEdgeCases(unittest.TestCase):
             # Config
             config = {
                 'symbol': 'KC',
+                'exchange': 'NYBOT',
                 'notifications': {},
                 'risk_management': {
                     'stop_loss_max_risk_pct': 0.50,
@@ -93,6 +94,7 @@ class TestRiskManagementEdgeCases(unittest.TestCase):
 
             config = {
                 'symbol': 'KC',
+                'exchange': 'NYBOT',
                 'notifications': {},
                 'risk_management': {
                     'stop_loss_pct': 0.50,

--- a/tests/test_sentinels.py
+++ b/tests/test_sentinels.py
@@ -62,7 +62,7 @@ async def test_price_sentinel_no_trigger():
             mock_contract = MagicMock()
             mock_futures.return_value = [mock_contract]
 
-            config = {'sentinels': {'price': {'pct_change_threshold': 1.5}}}
+            config = {'sentinels': {'price': {'pct_change_threshold': 1.5}}, 'symbol': 'KC', 'exchange': 'NYBOT'}
             sentinel = PriceSentinel(config, mock_ib)
 
             trigger = await sentinel.check()
@@ -77,7 +77,7 @@ async def test_price_sentinel_market_closed():
         mock_now = datetime(2023, 10, 22, 14, 0, 0, tzinfo=timezone.utc) # Sunday
         mock_datetime.now.return_value = mock_now
 
-        config = {'sentinels': {'price': {'pct_change_threshold': 1.5}}}
+        config = {'sentinels': {'price': {'pct_change_threshold': 1.5}}, 'symbol': 'KC', 'exchange': 'NYBOT'}
         sentinel = PriceSentinel(config, mock_ib)
 
         trigger = await sentinel.check()

--- a/trading_bot/calendars.py
+++ b/trading_bot/calendars.py
@@ -33,6 +33,7 @@ def get_exchange_calendar(exchange: str) -> AbstractHolidayCalendar:
         'ICE': ICEHolidayCalendar,
         'NYBOT': ICEHolidayCalendar,
         'CME': USFederalHolidayCalendar,  # Approximation
+        'NYMEX': USFederalHolidayCalendar,  # CME Group
     }
     cal_class = calendars.get(exchange, USFederalHolidayCalendar)
     return cal_class()

--- a/trading_bot/commodity_engine.py
+++ b/trading_bot/commodity_engine.py
@@ -73,6 +73,10 @@ class CommodityEngine:
         config['data_dir'] = self.data_dir
         config['symbol'] = self.ticker
         config.setdefault('commodity', {})['ticker'] = self.ticker
+        # Inject exchange from commodity profile so all config.get('exchange')
+        # calls resolve correctly (NG→NYMEX, KC/CC→NYBOT).
+        from trading_bot.utils import get_ibkr_exchange
+        config['exchange'] = get_ibkr_exchange(config)
         # Primary commodity owns account-wide equity tracking (NetLiquidation).
         # Non-primary commodities skip equity snapshots to avoid duplicate data.
         if self.shared.active_commodities:

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -841,7 +841,7 @@ async def _handle_and_log_fill(ib: IB, trade: Trade, fill: Fill, combo_id: int, 
                             future_contract = Future(
                                 symbol=config.get('symbol', 'KC'),
                                 lastTradeDateOrContractMonth=contract_month,
-                                exchange=config.get('exchange', 'NYBOT')
+                                exchange=config['exchange']
                             )
                             # Define a quick fetch with timeout
                             async def _quick_fetch(c):
@@ -1856,7 +1856,7 @@ async def close_stale_positions(config: dict, connection_purpose: str = "orchest
         return
 
     from trading_bot.calendars import get_exchange_calendar
-    cal = get_exchange_calendar(config.get('exchange', 'ICE'))
+    cal = get_exchange_calendar(config['exchange'])
 
     # Check if today is Friday
     if weekday == 4:
@@ -1953,7 +1953,7 @@ async def close_stale_positions(config: dict, connection_purpose: str = "orchest
 
         # --- 3. Calculate trading day logic ---
         # M4 FIX: Use Exchange Holiday Calendar
-        cal = get_exchange_calendar(config.get('exchange', 'ICE'))
+        cal = get_exchange_calendar(config['exchange'])
         holidays = cal.holidays(start=date(date.today().year - 1, 1, 1), end=date.today()).to_pydatetime().tolist()
         today = datetime.now(timezone.utc).date()
         custom_bday = pd.offsets.CustomBusinessDay(holidays=holidays)

--- a/trading_bot/reconciliation.py
+++ b/trading_bot/reconciliation.py
@@ -139,7 +139,7 @@ def _calculate_actual_exit_time(entry_time: datetime, config: dict) -> datetime:
     entry_ny = entry_time.astimezone(ny_tz)
 
     # Build exchange holiday set
-    cal = get_exchange_calendar(config.get('exchange', 'ICE'))
+    cal = get_exchange_calendar(config['exchange'])
     entry_year = entry_ny.year
     exchange_holidays = set()
     for year in {entry_year, entry_year + 1}:
@@ -309,7 +309,7 @@ async def _process_reconciliation(ib: IB, df: pd.DataFrame, config: dict, file_p
                 contract = Contract()
                 contract.symbol = config.get('symbol', 'KC')
                 contract.secType = 'FUT'
-                contract.exchange = config.get('exchange', 'NYBOT')
+                contract.exchange = config['exchange']
                 contract.currency = 'USD'
                 contract.lastTradeDateOrContractMonth = last_trade_date
                 contract.includeExpired = True

--- a/trading_bot/risk_management.py
+++ b/trading_bot/risk_management.py
@@ -377,7 +377,7 @@ async def _execute_risk_closure(ib: IB, config: dict, combo_legs: list, reason: 
         contract.symbol = config.get('symbol', 'KC')
         contract.secType = "BAG"
         contract.currency = "USD"
-        contract.exchange = config.get('exchange', 'NYBOT')
+        contract.exchange = config['exchange']
 
         combo_legs_list = []
         for leg_pos in combo_legs:
@@ -393,7 +393,7 @@ async def _execute_risk_closure(ib: IB, config: dict, combo_legs: list, reason: 
                 conId=leg_pos.contract.conId,
                 ratio=leg_qty,  # v3.1: Use actual position size
                 action=action,
-                exchange=config.get('exchange', 'NYBOT')
+                exchange=config['exchange']
             ))
 
         contract.comboLegs = combo_legs_list

--- a/trading_bot/sentinels.py
+++ b/trading_bot/sentinels.py
@@ -335,7 +335,7 @@ class PriceSentinel(Sentinel):
         self.sentinel_config = config.get('sentinels', {}).get('price', {})
         self.pct_change_threshold = self.sentinel_config.get('pct_change_threshold', 1.5)
         self.symbol = config.get('symbol', 'KC')
-        self.exchange = config.get('exchange', 'NYBOT')
+        self.exchange = config['exchange']
 
     async def check(self, cached_contract=None) -> Optional[SentinelTrigger]:
         # Guard: Check connection before doing anything

--- a/trading_bot/utils.py
+++ b/trading_bot/utils.py
@@ -921,7 +921,7 @@ def hours_until_weekly_close(config: dict = None) -> float:
     CLOSE_HOUR, CLOSE_MINUTE = get_effective_close_time(config)
 
     # Build holiday set
-    profile_exchange = config.get('exchange', 'ICE') if config else 'ICE'
+    profile_exchange = config.get('exchange', 'ICE') if config else 'ICE'  # Fallback needed: config may be None
     cal = get_exchange_calendar(profile_exchange)
 
     exchange_holidays = set()


### PR DESCRIPTION
## Summary
- **P0 Fix**: NG engine was completely non-functional since launch — every 60s it attempted `Future(symbol='NG', exchange='NYBOT')` causing IBKR Error 200 (126+ errors/day)
- **Root cause**: `config.json` base has `exchange: "NYBOT"` (for KC/CC). NG's `commodity_overrides` didn't include an exchange key, so `deep_merge()` inherited NYBOT instead of NYMEX
- **Fix A (Immediate)**: `CommodityEngine._build_config()` and `orchestrator.main()` now inject `config['exchange']` via `get_ibkr_exchange()` at startup — resolves NG→NYMEX from the commodity profile
- **Fix B (Structural)**: Replaced all `config.get('exchange', 'NYBOT')` with `config['exchange']` across 8 modules — eliminates the class of bugs where future commodities (CL, GC) would inherit KC's exchange
- Added NYMEX to calendar map (CME Group holidays)

## Files Changed (12)
| File | Change |
|------|--------|
| `trading_bot/commodity_engine.py` | Inject exchange in `_build_config()` |
| `orchestrator.py` | Inject exchange in `main()` + remove 3 hardcoded defaults |
| `trading_bot/order_manager.py` | 3× NYBOT/ICE default → `config['exchange']` |
| `trading_bot/risk_management.py` | 2× NYBOT default → `config['exchange']` |
| `trading_bot/reconciliation.py` | 2× NYBOT/ICE default → `config['exchange']` |
| `trading_bot/sentinels.py` | 1× NYBOT default → `config['exchange']` |
| `trading_bot/calendars.py` | Add NYMEX to calendar map |
| `trading_bot/utils.py` | Comment clarifying config-can-be-None case |
| 4 test files | Add `'exchange': 'NYBOT'` to test configs |

## Test plan
- [x] 635 tests pass, 0 failures
- [x] Verified `get_ibkr_exchange()` returns KC→NYBOT, CC→NYBOT, NG→NYMEX
- [x] Zero remaining `config.get('exchange', 'NYBOT')` in production code
- [ ] After deploy: verify NG logs show `exchange='NYMEX'` and Error 200 stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)