### PR TITLE
Optimize LLM model assignments & harden fallback chains

### DIFF
--- a/config/api_costs.json
+++ b/config/api_costs.json
@@ -13,13 +13,14 @@
         "grok-2": {"input": 0.00500, "output": 0.01000},
         "grok-4-1-fast-reasoning": {"input": 0.00020, "output": 0.00050},
         "grok-4-fast-non-reasoning": {"input": 0.00020, "output": 0.00050},
-        "o3": {"input": 0.01000, "output": 0.04000},
+        "o3": {"input": 0.00200, "output": 0.00800},
+        "o3-2025-04-16": {"input": 0.00200, "output": 0.00800},
         "default": {"input": 0.00100, "output": 0.00200}
     },
     "x_api": {
         "cost_per_call": 0.0035,
         "notes": "X API v2 Basic tier ($200/mo) / ~1700 search calls/month estimate. Adjust to actual tier."
     },
-    "last_updated": "2026-02-26",
-    "notes": "Fixed Gemini 3 Flash/Pro, Grok 4.1 Fast pricing. Added X API per-call cost. Fixed substring match bug in calculate_api_cost."
+    "last_updated": "2026-02-27",
+    "notes": "Fixed o3 pricing (5x reduction post-price-cut). Added o3-2025-04-16 variant. Previous: Fixed Gemini 3 Flash/Pro, Grok 4.1 Fast pricing."
 }


### PR DESCRIPTION
## Summary
- **Geopolitical Analyst → Gemini Pro**: Google Search grounding is best-in-class for live geopolitical news (was OpenAI gpt-5.2)
- **Trade Analyst → xAI grok-4-1-fast-reasoning**: Post-mortem is batch utility, not safety-critical — 28x cost savings (was OpenAI gpt-5.2)
- **Tier 3 fallbacks**: Added 3rd provider (xAI Pro or Gemini Pro) to all decision-maker chains for resilience
- **Tier 2 fallbacks**: Added TECHNICAL_ANALYST and SENTIMENT_ANALYST to the role list (were falling through to Tier 1 sentinel Flash fallbacks); reordered for quality-first infrastructure independence
- **Tier 1 fallbacks**: Reordered to xAI Flash → Gemini Flash → OpenAI (cheapest first; OpenAI "flash" resolves to gpt-5.2)
- **o3 pricing fix**: $10/$40 → $2/$8 per 1M tokens (5x post-price-cut correction); added `o3-2025-04-16` variant

New provider distribution: **Gemini 7 / OpenAI 3 / xAI 6 / Anthropic 3** (Technical Analyst stays on o3)

## Test plan
- [x] `pytest tests/test_router_fallback.py -v` — all 4 tests pass
- [x] `pytest tests/ -x -q` — all 714 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)