### PR TITLE
🛡️ Sentinel: [HIGH] Remove unsafe_allow_html usage in Streamlit Council page

### DIFF
--- a/create_mock_data.py
+++ b/create_mock_data.py
@@ -1,0 +1,69 @@
+
+import os
+import random
+import csv
+from datetime import datetime, timedelta
+
+def create_mock_council_history():
+    """Create a mock council_history.csv for frontend verification."""
+    ticker = os.environ.get("COMMODITY_TICKER", "KC")
+    data_dir = os.path.join("data", ticker)
+    os.makedirs(data_dir, exist_ok=True)
+
+    file_path = os.path.join(data_dir, "council_history.csv")
+
+    if os.path.exists(file_path):
+        print(f"Mock data already exists at {file_path}")
+        return
+
+    print(f"Creating mock council history at {file_path}")
+
+    headers = [
+        "timestamp", "contract", "master_decision", "master_confidence",
+        "master_reasoning", "compliance_approved", "weighted_score",
+        "vote_breakdown", "trigger_type", "primary_catalyst",
+        "conviction_multiplier", "thesis_strength", "dissent_acknowledged",
+        "meteorologist_sentiment", "macro_sentiment", "geopolitical_sentiment",
+        "fundamentalist_sentiment", "sentiment_sentiment", "technical_sentiment",
+        "volatility_sentiment"
+    ]
+
+    rows = []
+    now = datetime.now()
+
+    # Generate 10 sample rows
+    for i in range(10):
+        ts = (now - timedelta(hours=i*4)).isoformat()
+        decision = random.choice(["BULLISH", "BEARISH", "NEUTRAL"])
+
+        row = {
+            "timestamp": ts,
+            "contract": f"KC{chr(65+i)}25",
+            "master_decision": decision,
+            "master_confidence": f"{random.uniform(0.6, 0.9):.2f}",
+            "master_reasoning": "Mock reasoning for frontend verification of XSS fix.",
+            "compliance_approved": "True",
+            "weighted_score": f"{random.uniform(-0.8, 0.8):.2f}",
+            "vote_breakdown": '[{"agent": "Macro", "direction": "BULLISH", "contribution": 0.2}]',
+            "trigger_type": random.choice(["scheduled", "emergency", "PriceSentinel"]),
+            "primary_catalyst": "Mock Catalyst Event <script>alert('XSS')</script>",
+            "conviction_multiplier": "0.85",
+            "thesis_strength": random.choice(["PROVEN", "PLAUSIBLE", "SPECULATIVE"]),
+            "dissent_acknowledged": "Minor dissent from Macro agent regarding yield curve.",
+            "meteorologist_sentiment": "BULLISH",
+            "macro_sentiment": "NEUTRAL",
+            "geopolitical_sentiment": "BEARISH",
+            "fundamentalist_sentiment": "BULLISH",
+            "sentiment_sentiment": "NEUTRAL",
+            "technical_sentiment": "BULLISH",
+            "volatility_sentiment": "LOW"
+        }
+        rows.append(row)
+
+    with open(file_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=headers)
+        writer.writeheader()
+        writer.writerows(rows)
+
+if __name__ == "__main__":
+    create_mock_council_history()

--- a/pages/3_The_Council.py
+++ b/pages/3_The_Council.py
@@ -372,12 +372,7 @@ with forensic_cols[0]:
         # Sentinel-triggered (e.g., "PriceSentinel")
         trigger_badge = f"📡 {trigger_raw}"
         trigger_color = "#FFA15A"
-    st.markdown(f"""
-    <div style="background-color: {trigger_color}; padding: 8px 12px;
-                border-radius: 15px; color: white; font-weight: bold; text-align: center;">
-        {html.escape(trigger_badge)}
-    </div>
-    """, unsafe_allow_html=True)
+    st.markdown(f"**Trigger Type:** {html.escape(trigger_badge)}")
     st.caption("Trigger Type")
 
 with forensic_cols[1]:
@@ -398,12 +393,7 @@ with forensic_cols[2]:
             pass
     if conv_val is not None:
         st.progress(conv_val, text=f"{conv_val:.2f}")
-        st.caption("Conviction Pipeline")
-        st.markdown(
-            "<small>1.0 = full conviction. 0.70 = divergent (partial dampening). 0.50 = high disagreement</small>",
-            unsafe_allow_html=True,
-            help="1.0 = full conviction (FULL alignment). 0.70 = divergent (partial dampening). 0.50 = high disagreement"
-        )
+        st.caption("Conviction Pipeline", help="1.0 = full conviction. 0.70 = divergent (partial dampening). 0.50 = high disagreement")
     else:
         st.info("N/A")
         st.caption("Conviction Pipeline")
@@ -412,12 +402,7 @@ with forensic_cols[3]:
     thesis_str = safe_display(row.get('thesis_strength'), "UNKNOWN")
     ts_colors = {'PROVEN': '#00CC96', 'PLAUSIBLE': '#FFA15A', 'SPECULATIVE': '#EF553B'}
     ts_color = ts_colors.get(thesis_str, '#888888')
-    st.markdown(f"""
-    <div style="background-color: {ts_color}; padding: 8px 12px;
-                border-radius: 15px; color: white; font-weight: bold; text-align: center;">
-        {html.escape(thesis_str)}
-    </div>
-    """, unsafe_allow_html=True)
+    st.markdown(f"**Thesis Strength:** {html.escape(thesis_str)}")
     st.caption("Thesis Strength")
 
 st.markdown("---")
@@ -445,12 +430,7 @@ if thesis_strength != "UNKNOWN":
         'SPECULATIVE': '#EF553B', # Red
     }
     thesis_color = thesis_colors.get(thesis_strength, '#888888')
-    st.markdown(f"""
-    <div style="display: inline-block; background-color: {thesis_color}; padding: 5px 15px;
-                border-radius: 20px; color: white; font-weight: bold; margin-bottom: 10px;">
-        Thesis: {html.escape(thesis_strength)}
-    </div>
-    """, unsafe_allow_html=True)
+    st.caption(f"Thesis: {html.escape(thesis_strength)}")
 
 # === v7.1: Primary Catalyst ===
 primary_catalyst = safe_display(row.get('primary_catalyst'), "N/A")
@@ -461,11 +441,7 @@ master_cols = st.columns(4)
 with master_cols[0]:
     decision = row.get('master_decision', 'N/A')
     color = "#00CC96" if decision == 'BULLISH' else "#EF553B" if decision == 'BEARISH' else "#888888"
-    st.markdown(f"""
-    <div style="background-color: {color}; padding: 20px; border-radius: 10px; text-align: center;">
-        <h2 style="color: white; margin: 0;">{html.escape(decision)}</h2>
-    </div>
-    """, unsafe_allow_html=True)
+    st.metric(label="Decision", value=decision)
 
 with master_cols[1]:
     confidence = row.get('master_confidence', 0)

--- a/tests/test_council_security.py
+++ b/tests/test_council_security.py
@@ -1,0 +1,31 @@
+
+import unittest
+import sys
+import os
+import ast
+
+class TestCouncilUX(unittest.TestCase):
+    def test_unsafe_allow_html_removed(self):
+        """Verify unsafe_allow_html is not used in pages/3_The_Council.py"""
+        file_path = "pages/3_The_Council.py"
+        with open(file_path, "r") as f:
+            content = f.read()
+
+        # Check for the string directly
+        self.assertNotIn("unsafe_allow_html=True", content, "Found unsafe_allow_html=True in source code")
+
+    def test_safe_components_used(self):
+        """Verify safe Streamlit components are used instead"""
+        file_path = "pages/3_The_Council.py"
+        with open(file_path, "r") as f:
+            content = f.read()
+
+        # Check for new safe implementations
+        self.assertIn('st.markdown(f"**Trigger Type:** {html.escape(trigger_badge)}")', content)
+        self.assertIn('st.caption("Conviction Pipeline"', content)
+        self.assertIn('st.caption("Thesis Strength"', content)
+        self.assertIn('st.caption(f"Thesis: {html.escape(thesis_strength)}")', content)
+        self.assertIn('st.metric(label="Decision", value=decision)', content)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verification/verify_council.py
+++ b/verification/verify_council.py
@@ -1,0 +1,42 @@
+
+from playwright.sync_api import Page, expect, sync_playwright
+import time
+
+def test_council_page(page: Page):
+    """Verify The Council page renders safely without unsafe_allow_html."""
+
+    # 1. Navigate to the app
+    page.goto("http://localhost:8501")
+
+    # 2. Wait for loading
+    page.wait_for_timeout(5000)
+
+    # 3. Navigate to "The Council" page
+    # Streamlit sidebar navigation
+    page.get_by_text("The Council").click()
+    page.wait_for_timeout(3000)
+
+    # 4. Scroll to Forensic Context section
+    # Look for "Forensic Context" header
+    expect(page.get_by_text("Forensic Context")).to_be_visible()
+
+    # 5. Take Screenshot of Forensic Section (Trigger Type, Catalyst, etc)
+    page.screenshot(path="/home/jules/verification/council_forensic.png")
+
+    # 6. Scroll to Master Decision section
+    expect(page.get_by_text("Master Decision")).to_be_visible()
+
+    # 7. Take Screenshot of Master Decision
+    page.screenshot(path="/home/jules/verification/council_master_decision.png")
+
+if __name__ == "__main__":
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        try:
+            test_council_page(page)
+        except Exception as e:
+            print(f"Verification failed: {e}")
+            page.screenshot(path="/home/jules/verification/error.png")
+        finally:
+            browser.close()


### PR DESCRIPTION
**Vulnerability:** The 'Council' page used `unsafe_allow_html=True` to render custom HTML badges for 'Trigger Type', 'Thesis Strength', and 'Master Decision'. This practice exposes the application to Cross-Site Scripting (XSS) attacks if any dynamic data injected into the HTML (e.g., from external sentinels or LLM outputs) is malicious.

**Fix:** Replaced all 5 instances of `unsafe_allow_html` with native Streamlit components:
- Replaced custom HTML color blocks with `st.caption` and `st.metric`.
- Replaced the HTML-based Conviction Pipeline help text with the standard `help` parameter in `st.caption`.
- Ensured all dynamic content is safely rendered as plain text.

**Impact:** Eliminates the XSS vector on this page while preserving the core informational content, albeit with slightly simplified styling (standard Streamlit UI rather than custom CSS colors for some badges).

**Verification:**
- Validated via `test_council_security.py` (passes).
- Validated via frontend Playwright script `verify_council.py` (screenshots confirmed correct rendering).


---
*PR created automatically by Jules for task [3697543639890098096](https://jules.google.com/task/3697543639890098096) started by @rozavala*