### PR TITLE
Fix Yahoo Finance rollover gaps in dashboard charts

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -395,7 +395,7 @@ if not equity_df.empty:
         from config import get_active_profile
         profile = get_active_profile(config) if config else None
         if profile:
-            benchmark_col = f"{profile.ticker}=F"
+            benchmark_col = profile.ticker
             if benchmark_col in benchmark_df.columns:
                 fig_bm.add_trace(go.Scatter(
                     x=benchmark_df.index,

--- a/pages/1_Cockpit.py
+++ b/pages/1_Cockpit.py
@@ -995,8 +995,7 @@ if config:
         if _bi + 1 >= len(bench_cols):
             break
         with bench_cols[_bi + 1]:
-            _yf = f"{_bt}=F"
-            _pct = benchmarks.get(_yf, 0)
+            _pct = benchmarks.get(_bt, 0)
             # Highlight selected commodity
             _label = f"**{_bt}**" if _bt == ticker else _bt
             st.metric(_label, f"{_pct:+.2f}%")


### PR DESCRIPTION
## Summary

Yahoo Finance's continuous `=F` tickers have broken automated rollover dates. During contract transitions, the chart shows stale/zero-volume data for several days. This caused missing price data on Feb 20-23 in dashboard charts (the March KC contract expired but Yahoo hadn't rolled to May yet).

**Fix:** Use specific front-month contract tickers (e.g. `KCK26.NYB` instead of `KC=F`) which always have active trading data.

- New `resolve_yf_ticker()` helper in `dashboard_utils.py` — resolves commodity ticker to active front-month contract using the same DTE rules as the trading system
- Updated `fetch_todays_benchmark_data()` and `fetch_benchmark_data()` to use specific contracts
- Return data keyed by commodity ticker (`KC`, `CC`, `NG`) not yfinance format, so consumers don't need to know about yf internals
- Updated Cockpit benchmark display and dashboard.py Financials chart to use new key format

Note: Signal Overlay already had `resolve_front_month_ticker()` doing the same thing — this extends the pattern to all dashboard pages.

## Files Changed (3)

| File | Change |
|------|--------|
| `dashboard_utils.py` | Add `resolve_yf_ticker()`, update both benchmark functions |
| `pages/1_Cockpit.py` | Use commodity ticker key instead of `{ticker}=F` |
| `dashboard.py` | Use commodity ticker key for benchmark column |

## Test plan
- [x] 635 tests pass, 0 failures
- [x] `resolve_yf_ticker()` returns: KC→KCK26.NYB, CC→CCK26.NYB, NG→NGH26.NYM
- [ ] After deploy: dashboard charts show data for all recent trading days

🤖 Generated with [Claude Code](https://claude.com/claude-code)