### PR TITLE
Fix NG trade reconciliation Flex Query prefix (ON→LNE)

### DIFF
--- a/reconcile_trades.py
+++ b/reconcile_trades.py
@@ -129,8 +129,9 @@ async def reconcile_active_positions(config: dict):
     # 1b. Filter to active commodity symbol
     # IBKR uses different symbol prefixes for futures vs options:
     # KC futures = "KC*", KC options = "KO*"; CC futures = "CC*", CC options = "DC*"
+    # NG futures = "NG*", NG options = "LNE*" (NYMEX convention)
     ticker = config.get('commodity', {}).get('ticker', config.get('symbol', 'KC'))
-    _IBKR_SYMBOL_PREFIXES = {"KC": ("KC", "KO"), "CC": ("CC", "DC"), "SB": ("SB", "SO"), "NG": ("NG", "ON")}
+    _IBKR_SYMBOL_PREFIXES = {"KC": ("KC", "KO"), "CC": ("CC", "DC"), "SB": ("SB", "SO"), "NG": ("NG", "LNE")}
     prefixes = _IBKR_SYMBOL_PREFIXES.get(ticker, (ticker,))
     if not ib_positions.empty:
         pre_count = len(ib_positions)
@@ -736,9 +737,9 @@ async def main(lookback_days: int = None, config: dict = None):
     # --- 3b. Filter to active commodity symbol ---
     # The IBKR Flex Query returns ALL account trades. Filter to only trades
     # matching the active commodity. IBKR uses different prefixes for futures
-    # vs options: KC futures = "KC*", KC options = "KO*"; CC/"DC*"; SB/"SO*"
+    # vs options: KC/"KO*"; CC/"DC*"; SB/"SO*"; NG/"LNE*" (NYMEX convention)
     ticker = config.get('commodity', {}).get('ticker', config.get('symbol', 'KC'))
-    _IBKR_SYMBOL_PREFIXES = {"KC": ("KC", "KO"), "CC": ("CC", "DC"), "SB": ("SB", "SO"), "NG": ("NG", "ON")}
+    _IBKR_SYMBOL_PREFIXES = {"KC": ("KC", "KO"), "CC": ("CC", "DC"), "SB": ("SB", "SO"), "NG": ("NG", "LNE")}
     prefixes = _IBKR_SYMBOL_PREFIXES.get(ticker, (ticker,))
     pre_filter_count = len(ib_trades_df)
     ib_trades_df = ib_trades_df[ib_trades_df['local_symbol'].apply(lambda s: any(s.startswith(p) for p in prefixes))]


### PR DESCRIPTION
## Summary
- Fix `_IBKR_SYMBOL_PREFIXES` for NG: `("NG", "ON")` → `("NG", "LNE")`
- IBKR uses `LNE` as the localSymbol prefix for NG options (e.g., `LNEK6 P2800`, `LNEM6 P2950`, `LNEN6 P3300`), not `ON`
- Both occurrences fixed (L133 for position filter, L742 for trade filter)

## Root cause
The NG option prefix was guessed as `ON` when the mapping was first created. Actual IBKR convention for NYMEX Natural Gas options is `LNE` (the tradingClass). This caused the commodity filter to drop all 63 Flex trades to 0, marking all 6 local NG trades as superfluous every reconciliation run.

## Test plan
- [x] 671 tests pass
- [ ] Re-run trade reconciliation for NG from dashboard — should now match Flex trades to local ledger

🤖 Generated with [Claude Code](https://claude.com/claude-code)