### PR TITLE
Fix signal overlay grading for trend-based outcomes

### DIFF
--- a/dashboard_utils.py
+++ b/dashboard_utils.py
@@ -1242,8 +1242,9 @@ def grade_decision_quality(council_df: pd.DataFrame, lookback_days: int = 5) -> 
         if candidates.any():
             bullish = graded_df['master_decision'] == 'BULLISH'
             bearish = graded_df['master_decision'] == 'BEARISH'
-            up = graded_df['actual_trend_direction'] == 'UP'
-            down = graded_df['actual_trend_direction'] == 'DOWN'
+            # Reconciliation stores BULLISH/BEARISH (not UP/DOWN)
+            up = graded_df['actual_trend_direction'].isin(['UP', 'BULLISH'])
+            down = graded_df['actual_trend_direction'].isin(['DOWN', 'BEARISH'])
 
             graded_df.loc[candidates & bullish & up, 'outcome'] = 'WIN'
             graded_df.loc[candidates & bullish & down, 'outcome'] = 'LOSS'


### PR DESCRIPTION
## Summary
- `grade_decision_quality()` in `dashboard_utils.py` checked for `UP`/`DOWN` in `actual_trend_direction`, but `reconciliation.py` stores `BULLISH`/`BEARISH`
- The trend fallback grading path never matched, so signals without `pnl_realized` (e.g., backfilled rows) stayed PENDING — no green/red borders
- Now accepts both `UP`/`BULLISH` and `DOWN`/`BEARISH` via `.isin()`

## Test plan
- [x] 667 tests pass
- [ ] Verify Feb 24 KC signals show green/red borders in Signal Overlay dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)