### PR TITLE
Add missing inventory research prompt to NG profile

### DIFF
--- a/config/profiles/ng.json
+++ b/config/profiles/ng.json
@@ -166,6 +166,7 @@
         "volatility": "Assess natural gas implied volatility levels, term structure (contango/backwardation), seasonal volatility patterns, and weather-driven vol spikes. NG is historically one of the most volatile commodity markets.",
         "geopolitical": "Evaluate geopolitical factors: US LNG export policy, European gas supply dynamics (TTF spread), pipeline politics, sanctions on competing suppliers, and energy security concerns.",
         "sentiment": "Gauge market sentiment from trader positioning (COT data), gas-focused social media, industry newsletters (RBN, NGI), and options market skew.",
+        "inventory": "Search for 'EIA Weekly Natural Gas Storage Report latest 2026' and 'EIA natural gas storage levels vs 5-year average'. Look for storage volumes in Bcf (billion cubic feet) and trend direction (injection vs withdrawal). Also search for 'Baker Hughes natural gas rig count' for supply outlook.",
         "supply_chain": "Monitor pipeline maintenance schedules, LNG terminal utilization, storage injection/withdrawal rates, and regional basis differentials (Henry Hub vs other hubs)."
     }
 }


### PR DESCRIPTION
## Summary
- NG's `research_prompts` in `config/profiles/ng.json` was missing the `inventory` key
- `signal_generator.py` L163 falls back to `"Analyze inventory conditions."` when key is missing
- This generic prompt caused Google Search to return irrelevant manufacturing data (Kearney, NFIB) instead of EIA Weekly Storage Reports
- The hallucination detector didn't catch it because the numbers *were* in the grounded data — just from the wrong domain entirely
- KC and CC profiles already have correct `inventory` prompts; this was NG-specific

## Fix
Added `inventory` research prompt targeting EIA Weekly Natural Gas Storage Report, storage levels vs 5-year average, and Baker Hughes rig count.

## Test plan
- [x] 668 tests passing
- [ ] After deploy: verify NG council_history shows EIA storage data instead of Kearney/NFIB reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)