### PR TITLE
feat: Health Digest button in Utilities + full audit

### DIFF
--- a/verify_system_readiness.py
+++ b/verify_system_readiness.py
@@ -968,11 +968,20 @@ async def main():
             print_result(check)
 
         if report.is_ready:
-            print(f"\n✅ SYSTEM READY ({report.pass_count} Passed)")
+            if report.warn_count > 0:
+                print(f"\n⚠️ SYSTEM READY WITH WARNINGS ({report.pass_count} Passed, {report.warn_count} Warnings)")
+            else:
+                print(f"\n✅ SYSTEM READY ({report.pass_count} Passed)")
         else:
             print(f"\n❌ SYSTEM FAILURE ({report.fail_count} Failed)")
 
-    sys.exit(0 if report.is_ready else 1)
+    # Exit codes: 0=all pass, 2=pass with warnings, 1=failures
+    if report.fail_count > 0:
+        sys.exit(1)
+    elif report.warn_count > 0:
+        sys.exit(2)
+    else:
+        sys.exit(0)
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary

- **New**: System Health Digest button in Utilities page (Section 5) — generates on-demand health report with score, components, improvement opportunities, and per-commodity decision traces
- **Fix**: `verify_system_readiness.py` now exits with code 2 for warnings-only (dashboard had dead code path expecting this)
- **Cleanup**: Removed duplicate equity sync button from Data Reconciliation section (kept the faster async version in Manual Trading Operations)

### Full Audit Results (4 parallel agents)

All 11 sections of the Utilities page were audited:

| Section | Status | Notes |
|---------|--------|-------|
| 1. Log Collection | PASS | `scripts/collect_logs.sh` exists, all invocations correct |
| 2. Log Analysis | PASS | `scripts/log_analysis.sh` supports all 5 subcommands |
| 3. Manual Trading | PASS | All 7 functions verified (signatures match) |
| 4. System Diagnostics | PASS | IB pool, notifications, market status all correct |
| **5. Health Digest** | **NEW** | Added on-demand digest generation button |
| 6. State Management | PASS | `_resolve_data_path` works, backup-before-clear is safe |
| 7. System Validation | **FIXED** | Exit code 2 for warnings now emitted |
| 8. Data Reconciliation | **FIXED** | Removed duplicate equity sync, all 5 scripts verified |
| 9. Cache Management | PASS | `st.cache_data.clear()` is correct API |
| 10. System Info | PASS | Python/Streamlit versions, log file listing |
| 11. Sentinel Statistics | PASS | `get_dashboard_stats()` API verified |

## Test plan

- [x] `pytest tests/ -x -q` — 714 passed, 0 failures
- [x] No new test files needed (dashboard UI changes only)
- [x] Verified `verify_system_readiness.py` exit code logic correct (0=pass, 2=warn, 1=fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)