### PR TITLE
fix: resolve ledger reconciliation cross-commodity contamination and phantom loop

### DIFF
--- a/reconcile_trades.py
+++ b/reconcile_trades.py
@@ -792,8 +792,9 @@ async def full_reconciliation(config: dict) -> int:
     """
     logger.info("Running FULL trade reconciliation (no date limit)")
 
-    # Run main with 365 days lookback
-    missing, superfluous = await main(lookback_days=365)
+    # Run main with 365 days lookback — pass config to ensure correct
+    # commodity prefix filtering (without it, defaults to KC)
+    missing, superfluous = await main(lookback_days=365, config=config)
 
     count = len(missing) + len(superfluous)
     if count > 0:

--- a/trading_bot/master_orchestrator.py
+++ b/trading_bot/master_orchestrator.py
@@ -270,11 +270,13 @@ async def _post_close_service(shared: SharedContext, config: dict):
 
             # 2. Trade reconciliation
             try:
+                import copy
                 from reconcile_trades import main as run_reconciliation
                 for ticker in shared.active_commodities:
-                    ticker_config = config.copy()
+                    ticker_config = copy.deepcopy(config)
                     ticker_config['data_dir'] = os.path.join('data', ticker)
                     ticker_config['symbol'] = ticker
+                    ticker_config.setdefault('commodity', {})['ticker'] = ticker
                     await run_reconciliation(config=ticker_config)
             except Exception as e:
                 logger.error(f"Post-close reconciliation failed: {e}")

--- a/trading_bot/var_calculator.py
+++ b/trading_bot/var_calculator.py
@@ -964,7 +964,12 @@ OUTPUT JSON:
 
     try:
         response = await router.route(AgentRole.COMPLIANCE_OFFICER, prompt, response_json=True)
-        result = json.loads(response) if isinstance(response, str) else response
+        if isinstance(response, str) and response.strip():
+            result = json.loads(response)
+        elif isinstance(response, dict):
+            result = response
+        else:
+            raise ValueError(f"Empty or invalid LLM response: {repr(response)[:100]}")
         # Validate expected keys
         for key in ("dominant_risk", "correlation_warning", "trend", "urgency"):
             if key not in result:


### PR DESCRIPTION
## Summary

- **master_orchestrator.py**: `config.copy()` → `copy.deepcopy()` + explicit `commodity.ticker` in post_close reconciliation loop. The shallow copy caused all commodities to use KC's prefix filter — CC was writing 52 KC trades as "missing" to its own archive every day.
- **orchestrator.py**: Phantom reconciliation now skips `RECONCILIATION_MISSING` entries (single-leg historical records from Flex Query, not real open positions) and entries already processed with `PHANTOM_RECONCILIATION` (idempotency guard breaks the KC feedback loop of 10 superfluous trades per cycle).
- **reconcile_trades.py**: Pass `config` to `full_reconciliation()` — same latent bug as pre-#1083 (defaults to KC without config).
- **reconciliation.py**: Skip HMDS queries for contracts expired >60 days (KCZ5 Dec 2025 was failing with Error 162 every cycle).
- **var_calculator.py**: Guard against empty LLM response in L1 Interpreter before `json.loads()`.
- **Data cleanup**: Deleted contaminated `trade_ledger_missing_trades.csv` from CC and NG archives (contained KC trades from pre-#1083 era).

## Root Cause Analysis

| Commodity | Symptom | Root Cause |
|-----------|---------|------------|
| CC | 52 "missing" trades every day | Shallow `config.copy()` in post_close — `commodity.ticker` stayed `KC` for all engines |
| NG | 64 superfluous trades | Contaminated `trade_ledger_missing_trades.csv` (KC entries from pre-#1083) loaded by archive glob |
| KC | 10 superfluous trades (feedback loop) | RECONCILIATION_MISSING single-leg entries → phantom recon writes synthetics → Flex Query flags as superfluous → repeats |

## Test plan

- [x] 712 tests pass (2 pre-existing failures on main deselected: `test_brier_bridge`, `test_system_digest`)
- [ ] Verify next trading day: CC reconciliation shows 0 missing (not 52 KC trades)
- [ ] Verify next trading day: NG reconciliation shows reduced superfluous count
- [ ] Verify next trading day: KC phantom reconciliation does not regenerate synthetics
- [ ] Verify KCZ5 reconciliation is skipped with info log (not Error 162)

🤖 Generated with [Claude Code](https://claude.com/claude-code)