### PR TITLE
fix: include health digest in log collection

### DIFF
--- a/scripts/collect_logs.sh
+++ b/scripts/collect_logs.sh
@@ -221,6 +221,12 @@ if [ -f "$REPO_DIR/state.json" ]; then
     cp "$REPO_DIR/state.json" "$DEST_DIR/"
 fi
 
+# === SYSTEM HEALTH DIGEST ===
+if [ -f "$REPO_DIR/data/system_health_digest.json" ]; then
+    echo "Copying system_health_digest.json..."
+    cp "$REPO_DIR/data/system_health_digest.json" "$DEST_DIR/"
+fi
+
 # === PERFORMANCE FILES ===
 if [ -f "$REPO_DIR/daily_performance.png" ]; then
     echo "Copying daily_performance.png..."


### PR DESCRIPTION
## Summary

- Adds `data/system_health_digest.json` to `scripts/collect_logs.sh` so the daily health report is captured alongside state files and logs during log collection

## Test plan

- [x] Verified the file path matches where `system_digest.py` writes the output
- [x] Follows existing pattern (copy if exists, skip if not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)