### PR TITLE
Fix 7 production issues: PANIC recovery, phantom ledger, liquidity thresholds

### DIFF
--- a/config.json
+++ b/config.json
@@ -76,7 +76,9 @@
     "enabled": true,
     "warning_pct": 1.5,
     "halt_pct": 2.5,
-    "panic_pct": 4.0
+    "panic_pct": 4.0,
+    "recovery_pct": 3.0,
+    "recovery_hold_minutes": 30
   },
   "notifications": {
     "enabled": true,
@@ -450,7 +452,7 @@
 
       "supply_chain": "You are a Supply Chain Analyst. \n\nYOUR GOAL: Analyze STRUCTURAL EXPORT FLOW and BASIS SHIFTS.\n\nOPERATIONAL RULES:\n1. DATA SOURCES: Focus on 'Cecafé Export Reports', 'Shipping Manifest Volumes', and 'Container Availability Indices'.\n2. DIFFERENTIATION: The Sentinel tracks *active* disruptions (Strikes). YOU track *structural* flow issues (e.g. lack of containers, bumper crop overwhelming ports).\n3. SIGNAL: High Export Volume + Low Container Availability = Bullish (Basis Widening). Record Exports = Bearish (Supply Flood).\n4. CONFIDENCE LEVEL (use EXACTLY one):\n   - 'LOW': Weak signal, conflicting data, low conviction. (Default if unsure.)\n   - 'MODERATE': One clear signal supported by evidence.\n   - 'HIGH': Strong signal with multiple corroborating data points.\n   - 'EXTREME': Overwhelming, unambiguous evidence (rare — use sparingly).\n5. FORMAT: [EVIDENCE] (Cite raw data), [ANALYSIS] (Step 1: List 'BULLISH DRIVERS'. Step 2: List 'BEARISH DRIVERS'. Step 3: Weigh them.), [SENTIMENT TAG] (Must align with Step 3).",
 
-      "inventory": "You are a purely quantitative Inventory Analyst. \n\nYOUR GOAL: Track CERTIFIED STOCKS.\n\nOPERATIONAL RULES:\n1. DATA SOURCES: ICE Certified Stocks, GCA Warehouse Counts.\n2. SIGNAL: Stocks Drawing Down = Bullish. Stocks Building Up = Bearish.\n3. GRADING: Watch for 'Grading Pass Rate'. Low pass rate = Bullish (Tight Quality).\n4. CONFIDENCE LEVEL (use EXACTLY one):\n   - 'LOW': Weak signal, conflicting data, low conviction. (Default if unsure.)\n   - 'MODERATE': One clear signal supported by evidence.\n   - 'HIGH': Strong signal with multiple corroborating data points.\n   - 'EXTREME': Overwhelming, unambiguous evidence (rare — use sparingly).\n5. FORMAT: [EVIDENCE], [ANALYSIS], [SENTIMENT TAG].",
+      "inventory": "You are a purely quantitative Inventory Analyst. \n\nYOUR GOAL: Track CERTIFIED STOCKS.\n\nOPERATIONAL RULES:\n1. DATA SOURCES: ICE Certified Stocks, GCA Warehouse Counts.\n2. SIGNAL: Stocks Drawing Down = Bullish. Stocks Building Up = Bearish.\n3. GRADING: Watch for 'Grading Pass Rate'. Low pass rate = Bullish (Tight Quality).\n4. CONFIDENCE LEVEL (use EXACTLY one):\n   - 'LOW': Weak signal, conflicting data, low conviction. (Default if unsure.)\n   - 'MODERATE': One clear signal supported by evidence.\n   - 'HIGH': Strong signal with multiple corroborating data points.\n   - 'EXTREME': Overwhelming, unambiguous evidence (rare — use sparingly).\n5. FORMAT: [EVIDENCE], [ANALYSIS], [SENTIMENT TAG].\n\nANTI-HALLUCINATION RULES:\n1. ONLY cite numbers that appear in the Grounded Data Packet. If a specific stock level is not in the data, say 'data not available'.\n2. Do NOT invent historical comparisons unless the data explicitly provides them.\n3. Do NOT fabricate GCA warehouse counts or ICE certified stock numbers.\n4. If the Grounded Data Packet contains no inventory-specific data, set confidence to LOW and sentiment to NEUTRAL.",
 
       "macro": "You are a Macro-Currency Strategist. \n\nYOUR GOAL: Analyze the RATE OF CHANGE in USD/BRL.\n\nOPERATIONAL RULES:\n1. CITATIONS REQUIRED: Quote specific bank/report for forecasts.\n2. CURRENCY VELOCITY: Sudden spikes (>1% in 24h) trigger farmer selling. Slow drift is priced in.\n3. FARMER PSYCHOLOGY: Farmers sell when BRL weakens *rapidly* to lock in local currency gains.\n4. SENTIMENT RULE: Weaker BRL = BEARISH for Coffee Prices (Supply Push). Stronger BRL = BULLISH.\n5. CONFIDENCE LEVEL (use EXACTLY one):\n   - 'LOW': Weak signal, conflicting data, low conviction. (Default if unsure.)\n   - 'MODERATE': One clear signal supported by evidence.\n   - 'HIGH': Strong signal with multiple corroborating data points.\n   - 'EXTREME': Overwhelming, unambiguous evidence (rare — use sparingly).\n6. FORMAT: [EVIDENCE], [ANALYSIS], [SENTIMENT TAG].",
 
@@ -601,6 +603,13 @@
     "max_concurrent_calls": 4
   },
   "commodity_overrides": {
+    "KC": {
+      "strategy_tuning": {
+        "max_liquidity_spread_percentage": 1.25,
+        "cap_timeout_seconds": 1800,
+        "monitoring_duration_seconds": 2400
+      }
+    },
     "CC": {
       "commodity": {
         "ticker": "CC",
@@ -611,6 +620,11 @@
       },
       "risk_management": {
         "max_open_positions": 3
+      },
+      "strategy_tuning": {
+        "max_liquidity_spread_percentage": 0.50,
+        "cap_timeout_seconds": 900,
+        "monitoring_duration_seconds": 1800
       }
     },
     "NG": {
@@ -623,6 +637,11 @@
       },
       "risk_management": {
         "max_open_positions": 3
+      },
+      "strategy_tuning": {
+        "max_liquidity_spread_percentage": 0.35,
+        "cap_timeout_seconds": 900,
+        "monitoring_duration_seconds": 1800
       }
     }
   }

--- a/tests/test_drawdown_recovery.py
+++ b/tests/test_drawdown_recovery.py
@@ -1,0 +1,398 @@
+"""
+Tests for PANIC/HALT recovery de-escalation in DrawdownGuard and PortfolioRiskGuard.
+
+Covers:
+1. Status sticks during active drawdown (no recovery)
+2. Recovery timer starts when drawdown improves below threshold
+3. Recovery timer resets when drawdown worsens
+4. Recovery completes after hold period → de-escalate to WARNING
+5. Pushover notification sent on recovery
+6. Daily reset clears recovery timer
+7. Backward-compatible state loading (no recovery_start key)
+8. PortfolioRiskGuard mirrors DrawdownGuard recovery behavior
+"""
+
+import asyncio
+import json
+import os
+import tempfile
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# DrawdownGuard Tests
+# ---------------------------------------------------------------------------
+
+class TestDrawdownGuardRecovery:
+    """Tests for recovery logic in DrawdownGuard."""
+
+    def _make_guard(self, tmpdir, status="PANIC", drawdown=-4.5, starting_equity=100000):
+        """Create a DrawdownGuard with pre-set state."""
+        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+
+        data_dir = str(tmpdir)
+        config = {
+            'drawdown_circuit_breaker': {
+                'enabled': True,
+                'warning_pct': 1.5,
+                'halt_pct': 2.5,
+                'panic_pct': 4.0,
+                'recovery_pct': 3.0,
+                'recovery_hold_minutes': 30,
+            },
+            'notifications': {'enabled': False},
+            'data_dir': data_dir,
+        }
+
+        # Pre-write state so constructor loads it
+        state_file = os.path.join(data_dir, 'drawdown_state.json')
+        os.makedirs(data_dir, exist_ok=True)
+        state = {
+            "status": status,
+            "current_drawdown_pct": drawdown,
+            "starting_equity": starting_equity,
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "date": datetime.now(timezone.utc).date().isoformat(),
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        guard = DrawdownGuard(config)
+        return guard
+
+    def _mock_ib(self, net_liq):
+        """Create a mock IB that returns the given NetLiquidation."""
+        ib = MagicMock()
+        summary_item = MagicMock()
+        summary_item.tag = 'NetLiquidation'
+        summary_item.currency = 'USD'
+        summary_item.value = str(net_liq)
+        ib.accountSummaryAsync = AsyncMock(return_value=[summary_item])
+        return ib
+
+    @pytest.mark.asyncio
+    async def test_sticks_during_active_drawdown(self, tmp_path):
+        """PANIC status should stick when drawdown is still severe."""
+        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        ib = self._mock_ib(95000)  # -5% drawdown, still bad
+
+        result = await guard.update_pnl(ib)
+
+        assert result == "PANIC"
+        assert guard._recovery_start is None
+
+    @pytest.mark.asyncio
+    async def test_halt_sticks_during_active_drawdown(self, tmp_path):
+        """HALT status should stick when drawdown is still above recovery threshold."""
+        guard = self._make_guard(tmp_path, status="HALT", starting_equity=100000)
+        ib = self._mock_ib(96500)  # -3.5% drawdown, above recovery_pct=3% but below panic_pct=4%
+
+        result = await guard.update_pnl(ib)
+
+        assert result == "HALT"
+        assert guard._recovery_start is None
+
+    @pytest.mark.asyncio
+    async def test_recovery_timer_starts(self, tmp_path):
+        """Recovery timer should start when drawdown improves below recovery_pct."""
+        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        ib = self._mock_ib(98000)  # -2% drawdown, below recovery_pct=3%
+
+        result = await guard.update_pnl(ib)
+
+        assert result == "PANIC"  # Still holds during observation
+        assert guard._recovery_start is not None
+
+    @pytest.mark.asyncio
+    async def test_recovery_timer_resets_on_worsening(self, tmp_path):
+        """Recovery timer should reset if drawdown worsens again."""
+        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        guard._recovery_start = datetime.now(timezone.utc).isoformat()
+
+        # Drawdown worsens back to -4% (abs > recovery_pct=3%)
+        ib = self._mock_ib(96000)
+
+        result = await guard.update_pnl(ib)
+
+        assert result == "PANIC"
+        assert guard._recovery_start is None
+
+    @pytest.mark.asyncio
+    async def test_recovery_completes_after_hold_period(self, tmp_path):
+        """After sustained improvement for hold period, should de-escalate to WARNING."""
+        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        # Set recovery_start to 31 minutes ago
+        guard._recovery_start = (
+            datetime.now(timezone.utc) - timedelta(minutes=31)
+        ).isoformat()
+
+        ib = self._mock_ib(98000)  # -2% drawdown, below recovery_pct=3%
+
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification') as mock_notify:
+            result = await guard.update_pnl(ib)
+
+        assert result == "WARNING"
+        assert guard._recovery_start is None
+        # Recovery notification is the first call (status-change notification may also fire)
+        assert mock_notify.call_count >= 1
+        recovery_call = mock_notify.call_args_list[0]
+        assert "Recovery" in recovery_call[0][1]
+
+    @pytest.mark.asyncio
+    async def test_recovery_notification_sent(self, tmp_path):
+        """Pushover notification should be sent when recovery completes."""
+        guard = self._make_guard(tmp_path, status="HALT", starting_equity=100000)
+        guard._recovery_start = (
+            datetime.now(timezone.utc) - timedelta(minutes=45)
+        ).isoformat()
+
+        ib = self._mock_ib(98500)  # -1.5% drawdown
+
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification') as mock_notify:
+            result = await guard.update_pnl(ib)
+
+        assert result == "WARNING"
+        # Recovery notification is the first call
+        assert mock_notify.call_count >= 1
+        recovery_call = mock_notify.call_args_list[0]
+        title = recovery_call[0][1]
+        body = recovery_call[0][2]
+        assert "HALT" in title
+        assert "WARNING" in title
+        assert "resumed with caution" in body
+
+    def test_daily_reset_clears_recovery_timer(self, tmp_path):
+        """Daily reset should clear recovery timer."""
+        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        guard._recovery_start = datetime.now(timezone.utc).isoformat()
+
+        # Simulate new day by changing the state date
+        guard.state['date'] = '1999-01-01'
+        guard._reset_daily()
+
+        assert guard._recovery_start is None
+        assert guard.state['status'] == "NORMAL"
+
+    def test_backward_compatible_state_loading(self, tmp_path):
+        """Old state files without recovery_start should load fine."""
+        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+
+        data_dir = str(tmp_path)
+        state_file = os.path.join(data_dir, 'drawdown_state.json')
+        os.makedirs(data_dir, exist_ok=True)
+        # Old-format state (no recovery_start key)
+        state = {
+            "status": "HALT",
+            "current_drawdown_pct": -3.0,
+            "starting_equity": 100000,
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "date": datetime.now(timezone.utc).date().isoformat(),
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        config = {
+            'drawdown_circuit_breaker': {'enabled': True},
+            'notifications': {},
+            'data_dir': data_dir,
+        }
+        guard = DrawdownGuard(config)
+
+        assert guard.state['status'] == "HALT"
+        assert guard._recovery_start is None
+
+    @pytest.mark.asyncio
+    async def test_halt_to_panic_escalation_still_works(self, tmp_path):
+        """HALT should still escalate to PANIC when drawdown worsens past panic threshold."""
+        guard = self._make_guard(tmp_path, status="HALT", starting_equity=100000)
+        ib = self._mock_ib(95500)  # -4.5% drawdown, past panic_pct=4%
+
+        result = await guard.update_pnl(ib)
+
+        assert result == "PANIC"
+        assert guard._recovery_start is None
+
+    @pytest.mark.asyncio
+    async def test_recovery_state_persisted(self, tmp_path):
+        """Recovery timer should be persisted to disk."""
+        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        ib = self._mock_ib(98000)  # Triggers recovery timer start
+
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+
+        assert guard._recovery_start is not None
+
+        # Read state file and verify recovery_start is saved
+        with open(guard.state_file, 'r') as f:
+            saved = json.load(f)
+        assert 'recovery_start' in saved
+        assert saved['recovery_start'] == guard._recovery_start
+
+
+# ---------------------------------------------------------------------------
+# PortfolioRiskGuard Tests
+# ---------------------------------------------------------------------------
+
+class TestPortfolioRiskGuardRecovery:
+    """Tests for recovery logic in PortfolioRiskGuard."""
+
+    def _make_guard(self, tmpdir, status="PANIC", starting_equity=100000, current_equity=95000):
+        """Create a PortfolioRiskGuard with pre-set state."""
+        from trading_bot.shared_context import PortfolioRiskGuard
+
+        data_dir = str(tmpdir)
+        config = {
+            'data_dir_root': data_dir,
+            'drawdown_circuit_breaker': {
+                'enabled': True,
+                'warning_pct': 1.5,
+                'halt_pct': 2.5,
+                'panic_pct': 4.0,
+                'recovery_pct': 3.0,
+                'recovery_hold_minutes': 30,
+            },
+            'notifications': {'enabled': False},
+        }
+
+        # Pre-write state
+        state_file = os.path.join(data_dir, 'portfolio_risk_state.json')
+        os.makedirs(data_dir, exist_ok=True)
+        state = {
+            "status": status,
+            "peak_equity": starting_equity,
+            "current_equity": current_equity,
+            "starting_equity": starting_equity,
+            "daily_pnl": current_equity - starting_equity,
+            "positions": {},
+            "margin": {},
+            "date": datetime.now(timezone.utc).date().isoformat(),
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        guard = PortfolioRiskGuard(config=config)
+        return guard
+
+    @pytest.mark.asyncio
+    async def test_sticks_during_active_drawdown(self, tmp_path):
+        """PANIC should stick when drawdown is still severe."""
+        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        # equity=95000 → drawdown_pct=5.0%, above recovery_pct=3.0%
+        await guard.update_equity(95000, -5000)
+
+        assert guard._status == "PANIC"
+        assert guard._recovery_start is None
+
+    @pytest.mark.asyncio
+    async def test_recovery_timer_starts(self, tmp_path):
+        """Recovery timer should start when drawdown improves below recovery_pct."""
+        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        # equity=98000 → drawdown_pct=2.0%, below recovery_pct=3.0%
+        await guard.update_equity(98000, -2000)
+
+        assert guard._status == "PANIC"  # Holds during observation
+        assert guard._recovery_start is not None
+
+    @pytest.mark.asyncio
+    async def test_recovery_timer_resets_on_worsening(self, tmp_path):
+        """Recovery timer should reset if drawdown worsens."""
+        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        guard._recovery_start = datetime.now(timezone.utc).isoformat()
+
+        # equity=96000 → drawdown_pct=4.0%, above recovery_pct=3.0%
+        await guard.update_equity(96000, -4000)
+
+        assert guard._status == "PANIC"
+        assert guard._recovery_start is None
+
+    @pytest.mark.asyncio
+    async def test_recovery_completes_after_hold_period(self, tmp_path):
+        """After sustained improvement, should de-escalate to WARNING."""
+        guard = self._make_guard(tmp_path, status="HALT", starting_equity=100000)
+        guard._recovery_start = (
+            datetime.now(timezone.utc) - timedelta(minutes=35)
+        ).isoformat()
+
+        with patch('notifications.send_pushover_notification') as mock_notify:
+            # equity=98000 → drawdown_pct=2.0%, below recovery_pct=3.0%
+            await guard.update_equity(98000, -2000)
+
+        assert guard._status == "WARNING"
+        assert guard._recovery_start is None
+        mock_notify.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_halt_to_panic_escalation(self, tmp_path):
+        """HALT should escalate to PANIC when drawdown exceeds panic threshold."""
+        guard = self._make_guard(tmp_path, status="HALT", starting_equity=100000)
+        # equity=95500 → drawdown_pct=4.5%, above panic_pct=4.0%
+        await guard.update_equity(95500, -4500)
+
+        assert guard._status == "PANIC"
+
+    @pytest.mark.asyncio
+    async def test_backward_compatible_state_loading(self, tmp_path):
+        """Old state files without recovery_start should load fine."""
+        from trading_bot.shared_context import PortfolioRiskGuard
+
+        data_dir = str(tmp_path)
+        state_file = os.path.join(data_dir, 'portfolio_risk_state.json')
+        os.makedirs(data_dir, exist_ok=True)
+        state = {
+            "status": "HALT",
+            "peak_equity": 100000,
+            "current_equity": 97000,
+            "starting_equity": 100000,
+            "daily_pnl": -3000,
+            "positions": {},
+            "margin": {},
+            "date": datetime.now(timezone.utc).date().isoformat(),
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        config = {
+            'data_dir_root': data_dir,
+            'drawdown_circuit_breaker': {'enabled': True},
+            'notifications': {},
+        }
+        guard = PortfolioRiskGuard(config=config)
+
+        assert guard._status == "HALT"
+        assert guard._recovery_start is None
+
+    @pytest.mark.asyncio
+    async def test_recovery_state_persisted(self, tmp_path):
+        """Recovery start time should be saved to disk."""
+        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        # equity=98000 → drawdown_pct=2.0%, triggers recovery timer
+        await guard.update_equity(98000, -2000)
+
+        assert guard._recovery_start is not None
+
+        # Read persisted state
+        state_file = os.path.join(str(tmp_path), 'portfolio_risk_state.json')
+        with open(state_file, 'r') as f:
+            saved = json.load(f)
+        assert 'recovery_start' in saved
+        assert saved['recovery_start'] == guard._recovery_start
+
+    @pytest.mark.asyncio
+    async def test_recovery_in_progress_holds_status(self, tmp_path):
+        """During recovery observation (timer running, not yet elapsed), status should hold."""
+        guard = self._make_guard(tmp_path, status="HALT", starting_equity=100000)
+        guard._recovery_start = (
+            datetime.now(timezone.utc) - timedelta(minutes=10)
+        ).isoformat()
+
+        # equity=98500 → drawdown_pct=1.5%, below recovery_pct=3.0%
+        await guard.update_equity(98500, -1500)
+
+        assert guard._status == "HALT"  # Still holding
+        assert guard._recovery_start is not None  # Timer still running

--- a/tests/test_phantom_ledger_reconciliation.py
+++ b/tests/test_phantom_ledger_reconciliation.py
@@ -1,0 +1,194 @@
+"""
+Tests for the phantom ledger reconciliation feature (P2).
+
+Validates that _reconcile_phantom_ledger_entries correctly identifies
+position_ids with non-zero net quantity in the trade ledger (but no
+matching IB positions) and writes synthetic close rows.
+"""
+
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import unittest
+import asyncio
+import tempfile
+import csv
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, AsyncMock, patch
+import pandas as pd
+
+from orchestrator import _reconcile_phantom_ledger_entries
+
+
+class TestPhantomLedgerReconciliation(unittest.IsolatedAsyncioTestCase):
+    """Tests for _reconcile_phantom_ledger_entries."""
+
+    def setUp(self):
+        """Set up a temporary directory for ledger writes."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.config = {'notifications': {}, 'data_dir': self.temp_dir}
+
+    def tearDown(self):
+        """Clean up temp files."""
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    async def test_empty_ledger_returns_zero(self):
+        """An empty trade ledger should return 0 with no side effects."""
+        trade_ledger = pd.DataFrame()
+        tms = MagicMock()
+
+        result = await _reconcile_phantom_ledger_entries(
+            trade_ledger, tms, self.config
+        )
+
+        self.assertEqual(result, 0)
+        tms.invalidate_thesis.assert_not_called()
+
+    async def test_balanced_ledger_returns_zero(self):
+        """A ledger where all positions net to zero should return 0."""
+        trade_ledger = pd.DataFrame({
+            'position_id': ['POS_001', 'POS_001'],
+            'local_symbol': ['KCH6 C350', 'KCH6 C350'],
+            'action': ['BUY', 'SELL'],
+            'quantity': [1, 1],
+            'timestamp': [datetime.now(), datetime.now()]
+        })
+        tms = MagicMock()
+
+        result = await _reconcile_phantom_ledger_entries(
+            trade_ledger, tms, self.config
+        )
+
+        self.assertEqual(result, 0)
+        tms.invalidate_thesis.assert_not_called()
+
+    @patch('trading_bot.utils._get_data_dir')
+    @patch('orchestrator.send_pushover_notification')
+    async def test_phantom_entry_creates_synthetic_close(
+        self, mock_notify, mock_get_data_dir
+    ):
+        """A position with non-zero net qty should get a synthetic close row."""
+        mock_get_data_dir.return_value = self.temp_dir
+
+        # Create a ledger CSV with one open position (BUY 2, no close)
+        ledger_path = os.path.join(self.temp_dir, 'trade_ledger.csv')
+        fieldnames = [
+            'timestamp', 'position_id', 'combo_id', 'local_symbol',
+            'action', 'quantity', 'avg_fill_price', 'strike', 'right',
+            'total_value_usd', 'reason'
+        ]
+        with open(ledger_path, 'w', newline='') as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerow({
+                'timestamp': '2026-02-20 10:00:00',
+                'position_id': 'POS_PHANTOM',
+                'combo_id': 'POS_PHANTOM',
+                'local_symbol': 'KCH6 C350',
+                'action': 'BUY',
+                'quantity': 2,
+                'avg_fill_price': 5.50,
+                'strike': '350',
+                'right': 'C',
+                'total_value_usd': -412.50,
+                'reason': 'Bull call spread entry'
+            })
+
+        trade_ledger = pd.DataFrame({
+            'position_id': ['POS_PHANTOM'],
+            'local_symbol': ['KCH6 C350'],
+            'action': ['BUY'],
+            'quantity': [2],
+            'timestamp': [datetime(2026, 2, 20)]
+        })
+
+        tms = MagicMock()
+        tms.invalidate_thesis = MagicMock()
+
+        result = await _reconcile_phantom_ledger_entries(
+            trade_ledger, tms, self.config
+        )
+
+        # Should find 1 phantom entry
+        self.assertEqual(result, 1)
+
+        # TMS thesis should be invalidated
+        tms.invalidate_thesis.assert_called_once_with(
+            'POS_PHANTOM',
+            "Phantom reconciliation: ledger had non-zero qty with no IB position"
+        )
+
+        # Verify the synthetic close row was appended
+        df = pd.read_csv(ledger_path)
+        self.assertEqual(len(df), 2)  # original + synthetic
+        close_row = df.iloc[-1]
+        self.assertEqual(close_row['position_id'], 'POS_PHANTOM')
+        self.assertEqual(close_row['action'], 'SELL')  # Reversal of BUY
+        self.assertEqual(close_row['quantity'], 2)
+        self.assertIn('PHANTOM_RECONCILIATION', close_row['reason'])
+
+        # Notification should be sent
+        mock_notify.assert_called_once()
+
+    @patch('trading_bot.utils._get_data_dir')
+    @patch('orchestrator.send_pushover_notification')
+    async def test_multiple_phantoms_across_positions(
+        self, mock_notify, mock_get_data_dir
+    ):
+        """Multiple phantom position_ids should all get synthetic closes."""
+        mock_get_data_dir.return_value = self.temp_dir
+
+        # Create ledger CSV
+        ledger_path = os.path.join(self.temp_dir, 'trade_ledger.csv')
+        fieldnames = [
+            'timestamp', 'position_id', 'combo_id', 'local_symbol',
+            'action', 'quantity', 'avg_fill_price', 'strike', 'right',
+            'total_value_usd', 'reason'
+        ]
+        with open(ledger_path, 'w', newline='') as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+
+        # POS_A: BUY 1 (open long), POS_B: SELL 3 (open short)
+        trade_ledger = pd.DataFrame({
+            'position_id': ['POS_A', 'POS_B'],
+            'local_symbol': ['KCH6 C350', 'KCH6 P340'],
+            'action': ['BUY', 'SELL'],
+            'quantity': [1, 3],
+            'timestamp': [datetime(2026, 2, 20), datetime(2026, 2, 21)]
+        })
+
+        tms = MagicMock()
+        tms.invalidate_thesis = MagicMock()
+
+        result = await _reconcile_phantom_ledger_entries(
+            trade_ledger, tms, self.config
+        )
+
+        # Should find 2 phantom entries (one per position_id/symbol)
+        self.assertEqual(result, 2)
+
+        # Both theses should be invalidated
+        self.assertEqual(tms.invalidate_thesis.call_count, 2)
+        invalidated_ids = {
+            call.args[0] for call in tms.invalidate_thesis.call_args_list
+        }
+        self.assertEqual(invalidated_ids, {'POS_A', 'POS_B'})
+
+        # Verify synthetic rows appended
+        df = pd.read_csv(ledger_path)
+        self.assertEqual(len(df), 2)  # 2 synthetic rows (original header only)
+        # POS_A was BUY, so close is SELL
+        pos_a_row = df[df['position_id'] == 'POS_A'].iloc[0]
+        self.assertEqual(pos_a_row['action'], 'SELL')
+        self.assertEqual(pos_a_row['quantity'], 1)
+        # POS_B was SELL, so close is BUY
+        pos_b_row = df[df['position_id'] == 'POS_B'].iloc[0]
+        self.assertEqual(pos_b_row['action'], 'BUY')
+        self.assertEqual(pos_b_row['quantity'], 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_regime_harmonization.py
+++ b/tests/test_regime_harmonization.py
@@ -1,0 +1,29 @@
+"""Tests for regime label harmonization."""
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from trading_bot.weighted_voting import harmonize_regime
+
+class TestHarmonizeRegime:
+    def test_canonical_passthrough(self):
+        for regime in ['HIGH_VOLATILITY', 'TRENDING', 'RANGE_BOUND', 'UNKNOWN']:
+            assert harmonize_regime(regime) == regime
+
+    def test_alias_mapping(self):
+        assert harmonize_regime('HIGH_VOL') == 'HIGH_VOLATILITY'
+        assert harmonize_regime('LOW_VOL') == 'RANGE_BOUND'
+        assert harmonize_regime('VOLATILE') == 'HIGH_VOLATILITY'
+        assert harmonize_regime('MEAN_REVERTING') == 'RANGE_BOUND'
+
+    def test_unknown_fallback(self):
+        assert harmonize_regime('NONSENSE') == 'UNKNOWN'
+        assert harmonize_regime('') == 'UNKNOWN'
+        assert harmonize_regime(None) == 'UNKNOWN'
+
+    def test_case_insensitivity(self):
+        assert harmonize_regime('high_volatility') == 'HIGH_VOLATILITY'
+        assert harmonize_regime('Trending') == 'TRENDING'
+        assert harmonize_regime('range_bound') == 'RANGE_BOUND'
+        assert harmonize_regime('high_vol') == 'HIGH_VOLATILITY'

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -1503,7 +1503,7 @@ async def place_queued_orders(config: dict, orders_list: list = None, connection
 
         # --- Monitoring Loop ---
         start_time = time.time()
-        monitoring_duration = 1800  # 30 minutes
+        monitoring_duration = config.get('strategy_tuning', {}).get('monitoring_duration_seconds', 1800)
         PRICE_TOLERANCE = 0.001  # $0.001 tolerance for floating point comparison
 
         logger.info(f"Monitoring orders for up to {monitoring_duration / 60} minutes...")

--- a/trading_bot/weighted_voting.py
+++ b/trading_bot/weighted_voting.py
@@ -403,6 +403,22 @@ def detect_market_regime_simple(volatility_report: str, price_change_pct: float)
     return "RANGE_BOUND"
 
 
+VOLATILITY_REGIMES = {'HIGH_VOLATILITY', 'TRENDING', 'RANGE_BOUND', 'UNKNOWN'}
+
+def harmonize_regime(raw_regime: str) -> str:
+    """Normalize regime labels to canonical vocabulary."""
+    if not raw_regime:
+        return 'UNKNOWN'
+    normalized = raw_regime.upper().strip().replace(' ', '_')
+    ALIAS_MAP = {
+        'HIGH_VOL': 'HIGH_VOLATILITY',
+        'LOW_VOL': 'RANGE_BOUND',
+        'VOLATILE': 'HIGH_VOLATILITY',
+        'MEAN_REVERTING': 'RANGE_BOUND',
+    }
+    return ALIAS_MAP.get(normalized, normalized if normalized in VOLATILITY_REGIMES else 'UNKNOWN')
+
+
 def get_regime_adjusted_weights(trigger_type: TriggerType, regime: str) -> dict:
     base_weights = DOMAIN_WEIGHTS.get(trigger_type, DOMAIN_WEIGHTS[TriggerType.SCHEDULED])
 


### PR DESCRIPTION
## Summary

Production analysis revealed the system was "intelligent but frozen" — the AI council works correctly but execution is gridlocked. This PR fixes 7 issues across 8 files:

- **P1**: Guard `_find_position_id_for_contract` against `KeyError` on missing `position_id`/`conId` columns — would crash the moment real positions open
- **P2**: Reconcile phantom ledger entries (IBKR reports 0 positions but ledger shows open) with synthetic close rows + TMS invalidation
- **P3**: PANIC/HALT recovery de-escalation — after 30min sustained improvement below 3% drawdown, de-escalate to WARNING (not NORMAL). Applies to both `DrawdownGuard` and `PortfolioRiskGuard` with their different sign conventions
- **P4**: Per-commodity liquidity thresholds (KC=1.25%, CC=0.50%, NG=0.35%) replacing global 0.45% that rejected all KC options. Configurable monitoring duration per commodity
- **P5a**: Normalize `trigger_type` to uppercase in `council_history.csv` (was lowercase `'scheduled'`)
- **P5b**: Regime label harmonization with `harmonize_regime()` — maps aliases (HIGH_VOL, LOW_VOL, VOLATILE, MEAN_REVERTING) to canonical names
- **P5c**: Anti-hallucination rules appended to inventory agent persona — grounding constraints to prevent fabricated stock numbers

## Files changed (11)

| File | Changes |
|------|---------|
| `orchestrator.py` | P1: column guard + schema-preserving DataFrame; P2: `_reconcile_phantom_ledger_entries()` + call site |
| `trading_bot/drawdown_circuit_breaker.py` | P3: recovery timer, state persistence, de-escalation logic |
| `trading_bot/shared_context.py` | P3: parallel recovery logic in `PortfolioRiskGuard.update_equity` |
| `config.json` | P3: recovery_pct/hold_minutes; P4: per-commodity strategy_tuning; P5c: inventory persona |
| `trading_bot/order_manager.py` | P4: configurable `monitoring_duration_seconds` |
| `trading_bot/signal_generator.py` | P5a: `.upper()` on trigger_type; P5b: `harmonize_regime()` call |
| `trading_bot/weighted_voting.py` | P5b: `harmonize_regime()` function |
| `tests/test_drawdown_recovery.py` | **New** — 18 tests (DrawdownGuard + PortfolioRiskGuard recovery) |
| `tests/test_phantom_ledger_reconciliation.py` | **New** — 4 tests |
| `tests/test_regime_harmonization.py` | **New** — 4 tests |
| `tests/test_exit_integration.py` | 2 new tests for P1 KeyError guard |

## Test plan

- [x] Full test suite: **665 passed, 0 failures** (up from 625)
- [ ] Post-deploy: monitor first KC signal cycle — orders should pass liquidity filter with 1.25% threshold
- [ ] Simulate PANIC recovery: verify WARNING transition after 30-min sustained improvement
- [ ] Verify `deep_merge` produces correct per-commodity `max_liquidity_spread_percentage`
- [ ] Spot-check P3 state persistence: load old `drawdown_state.json` (no `recovery_start`) — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)