### PR TITLE
Fix _fetch_by_slug **kwargs regression from sub-market pinning

### DIFF
--- a/trading_bot/sentinels.py
+++ b/trading_bot/sentinels.py
@@ -1878,7 +1878,7 @@ class PredictionMarketSentinel(Sentinel):
 
         return False
 
-    async def _fetch_by_slug(self, slug: str) -> Optional[Dict[str, Any]]:
+    async def _fetch_by_slug(self, slug: str, **kwargs) -> Optional[Dict[str, Any]]:
         """
         Fetch a specific Polymarket event by slug.
         Used for slug pinning — avoids re-searching the API.


### PR DESCRIPTION
## Summary
- **Hotfix**: `_fetch_by_slug()` was missing `**kwargs` in its method signature, so the `pinned_market_id` kwarg from PR #1051 caused `TypeError` on every call — making the PredictionMarketSentinel completely blind across all 3 engines (safe but unable to poll any topics)
- **Production cleanup**: Removed stale BEAN_FILLING deferred trigger from NG queue (created before the weather fix in #1051)

## Test plan
- [x] `test_sentinels.py` + `test_prediction_market_sentinel.py` — 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)