### PR TITLE
Fix X API 'arabica prices' query rejected for 12 days

### DIFF
--- a/config/commodity_profiles.py
+++ b/config/commodity_profiles.py
@@ -430,7 +430,7 @@ COFFEE_ARABICA_PROFILE = CommodityProfile(
 
     sentiment_search_queries=[
         "coffee futures",
-        "arabica prices",
+        "arabica coffee market",
         "KC futures",
         "robusta market",
         "coffee supply",

--- a/tests/test_x_sentinel.py
+++ b/tests/test_x_sentinel.py
@@ -16,7 +16,7 @@ def mock_config():
         'sentinels': {
             'x_sentiment': {
                 'model': 'grok-4-1-fast-reasoning',
-                'search_queries': ['coffee futures', 'arabica prices'],
+                'search_queries': ['coffee futures', 'arabica coffee market'],
                 'sentiment_threshold': 6.5,
                 'min_engagement': 5,
                 'volume_spike_multiplier': 2.0,


### PR DESCRIPTION
## Summary
- Replace `"arabica prices"` → `"arabica coffee market"` in KC sentiment search queries
- The bare `"arabica prices"` query has been rejected by X's API since Feb 12 (184 errors logged), while other queries like `"coffee futures"` work fine
- System degrades gracefully (uses working queries) but wastes ~15 API calls/day on guaranteed failures

## Test plan
- [x] `test_x_sentinel.py` — 20 passed
- [x] `test_sentinels.py` — passed
- [x] Verified profile loads with updated query

🤖 Generated with [Claude Code](https://claude.com/claude-code)