### PR TITLE
Fix Signal Overlay Y-axis scaling for NG charts

### DIFF
--- a/pages/6_Signal_Overlay.py
+++ b/pages/6_Signal_Overlay.py
@@ -941,6 +941,11 @@ if price_df is not None and not price_df.empty:
                 plot_df['candle_low'] * 0.997
             )
 
+            # Clip signal positions to visible price range so outliers can't stretch the Y-axis
+            price_floor = price_df['Low'].min() * 0.995
+            price_ceil = price_df['High'].max() * 1.005
+            plot_df['y_pos'] = plot_df['y_pos'].clip(lower=price_floor, upper=price_ceil)
+
             plot_df['text_pos'] = np.where(
                 plot_df['marker_symbol'] == 'triangle-up',
                 "top center",
@@ -1267,7 +1272,9 @@ if price_df is not None and not price_df.empty:
         row=2, col=1
     )
 
-    # Row 1 Y-axis - CRITICAL: Set explicit range to prevent candlestick disappearing on short lookbacks
+    # Row 1 Y-axis - Set explicit range from price data only.
+    # autorange=False is critical: without it, Plotly can stretch the axis to
+    # accommodate outlier signal markers that fall outside the price range.
     if not price_df.empty:
         y_min = price_df['Low'].min()
         y_max = price_df['High'].max()
@@ -1277,6 +1284,7 @@ if price_df is not None and not price_df.empty:
         fig.update_yaxes(
             title_text=f"Price ({profile.name})",
             range=[y_min - y_buffer, y_max + y_buffer],
+            autorange=False,
             row=1, col=1
         )
     else:


### PR DESCRIPTION
## Summary

- **NG candlesticks appeared as thin lines** because an outlier signal marker at ~$3.60 was stretching the Y-axis (actual price range: $2.90-$3.15), compressing all candles into ~25% of the vertical space
- **Root cause**: Plotly's autorange was overriding the explicit `range=` setting when scatter trace data points fell outside the price-based range
- **Fix 1**: Add `autorange=False` to the Y-axis update so Plotly can't stretch beyond the price range
- **Fix 2**: Clip signal `y_pos` values to within the visible price range (0.5% buffer) so outlier markers sit at the chart edge instead of stretching the axis

Affects all commodities, most visible on NG due to lower absolute prices where small axis stretches have outsized visual impact.

## Test plan

- [x] 637 tests pass
- [ ] NG chart candles fill the vertical space properly
- [ ] KC and CC charts unaffected (signals already within range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)