### PR TITLE
Fix PredictionMarket sub-market rotation + NG weather stage labels

### DIFF
--- a/config/commodity_profiles.py
+++ b/config/commodity_profiles.py
@@ -723,9 +723,9 @@ def _load_profile_from_json(path: str) -> CommodityProfile:
             historical_weekly_precip_mm=r.get('historical_weekly_precip_mm', 60.0),
             drought_threshold_mm=r.get('drought_threshold_mm', 30.0),
             flood_threshold_mm=r.get('flood_threshold_mm', 150.0),
-            flowering_months=r.get('flowering_months', [9, 10, 11]),
-            harvest_months=r.get('harvest_months', [5, 6, 7, 8]),
-            bean_filling_months=r.get('bean_filling_months', [12, 1, 2, 3]),
+            flowering_months=r.get('flowering_months', []),
+            harvest_months=r.get('harvest_months', []),
+            bean_filling_months=r.get('bean_filling_months', []),
 
             # Legacy/Optional
             planting_months=r.get('planting_months', []),


### PR DESCRIPTION
## Summary
- **PredictionMarketSentinel sub-market rotation bug**: When a multi-outcome Polymarket event has liquidity shift between sub-markets (e.g., "Cut-Pause-Pause" → "Other"), the sentinel was computing a delta between different sub-markets, producing phantom 94.5% crash alerts. Now tracks `market_id` in state cache and resets baseline on sub-market change instead of triggering.
- **NG Weather growth stage fix**: JSON loader used coffee-specific defaults (`flowering_months=[9,10,11]`, `bean_filling_months=[12,1,2,3]`) for profiles loaded from JSON. NG gas regions were labeled "BEAN_FILLING" which affected severity scoring (CRITICAL vs HIGH) and direction (BULLISH/BEARISH) — not just cosmetic.
- **Production cleanup**: Removed 3 false PredictionMarket deferred triggers from KC/CC/NG queues that would have fired unnecessary emergency cycles at market open.

## What was happening
The Fed decisions (Dec-Mar) topic has 9 sub-markets. Previously tracked "Cut-Pause-Pause" at 95.5% (liquidity ~28k). "Other" sub-market grew to 32k liquidity, got selected, price=0.009. Delta computed as 0.009 - 0.955 = -94.6% → severity 9 on all 3 engines.

## Test plan
- [x] `test_sentinels.py` — 18 passed
- [x] Full suite — 635 passed, 0 failures
- [x] Verified KC/CC profiles unaffected (hardcoded, not JSON-loaded)
- [x] Verified NG regions now get empty flowering/bean_filling months
- [x] Production deferred triggers cleaned (3 false removed, 4 legitimate preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)