### PR TITLE
Fix LLM cost calculation bugs and add X API spend tracking

### DIFF
--- a/config/api_costs.json
+++ b/config/api_costs.json
@@ -2,20 +2,24 @@
     "costs_per_1k_tokens": {
         "gemini-2.0-flash": {"input": 0.00010, "output": 0.00040},
         "gemini-2.0-pro": {"input": 0.00125, "output": 0.00500},
-        "gemini-3-flash-preview": {"input": 0.00010, "output": 0.00040},
-        "gemini-3-pro-preview": {"input": 0.00125, "output": 0.00500},
-        "gemini-3.1-pro-preview": {"input": 0.00125, "output": 0.00500},
+        "gemini-3-flash-preview": {"input": 0.00050, "output": 0.00300},
+        "gemini-3-pro-preview": {"input": 0.00200, "output": 0.01200},
+        "gemini-3.1-pro-preview": {"input": 0.00200, "output": 0.01200},
         "gpt-4o": {"input": 0.00250, "output": 0.01000},
         "gpt-4o-mini": {"input": 0.00015, "output": 0.00060},
         "gpt-5.2": {"input": 0.00175, "output": 0.01400},
         "claude-sonnet": {"input": 0.00300, "output": 0.01500},
         "claude-opus": {"input": 0.01500, "output": 0.07500},
         "grok-2": {"input": 0.00500, "output": 0.01000},
-        "grok-4-1-fast-reasoning": {"input": 0.00300, "output": 0.01500},
-        "grok-4-fast-non-reasoning": {"input": 0.00050, "output": 0.00200},
+        "grok-4-1-fast-reasoning": {"input": 0.00020, "output": 0.00050},
+        "grok-4-fast-non-reasoning": {"input": 0.00020, "output": 0.00050},
         "o3": {"input": 0.01000, "output": 0.04000},
         "default": {"input": 0.00100, "output": 0.00200}
     },
-    "last_updated": "2026-02-19",
-    "notes": "Added gemini-3.1-pro-preview, gpt-5.2 pricing. Gemini 3.1 Pro assumed same pricing as 3 Pro (preview). Verify when GA pricing published."
+    "x_api": {
+        "cost_per_call": 0.0035,
+        "notes": "X API v2 Basic tier ($200/mo) / ~1700 search calls/month estimate. Adjust to actual tier."
+    },
+    "last_updated": "2026-02-26",
+    "notes": "Fixed Gemini 3 Flash/Pro, Grok 4.1 Fast pricing. Added X API per-call cost. Fixed substring match bug in calculate_api_cost."
 }

--- a/tests/test_budget_guard_wiring.py
+++ b/tests/test_budget_guard_wiring.py
@@ -86,9 +86,19 @@ def test_calculate_api_cost_zero_tokens():
 def test_calculate_api_cost_gemini_flash():
     """Gemini Flash model matched by substring."""
     cost = calculate_api_cost("gemini-3-flash-preview", 10000, 5000)
-    # gemini-3-flash-preview: input=0.00010/1k, output=0.00040/1k
-    # (10000/1000)*0.00010 + (5000/1000)*0.00040 = 0.001 + 0.002 = 0.003
-    assert abs(cost - 0.003) < 0.0001
+    # gemini-3-flash-preview: input=0.00050/1k, output=0.00300/1k
+    # (10000/1000)*0.00050 + (5000/1000)*0.00300 = 0.005 + 0.015 = 0.020
+    assert abs(cost - 0.020) < 0.0001
+
+
+def test_calculate_api_cost_mini_not_overcharged():
+    """gpt-4o-mini must match its own rate, not gpt-4o (longest match wins)."""
+    cost_mini = calculate_api_cost("gpt-4o-mini", 1000, 500)
+    cost_4o = calculate_api_cost("gpt-4o", 1000, 500)
+    # gpt-4o-mini: (1/1)*0.00015 + (0.5/1)*0.00060 = 0.00015 + 0.00030 = 0.00045
+    # gpt-4o:      (1/1)*0.00250 + (0.5/1)*0.01000 = 0.00250 + 0.00500 = 0.00750
+    assert abs(cost_mini - 0.00045) < 0.0001, f"gpt-4o-mini overcharged: {cost_mini}"
+    assert cost_mini < cost_4o, "gpt-4o-mini should be cheaper than gpt-4o"
 
 
 # --- Singleton Factory Tests ---


### PR DESCRIPTION
## Summary
- **Fix substring matching bug** in `calculate_api_cost()`: `"gpt-4o"` was matching `"gpt-4o-mini"` (first-match), overcharging mini calls ~17x. Now uses longest-match.
- **Correct 5 model prices** verified against current API pricing pages:
  - Gemini 3 Flash: was 5-7.5x too low ($0.10/$0.40 → $0.50/$3.00 per 1M)
  - Gemini 3 Pro / 3.1 Pro: was 1.6-2.4x too low ($1.25/$5.00 → $2.00/$12.00 per 1M)
  - Grok 4.1 Fast Reasoning: was 15-30x too high ($3.00/$15.00 → $0.20/$0.50 per 1M)
  - Grok 4 Fast Non-Reasoning: was 2.5-4x too high ($0.50/$2.00 → $0.20/$0.50 per 1M)
- **Add X Bearer API cost tracking**: configurable per-call rate in `api_costs.json`, cost accumulated alongside call count in `budget_state.json` and `llm_daily_costs.csv`
- **Dashboard**: X API section always visible with estimated cost, historical dual-axis chart (calls + cost) in LLM Monitor
- **Defensive `mkdir`** in `_archive_daily_costs()` prevents silent CSV write failure

## Test plan
- [x] 668 tests passing, 0 failures
- [x] New test `test_calculate_api_cost_mini_not_overcharged` verifies longest-match fix
- [x] Updated `test_calculate_api_cost_gemini_flash` for corrected price
- [ ] After deploy: verify budget_state.json includes `x_api_cost` field
- [ ] After midnight UTC reset: verify llm_daily_costs.csv includes `x_api_cost_usd` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)