### PR TITLE
Widen 5m/15m signal alignment tolerance to 90 minutes

### DIFF
--- a/pages/6_Signal_Overlay.py
+++ b/pages/6_Signal_Overlay.py
@@ -897,8 +897,9 @@ if price_df is not None and not price_df.empty:
         price_idx.columns = ['candle_timestamp']
 
         # Dynamic tolerance: tighter for intraday, wider for daily
-        # Daily candles sit at midnight ET — signals arrive 3-14h later during market hours
-        _tolerance_map = {'5m': 'minutes=30', '15m': 'minutes=30', '30m': 'hours=2', '1h': 'hours=2', '1d': 'hours=20'}
+        # Yahoo 5m data often starts 30-75 min after ICE market open (4:15 ET),
+        # so early signals need ~90 min tolerance. Daily candles sit at midnight ET.
+        _tolerance_map = {'5m': 'minutes=90', '15m': 'minutes=90', '30m': 'hours=2', '1h': 'hours=2', '1d': 'hours=20'}
         _tol_str = _tolerance_map.get(timeframe, 'hours=4')
         _tol = pd.Timedelta(**{_tol_str.split('=')[0]: int(_tol_str.split('=')[1])})
 


### PR DESCRIPTION
## Summary
- Yahoo Finance 5m data for KC often starts 30-75 min after ICE market open (4:15 AM ET), leaving early `signal_open` signals unmatched
- Widened 5m/15m tolerance from 30 min to 90 min in `merge_asof` alignment
- All 6 previously-unmatched signals now align correctly; 666 tests pass

## Root cause
All 6 unmatched signals were generated between 4:18-4:49 AM ET (Feb 25) during the `signal_open` task, but Yahoo's 5m data for that day starts at 5:20 AM ET — a 61-min gap. The 30-min tolerance was too tight.

## Test plan
- [x] Verified all 40 KC signals match with 90-min tolerance (0 unmatched)
- [x] 666 tests pass
- [ ] Visual check: open Signal Overlay on 5m — no "outside alignment tolerance" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)