### PR TITLE
docs: synchronize architecture docs with recent system capabilities

### DIFF
--- a/.jules/knowledge.md
+++ b/.jules/knowledge.md
@@ -9,11 +9,12 @@ The system is organized into a tiered architecture:
 ### Tier 1: Always-On Sentinels
 Sentinels are lightweight monitors that observe external data sources and trigger the decision pipeline when significant events occur.
 - **PriceSentinel:** Monitors for rapid price movements or liquidity gaps.
-- **WeatherSentinel:** Tracks weather patterns in key commodity regions (e.g., Brazil for Coffee).
+- **WeatherSentinel:** Tracks weather patterns in key commodity regions (e.g., Brazil for Coffee (KC) or Cocoa (CC)).
 - **LogisticsSentinel:** Monitors RSS feeds for strikes, port closures, or canal disruptions.
 - **NewsSentinel:** Scans news feeds for fundamental shifts.
 - **XSentimentSentinel:** Analyzes social media sentiment on X (via xAI).
 - **PredictionMarketSentinel:** Monitors Polymarket odds for geopolitical or macro events.
+- **TopicDiscoveryAgent:** Dynamically scans Polymarket for new, relevant topics using Claude Haiku to auto-configure the PredictionMarketSentinel.
 - **MacroContagionSentinel:** Detects cross-asset contagion (e.g., DXY, Gold correlation).
 - **FundamentalRegimeSentinel:** Determines long-term surplus/deficit regimes.
 - **MicrostructureSentinel:** Monitors order book depth and flow toxicity.
@@ -44,7 +45,7 @@ A set of agents that synthesize the analysts' reports.
 
 ## Infrastructure
 
-- **Master Orchestrator:** Manages multi-commodity instances.
+- **Master Orchestrator:** Manages multi-commodity instances for active tickers (Coffee, Cocoa, Natural Gas).
 - **Commodity Engine:** Runs the per-commodity loop.
 - **Heterogeneous Router:** Dispatches LLM calls to Gemini, OpenAI, Anthropic, or xAI.
 - **Semantic Cache:** Caches decisions to optimize costs and latency.
@@ -63,3 +64,4 @@ The system uses a **Transactive Memory System (TMS)** powered by ChromaDB. This 
 2. **Scheduled Cycle:** Runs 3 times per session (at 20%, 62%, and 80% of session duration) to generate daily orders.
 3. **Position Audit Cycle:** Regularly reviews open positions against their original entry thesis to decide on early exits.
 4. **Reconciliation Cycle:** Syncs the local trade ledger with IBKR records at the end of the day.
+5. **System Health Digest Cycle:** Generates a daily post-close JSON summary of system health, agent calibration, and error telemetry without interacting with IBKR or live LLMs.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An event-driven, multi-agent AI trading system for commodity futures options. Us
 
 ## Architecture: The Federated Cognitive Lattice
 
-The system operates on a tiered, event-driven architecture designed for modularity, fail-safety, and heterogeneous intelligence. The default execution mode is **Multi-Commodity**, where a `MasterOrchestrator` manages isolated `CommodityEngine` instances for each active ticker (e.g., Coffee, Cocoa).
+The system operates on a tiered, event-driven architecture designed for modularity, fail-safety, and heterogeneous intelligence. The default execution mode is **Multi-Commodity**, where a `MasterOrchestrator` manages isolated `CommodityEngine` instances for each active ticker (e.g., Coffee (KC), Cocoa (CC), Natural Gas (NG)).
 
 ```mermaid
 graph TD
@@ -77,7 +77,7 @@ graph TD
 
 ### Core Components
 
-1.  **Master Orchestrator (`trading_bot/master_orchestrator.py`):** The top-level supervisor. Spawns and monitors `CommodityEngine` processes for each active ticker. Manages **Shared Services** (Equity Polling, Macro Research, Post-Close Reconciliation) to prevent API redundancy.
+1.  **Master Orchestrator (`trading_bot/master_orchestrator.py`):** The top-level supervisor. Spawns and monitors `CommodityEngine` processes for each active ticker. Manages **Shared Services** (Equity Polling, Macro Research, Post-Close Reconciliation, System Health Digest) to prevent API redundancy.
 2.  **Commodity Engine (`trading_bot/commodity_engine.py`):** The isolated runtime for a single commodity. Manages its own Sentinels, Council, and Schedule. Ensures strict data isolation.
 3.  **Heterogeneous Router (`trading_bot/heterogeneous_router.py`):** Routes LLM requests to the best-fit provider (Gemini, OpenAI, Anthropic, xAI) based on the agent's role.
 4.  **Semantic Cache (`trading_bot/semantic_cache.py`):** Caches Council decisions based on market state vectors. Prevents redundant LLM calls.
@@ -85,6 +85,7 @@ graph TD
 6.  **Brier Bridge (`trading_bot/brier_bridge.py`):** Tracks agent accuracy using an Enhanced Probabilistic Brier Score system to weight agent opinions dynamically.
 7.  **DSPy Optimizer (`trading_bot/dspy_optimizer.py`):** Offline pipeline that refines agent prompts using historical feedback (BootstrapFewShot).
 8.  **Automated Trade Journal (`trading_bot/trade_journal.py`):** Generates structured post-mortem narratives for every closed trade, stored in TMS for future learning.
+9.  **System Health Digest (`trading_bot/system_digest.py`):** Generates a daily post-close JSON summary of system health, agent calibration, and error telemetry.
 
 ### Tier 1: Sentinels (`trading_bot/sentinels.py`)
 Lightweight monitors that scan 24/7 for specific triggers.
@@ -133,6 +134,7 @@ Specialized LLM personas that analyze grounded data.
     *   **Compliance Guardian** checks VaR limits, margin, and concentration.
 8.  **Execution:** `OrderManager` constructs the order and submits to `ib_interface.py`.
 9.  **Monitoring:** System monitors positions for P&L, regime shifts, and thesis invalidation.
+10. **Digest:** Post-close `System Health Digest` generation summarizes system state and errors.
 
 ## Running
 


### PR DESCRIPTION
This pull request updates the architecture documentation to accurately reflect recent code additions and the current system state. Specifically:
- **System Health Digest**: Added to `README.md` (Core Components, Information Flow) and `.jules/knowledge.md` (Operational Cycles) as a new daily post-close generation cycle.
- **Natural Gas (NG)**: Added to the list of active commodities (`README.md`, `.jules/knowledge.md`).
- **TopicDiscoveryAgent**: Described in `.jules/knowledge.md` under Always-On Sentinels, reflecting its integration with the Polymarket/PredictionMarketSentinel.

These changes ensure the high-level architecture documents are synchronized with the multi-commodity expansion (KC, CC, NG) and the new daily operational digest feature.

Tests were successfully run locally to guarantee no regressions in the `.py` tests related to these modifications.

---
*PR created automatically by Jules for task [7364904057323392397](https://jules.google.com/task/7364904057323392397) started by @rozavala*