### PR TITLE
fix: dashboard digest finds all commodities and parses vote weights

### DIFF
--- a/pages/5_Utilities.py
+++ b/pages/5_Utilities.py
@@ -522,7 +522,13 @@ with digest_cols[0]:
         with st.spinner("Generating System Health Digest..."):
             try:
                 from trading_bot.system_digest import generate_system_digest
-                digest = generate_system_digest(config)
+                # Ensure data_dir is set for the digest generator
+                # (orchestrator sets this at runtime, dashboard must set it explicitly)
+                digest_config = dict(config)
+                if 'data_dir' not in digest_config:
+                    digest_config['data_dir'] = os.path.join(
+                        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'data')
+                digest = generate_system_digest(digest_config)
 
                 if digest:
                     # Health score banner

--- a/trading_bot/system_digest.py
+++ b/trading_bot/system_digest.py
@@ -431,8 +431,12 @@ def _build_decision_traces(ch_df: pd.DataFrame, max_traces: int = 5) -> list:
                         items = vb.items()
                     elif isinstance(vb, list):
                         # vote_breakdown is stored as a list of dicts:
-                        # [{"agent": "agronomist", "direction": "BEARISH", "weight": 0.5}, ...]
-                        items = [(d.get('agent', ''), d.get('weight', 0)) for d in vb if isinstance(d, dict)]
+                        # [{"agent": "agronomist", "direction": "BEARISH", "contribution": -2.13, "final_weight": 2.37}, ...]
+                        items = [
+                            (d.get('agent', ''),
+                             d.get('contribution') or d.get('final_weight') or d.get('weight', 0))
+                            for d in vb if isinstance(d, dict)
+                        ]
                     else:
                         items = []
                     if items:
@@ -1123,7 +1127,8 @@ def generate_system_digest(config: dict) -> Optional[dict]:
         now = datetime.now(timezone.utc)
 
         # 1. Determine active tickers
-        active_tickers = config.get('commodities', [])
+        # 'commodities' is set at runtime by orchestrator; 'active_commodities' is in config.json
+        active_tickers = config.get('commodities', []) or config.get('active_commodities', [])
         if not active_tickers:
             ticker = config.get('commodity', {}).get('ticker', 'KC')
             active_tickers = [ticker]


### PR DESCRIPTION
## Summary

Follow-up to #1114. Two bugs found when generating the digest from the dashboard:

- **Config key mismatch**: `generate_system_digest()` read `config['commodities']` (set at runtime by orchestrator) but `config.json` uses `active_commodities`. Dashboard was generating with only KC. Now checks both keys. Dashboard also wasn't setting `data_dir` — added fallback to project root `data/` directory.
- **Vote weight parsing**: `vote_breakdown` entries use `contribution` and `final_weight` keys, not `weight`. All `top_contributors` showed `0.0` weight. Now reads `contribution` → `final_weight` → `weight` in priority order.

## Test plan

- [x] All 40 digest tests pass
- [x] Full suite: 734 passed, 0 failed
- [x] Verified dashboard-like config (no `commodities`, no `data_dir`) now discovers all 3 tickers via `active_commodities`
- [x] Verified vote weights now populate (e.g., `2.25` instead of `0.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)