### PR TITLE
Reduce signal windows from 4 to 3, shift to liquid hours

### DIFF
--- a/config.json
+++ b/config.json
@@ -493,8 +493,8 @@
       "minute": 15
     },
     "session_template": {
-      "signal_count": 4,
-      "signal_start_pct": 0.05,
+      "signal_count": 3,
+      "signal_start_pct": 0.15,
       "signal_end_pct": 0.80,
       "cutoff_before_close_minutes": 78,
 

--- a/tests/test_schedule_config.py
+++ b/tests/test_schedule_config.py
@@ -112,8 +112,8 @@ def test_build_schedule_session_mode():
         'schedule': {
             'mode': 'session',
             'session_template': {
-                'signal_count': 4,
-                'signal_start_pct': 0.05,
+                'signal_count': 3,
+                'signal_start_pct': 0.15,
                 'signal_end_pct': 0.80,
                 'cutoff_before_close_minutes': 78,
                 'pre_open_tasks': [
@@ -130,11 +130,11 @@ def test_build_schedule_session_mode():
         }
     }
     result = build_schedule(config)
-    assert len(result) == 7  # 1 pre-open + 4 signals + 1 pre-close + 1 post-close
+    assert len(result) == 6  # 1 pre-open + 3 signals + 1 pre-close + 1 post-close
     ids = [t.id for t in result]
     assert 'start_monitoring' in ids
     assert 'signal_open' in ids
-    assert 'signal_late' in ids
+    assert 'signal_mid' in ids
     assert 'emergency_hard_close' in ids
     assert 'eod_shutdown' in ids
     # All times should be within a reasonable day range


### PR DESCRIPTION
## Summary
- Reduce `signal_count` from 4 to 3
- Shift `signal_start_pct` from 5% to 15% of session
- Signals now at 15%, 47.5%, 80% with ~3h gaps in liquid windows

## New schedule
| Commodity | Signal 1 | Signal 2 | Signal 3 |
|-----------|----------|----------|----------|
| KC | 05:38 ET | 08:38 ET | 11:39 ET |
| CC | 06:03 ET | 08:54 ET | 11:45 ET |
| NG | 07:07 ET | 09:33 ET | 12:00 ET |

## Rationale
The pre-open signal (5% into session) ran at 04:42/05:11/06:22 ET during thin liquidity with stale overnight data. It produced assessments highly correlated with the next signal, inflating Brier sample size with pseudo-replicates without adding independent information. Removing it:
- Saves ~25% of daily LLM spend on signal generation
- Produces cleaner Brier training data with genuinely independent observations
- Eliminates orders placed during widest spread windows

## Test plan
- [x] 671 tests pass
- [ ] Monitor tomorrow's schedule — verify 3 signals fire at expected times

🤖 Generated with [Claude Code](https://claude.com/claude-code)