### PR TITLE
docs: synchronize architecture docs with recent cost control and observability features

### DIFF
--- a/.jules/knowledge.md
+++ b/.jules/knowledge.md
@@ -12,7 +12,7 @@ Sentinels are lightweight monitors that observe external data sources and trigge
 - **WeatherSentinel:** Tracks weather patterns in key commodity regions (e.g., Brazil for Coffee (KC) or Cocoa (CC)).
 - **LogisticsSentinel:** Monitors RSS feeds for strikes, port closures, or canal disruptions.
 - **NewsSentinel:** Scans news feeds for fundamental shifts.
-- **XSentimentSentinel:** Analyzes social media sentiment on X (via xAI).
+- **XSentimentSentinel:** Analyzes social media sentiment on X (via xAI) and incorporates a multi-level spend-cap circuit breaker to throttle API calls during inactive market regimes or upon hitting budget limits.
 - **PredictionMarketSentinel:** Monitors Polymarket odds for geopolitical or macro events.
 - **TopicDiscoveryAgent:** Dynamically scans Polymarket for new, relevant topics using Claude Haiku to auto-configure the PredictionMarketSentinel.
 - **MacroContagionSentinel:** Detects cross-asset contagion (e.g., DXY, Gold correlation).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ This document provides instructions and guidelines for AI agents (like Jules) wo
 -   **Commodity Engine (`trading_bot/commodity_engine.py`):** The isolated runtime for a single commodity (ticker).
 -   **Heterogeneous Router (`trading_bot/heterogeneous_router.py`):** Routes LLM calls to different providers (Gemini, OpenAI, Anthropic, xAI).
 -   **Semantic Cache (`trading_bot/semantic_cache.py`):** Caches decisions to avoid redundant API calls.
--   **Sentinels (`trading_bot/sentinels.py`):** Monitor external events (Price, Weather, News, Polymarket, Macro).
+-   **Sentinels (`trading_bot/sentinels.py`):** Monitor external events (Price, Weather, News, Polymarket, Macro). Must implement graceful rate-limiting and API spend-cap circuit breakers to control costs autonomously.
 -   **Council (`trading_bot/agents.py`):** Specialized agents that debate and decide on trades.
 -   **Compliance (`trading_bot/compliance.py`):** Enforces risk limits and "dead checks".
 -   **Portfolio Risk Guard (`trading_bot/var_calculator.py`):** Calculates portfolio-wide VaR (95%/99%) and runs the **AI Risk Agent** for narrative analysis and stress testing.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Lightweight monitors that scan 24/7 for specific triggers.
 *   **WeatherSentinel:** Tracks precipitation/temp in key growing regions (via Open-Meteo).
 *   **LogisticsSentinel:** Monitors supply chain disruptions via RSS & Gemini Flash.
 *   **NewsSentinel:** Scans global news for fundamental shifts.
-*   **XSentimentSentinel:** Analyzes real-time social sentiment on X (via xAI).
+*   **XSentimentSentinel:** Analyzes real-time social sentiment on X (via xAI) with automated multi-level circuit breakers for API cost control.
 *   **PredictionMarketSentinel:** Monitors Polymarket odds for geopolitical/macro events via Gamma API.
 *   **TopicDiscoveryAgent (`trading_bot/topic_discovery.py`):** Dynamically scans Polymarket for new, relevant topics using Claude Haiku and auto-configures the PredictionMarketSentinel.
 *   **MacroContagionSentinel:** Detects cross-asset contagion (DXY shocks, Fed policy shifts, gold/silver correlation).
@@ -134,7 +134,7 @@ Specialized LLM personas that analyze grounded data.
     *   **Compliance Guardian** checks VaR limits, margin, and concentration.
 8.  **Execution:** `OrderManager` constructs the order and submits to `ib_interface.py`.
 9.  **Monitoring:** System monitors positions for P&L, regime shifts, and thesis invalidation.
-10. **Digest:** Post-close `System Health Digest` generation summarizes system state and errors.
+10. **Digest:** Post-close `System Health Digest` generation summarizes multi-commodity system state and errors for observability.
 
 ## Running
 


### PR DESCRIPTION
This PR syncs the system documentation with the latest code state from the last 24 hours. Key highlights include describing the autonomous spend-cap circuit breakers and rate-limiting recently implemented in `XSentimentSentinel` (to mitigate API runaway costs) and updating the `System Health Digest` documentation to explicitly note its multi-commodity capability. No application logic was modified.

---
*PR created automatically by Jules for task [13260417592727067644](https://jules.google.com/task/13260417592727067644) started by @rozavala*