### PR TITLE
Fix ICE zero-price bars + Databento cost optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ scripts/snapshot_data.sh
 archive_ledger
 *.csv
 macro_contagion_state.json
+data/databento_cache/


### PR DESCRIPTION
## Summary

- **Filter zero-price bars** from Databento ICE data (`KC`, `CC`) — ICE's `IFUS.IMPACT` dataset includes non-trading period bars (session boundaries, pre-open, settlement) where OHLCV = 0, causing charts to plunge to $0 with -100% period change. CME/NG unaffected.
- **Flip provider order**: yfinance (free) is now primary, Databento is surgical gap-fill only. ICE data costs ~$500/GB — dashboard reloads across 3 commodities were adding up fast.
- **Persistent disk cache** (`data/databento_cache/` — per-day parquet files): each missing trading day is fetched from Databento once and cached forever. Second load = zero API cost.
- **Exchange-aware gap detection**: uses `calendars.is_trading_day()` so ICE holidays (Good Friday) and CME holidays are handled correctly.

## Test plan

- [x] 637 tests pass (`pytest tests/ -x -q`)
- [x] Zero-price filter verified on simulated ICE data (4 zero bars dropped, 6 valid bars kept)
- [x] Gap detection verified against exchange calendar
- [x] Disk cache path generation verified
- [x] All 4 source labels verified: `yfinance (free)`, `yfinance + Databento gap-fill (N days)`, `Databento (licensed)`, `No data source available`
- [ ] Production verification: KC/CC charts no longer show $0 bars
- [ ] Production verification: dashboard reloads use yfinance (check logs for absence of Databento API calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)