### PR TITLE
fix: add system_digest to session schedule and fix 7 data bugs

### DIFF
--- a/config.json
+++ b/config.json
@@ -518,7 +518,8 @@
         {"id": "reconcile_and_analyze",  "offset_minutes": 8,  "function": "reconcile_and_analyze",        "label": "Reconcile & Analyze"},
         {"id": "brier_reconciliation",   "offset_minutes": 20, "function": "run_brier_reconciliation",     "label": "Brier Reconciliation"},
         {"id": "sentinel_effectiveness", "offset_minutes": 23, "function": "sentinel_effectiveness_check", "label": "Sentinel Effectiveness Check"},
-        {"id": "eod_shutdown",           "offset_minutes": 26, "function": "cancel_and_stop_monitoring",   "label": "End-of-Day Shutdown"}
+        {"id": "eod_shutdown",           "offset_minutes": 26, "function": "cancel_and_stop_monitoring",   "label": "End-of-Day Shutdown"},
+        {"id": "system_digest",          "offset_minutes": 30, "function": "generate_system_digest_task", "label": "System Health Digest"}
       ]
     }
   },

--- a/tests/test_system_digest.py
+++ b/tests/test_system_digest.py
@@ -308,19 +308,21 @@ class TestBuildDecisionTraces:
 
 
 class TestBuildDataFreshness:
-    @patch('trading_bot.state_manager.StateManager.load_state_raw')
-    def test_freshness(self, mock_load_raw, tmp_data_dir):
+    def test_freshness(self, tmp_data_dir):
         now = datetime.now(timezone.utc).timestamp()
-        mock_load_raw.return_value = {
-            'price': {
-                'timestamp': now - 300,  # 5 minutes ago
-                'data': {'interval_seconds': 600},
-            },
-            'weather': {
-                'timestamp': now - 2000,  # ~33 minutes ago
-                'data': {'interval_seconds': 600},
-            },
+        state = {
+            'sentinel_health': {
+                'price': {
+                    'timestamp': now - 300,  # 5 minutes ago
+                    'data': {'interval_seconds': 600},
+                },
+                'weather': {
+                    'timestamp': now - 2000,  # ~33 minutes ago
+                    'data': {'interval_seconds': 600},
+                },
+            }
         }
+        _write_json(os.path.join(tmp_data_dir, 'state.json'), state)
 
         result = _build_data_freshness(tmp_data_dir)
         assert result['sentinels']['price']['is_stale'] is False


### PR DESCRIPTION
## Summary

- **System digest never ran in production**: The `system_digest` task existed in the `FUNCTION_REGISTRY` and hardcoded default schedule but was missing from the `session_template` in config.json. Added at `+30` minutes post-close (after `eod_shutdown` at `+26`).
- **Fixed 7 data bugs** in `system_digest.py` that caused empty/incorrect output:
  1. `master_direction` → `master_decision` column name (cognitive layer, decision traces, agent contribution)
  2. `strategy` → `strategy_type` column name (cognitive layer, decision traces)
  3. `vote_breakdown` stored as JSON list, not dict (decision traces top_contributors)
  4. `_build_data_freshness` used StateManager default instead of per-commodity `state.json`
  5. `daily_equity.csv` only in per-commodity dirs — added fallback search (portfolio, rolling trends)
  6. `router_metrics.json` has nested `{success, failure}` dicts — fixed aggregation
  7. `_build_changes` re-read `council_history.csv` — now reuses pre-loaded DataFrames
- **Fixed pre-existing test failure**: `test_council_history_loaded_once` now passes

## Verified against production data

Generated digest with all 3 commodities (KC, CC, NG). All previously empty sections now populate:
- `cognitive_layer`: direction/strategy now populated
- `decision_traces`: `top_contributors` has 2 entries per trace
- `agent_contribution`: 7 agents per commodity
- `data_freshness`: 8 sentinels per commodity
- `portfolio`: NLV, VaR, drawdown populated
- `router_metrics`: total_requests, errors, fallbacks per commodity

## Test plan

- [x] All 40 `test_system_digest.py` tests pass (including previously failing `test_council_history_loaded_once`)
- [x] Full suite: 734 passed, 0 failed
- [x] Generated digest against production data — all sections populated correctly
- [x] Verified weekend behavior: scheduler skips weekends, digest only runs on trading days

🤖 Generated with [Claude Code](https://claude.com/claude-code)