### PR TITLE
Backfill intraday chart gaps + liquidity filter observability

### DIFF
--- a/trading_bot/ib_interface.py
+++ b/trading_bot/ib_interface.py
@@ -428,10 +428,16 @@ async def create_combo_order_object(ib: IB, config: dict, strategy_def: dict) ->
 
     # Liquidity Filter: Check if the market spread is too wide relative to the theoretical price
     if net_theoretical_price > 0 and (market_spread / net_theoretical_price) > max_spread_pct:
+        from datetime import datetime, timezone
+        _spread_pct = market_spread / net_theoretical_price
+        _hour_utc = datetime.now(timezone.utc).hour
+        _contract_sym = chain.get('tradingClass', config.get('symbol', '?'))
         logging.warning(
             f"LIQUIDITY FILTER FAILED: Market spread ({market_spread:.2f}) is "
-            f"{(market_spread / net_theoretical_price):.1%} of theoretical price ({net_theoretical_price:.2f}), "
-            f"which exceeds the max of {max_spread_pct:.1%}. Aborting order."
+            f"{_spread_pct:.1%} of theoretical price ({net_theoretical_price:.2f}), "
+            f"which exceeds the max of {max_spread_pct:.1%}. Aborting order. "
+            f"[liquidity_metric: contract={_contract_sym}, expiry={exp_details.get('exp_date', '?')}, "
+            f"spread_pct={_spread_pct:.3f}, hour_utc={_hour_utc}]"
         )
         return None
 


### PR DESCRIPTION
## Summary
- **Signal Overlay gap fix**: yfinance sometimes has 1d data for dates where 5m data is unavailable (e.g. Feb 20, Feb 23). When this happens, splice daily candles at market open time so signals on those dates still render on the chart instead of showing "27 signal(s) not shown"
- **Liquidity filter observability**: Add structured `[liquidity_metric: contract=OKC, expiry=2026-05-08, spread_pct=4.750, hour_utc=14]` to the LIQUIDITY FILTER FAILED log line for time-of-day analysis after 2-4 weeks of data collection

## Context
The 45% liquidity threshold correctly protects against adverse fills. KC spreads drop from 475% at open to passable by mid-session, suggesting time-of-day awareness may be warranted — but we need data first.

## Test plan
- [x] Verified `KCK26.NYB` 5m data missing Feb 20 + Feb 23, 1d data has them → backfill correct
- [x] Syntax check on Signal Overlay page passes
- [x] `test_ib_interface.py` — 9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)