### PR TITLE
fix: reconciliation incorrectly orphans theses on identical contracts

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1267,20 +1267,92 @@ async def _reconcile_orphaned_theses(
             logger.debug("Reconciliation: No active theses to reconcile")
             return 0
 
-        # 2. Build set of position_ids with live IB exposure
+        # 2. Build actual IB aggregate: {local_symbol: net_qty}
         try:
             live_positions = await asyncio.wait_for(ib.reqPositionsAsync(), timeout=30)
         except asyncio.TimeoutError:
-            logger.error("Reconciliation: reqPositionsAsync timed out (30s), treating as empty")
-            live_positions = []
+            logger.error("Reconciliation: reqPositionsAsync timed out (30s), skipping")
+            return 0  # Fail closed: don't orphan anything on timeout
+
+        commodity_symbol = config.get('symbol', 'KC')
+        ib_aggregate = {}
+        for pos in live_positions:
+            if pos.position == 0 or pos.contract.symbol != commodity_symbol:
+                continue
+            sym = pos.contract.localSymbol
+            ib_aggregate[sym] = ib_aggregate.get(sym, 0) + pos.position
+
+        # 2b. Build expected quantities per thesis from trade ledger
+        thesis_expected = {}  # tid -> {local_symbol: net_qty}
+        for tid in active_thesis_ids:
+            if trade_ledger.empty or 'position_id' not in trade_ledger.columns:
+                continue
+            tid_rows = trade_ledger[trade_ledger['position_id'] == tid]
+            if tid_rows.empty:
+                continue
+            leg_map = {}
+            for _, row in tid_rows.iterrows():
+                sym = row.get('local_symbol', '')
+                if not sym:
+                    continue
+                qty = row['quantity'] if row['action'] == 'BUY' else -row['quantity']
+                leg_map[sym] = leg_map.get(sym, 0) + qty
+            leg_map = {s: q for s, q in leg_map.items() if q != 0}
+            if leg_map:
+                thesis_expected[tid] = leg_map
+
+        # 2c. Greedy FIFO allocation — oldest theses claim IB qty first
+        thesis_order = []
+        for tid in active_thesis_ids:
+            if tid in thesis_expected:
+                tid_rows = trade_ledger[trade_ledger['position_id'] == tid]
+                entry_time = tid_rows['timestamp'].min() if not tid_rows.empty else ''
+                thesis_order.append((tid, entry_time))
+        thesis_order.sort(key=lambda x: x[1])
+
+        remaining_ib = dict(ib_aggregate)
         live_position_ids = set()
 
-        for pos in live_positions:
-            if pos.position == 0:
-                continue
-            pos_id = _find_position_id_for_contract(pos, trade_ledger)
-            if pos_id:
-                live_position_ids.add(pos_id)
+        for tid, _ in thesis_order:
+            expected_legs = thesis_expected[tid]
+            all_covered = True
+            for sym, exp_qty in expected_legs.items():
+                avail = remaining_ib.get(sym, 0)
+                if exp_qty > 0 and avail < exp_qty:
+                    all_covered = False
+                    break
+                if exp_qty < 0 and avail > exp_qty:
+                    all_covered = False
+                    break
+
+            if all_covered:
+                for sym, exp_qty in expected_legs.items():
+                    remaining_ib[sym] = remaining_ib.get(sym, 0) - exp_qty
+                live_position_ids.add(tid)
+            else:
+                # Fail closed: if ANY leg still has IB backing, don't orphan
+                any_present = any(
+                    (exp > 0 and remaining_ib.get(s, 0) > 0) or
+                    (exp < 0 and remaining_ib.get(s, 0) < 0)
+                    for s, exp in expected_legs.items()
+                )
+                if any_present:
+                    live_position_ids.add(tid)
+                    logger.warning(
+                        f"Reconciliation: Thesis {tid} partially covered "
+                        f"(expected={expected_legs}, remaining={remaining_ib}). "
+                        f"Keeping alive (fail-closed)."
+                    )
+
+        # Theses with no ledger entries but IB has positions: fail closed
+        for tid in active_thesis_ids:
+            if tid not in thesis_expected and tid not in live_position_ids:
+                if ib_aggregate:
+                    logger.warning(
+                        f"Reconciliation: Thesis {tid} has no ledger entries "
+                        f"but IB has positions. Skipping invalidation (fail-closed)."
+                    )
+                    live_position_ids.add(tid)
 
         # 3. Identify orphans: active in TMS but not in IB
         orphaned_ids = [

--- a/tests/test_exit_integration.py
+++ b/tests/test_exit_integration.py
@@ -25,6 +25,7 @@ from trading_bot.strategy import validate_iron_condor_risk
 from orchestrator import (
     _validate_thesis,
     _find_position_id_for_contract,
+    _reconcile_orphaned_theses,
     run_position_audit_cycle
 )
 from trading_bot.sentinels import SentinelTrigger
@@ -448,6 +449,237 @@ class TestPositionIdEdgeCases(unittest.TestCase):
         result = _find_position_id_for_contract(mock_position, trade_ledger, tms=tms)
         # Should still find POS_001 via direction/FIFO matching (Strategy 2)
         self.assertEqual(result, 'POS_001')
+
+
+class TestReconcileOrphanedThesesAggregation(unittest.IsolatedAsyncioTestCase):
+    """
+    Tests for aggregate-quantity reconciliation in _reconcile_orphaned_theses.
+    Validates that identical contracts across multiple theses are handled correctly
+    when IBKR aggregates them into a single position with combined qty.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.tms = TransactiveMemory(persist_path=self.temp_dir)
+        self.config = {'symbol': 'KC', 'exchange': 'NYBOT'}
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _make_ib_position(self, local_symbol, qty, symbol='KC'):
+        """Helper to create a mock IB Position."""
+        pos = MagicMock()
+        pos.contract.localSymbol = local_symbol
+        pos.contract.symbol = symbol
+        pos.position = qty
+        return pos
+
+    def _record_thesis(self, tid):
+        """Helper to register an active thesis in TMS."""
+        self.tms.record_trade_thesis(tid, {
+            'strategy_type': 'BEAR_PUT_SPREAD',
+            'guardian_agent': 'Master',
+            'primary_rationale': 'Test thesis',
+            'invalidation_triggers': ['test'],
+            'entry_timestamp': datetime.now(timezone.utc).isoformat(),
+            'entry_regime': 'TRENDING',
+            'supporting_data': {}
+        })
+
+    async def test_two_identical_spreads_both_live(self):
+        """
+        IB shows qty=2 on each leg. Two theses each expect qty=1.
+        Both theses should survive — neither is orphaned.
+        """
+        tid1, tid2 = 'thesis_older', 'thesis_newer'
+        self._record_thesis(tid1)
+        self._record_thesis(tid2)
+
+        # Trade ledger: two bear put spreads on identical contracts
+        trade_ledger = pd.DataFrame({
+            'position_id': [tid1, tid1, tid2, tid2],
+            'local_symbol': ['KCN6 P275', 'KCN6 P270', 'KCN6 P275', 'KCN6 P270'],
+            'action': ['BUY', 'SELL', 'BUY', 'SELL'],
+            'quantity': [1, 1, 1, 1],
+            'timestamp': [
+                datetime(2026, 2, 28, 10, 0),
+                datetime(2026, 2, 28, 10, 0),
+                datetime(2026, 3, 1, 10, 0),
+                datetime(2026, 3, 1, 10, 0),
+            ]
+        })
+
+        # IB aggregates: 2 long P275, 2 short P270
+        mock_ib = MagicMock()
+        mock_ib.reqPositionsAsync = AsyncMock(return_value=[
+            self._make_ib_position('KCN6 P275', 2),
+            self._make_ib_position('KCN6 P270', -2),
+        ])
+
+        result = await _reconcile_orphaned_theses(mock_ib, trade_ledger, self.tms, self.config)
+        self.assertEqual(result, 0, "No theses should be orphaned when IB qty covers both")
+
+        # Verify both theses remain active
+        active = self.tms.collection.get(where={"active": "true"}, include=['metadatas'])
+        active_ids = {m['trade_id'] for m in active['metadatas']}
+        self.assertIn(tid1, active_ids)
+        self.assertIn(tid2, active_ids)
+
+    async def test_one_of_two_identical_closed(self):
+        """
+        IB shows qty=1 on each leg. Two theses each expect qty=1.
+        Oldest (FIFO) should survive, newer should be orphaned.
+        """
+        tid1, tid2 = 'thesis_older', 'thesis_newer'
+        self._record_thesis(tid1)
+        self._record_thesis(tid2)
+
+        trade_ledger = pd.DataFrame({
+            'position_id': [tid1, tid1, tid2, tid2],
+            'local_symbol': ['KCN6 P275', 'KCN6 P270', 'KCN6 P275', 'KCN6 P270'],
+            'action': ['BUY', 'SELL', 'BUY', 'SELL'],
+            'quantity': [1, 1, 1, 1],
+            'timestamp': [
+                datetime(2026, 2, 28, 10, 0),
+                datetime(2026, 2, 28, 10, 0),
+                datetime(2026, 3, 1, 10, 0),
+                datetime(2026, 3, 1, 10, 0),
+            ]
+        })
+
+        # IB only has qty=1 — one spread was closed externally
+        mock_ib = MagicMock()
+        mock_ib.reqPositionsAsync = AsyncMock(return_value=[
+            self._make_ib_position('KCN6 P275', 1),
+            self._make_ib_position('KCN6 P270', -1),
+        ])
+
+        result = await _reconcile_orphaned_theses(mock_ib, trade_ledger, self.tms, self.config)
+        self.assertEqual(result, 1, "Newer thesis should be orphaned")
+
+        # Verify older survived, newer invalidated
+        active = self.tms.collection.get(where={"active": "true"}, include=['metadatas'])
+        active_ids = {m['trade_id'] for m in active['metadatas']}
+        self.assertIn(tid1, active_ids, "Older thesis should survive (FIFO)")
+        self.assertNotIn(tid2, active_ids, "Newer thesis should be orphaned")
+
+    async def test_different_spreads_unaffected(self):
+        """
+        Two theses on different contracts — standard mapping should work fine.
+        """
+        tid1, tid2 = 'thesis_jul', 'thesis_may'
+        self._record_thesis(tid1)
+        self._record_thesis(tid2)
+
+        trade_ledger = pd.DataFrame({
+            'position_id': [tid1, tid1, tid2, tid2],
+            'local_symbol': ['KCN6 P275', 'KCN6 P270', 'KCK6 P285', 'KCK6 P280'],
+            'action': ['BUY', 'SELL', 'BUY', 'SELL'],
+            'quantity': [1, 1, 1, 1],
+            'timestamp': [
+                datetime(2026, 2, 28, 10, 0),
+                datetime(2026, 2, 28, 10, 0),
+                datetime(2026, 3, 1, 10, 0),
+                datetime(2026, 3, 1, 10, 0),
+            ]
+        })
+
+        mock_ib = MagicMock()
+        mock_ib.reqPositionsAsync = AsyncMock(return_value=[
+            self._make_ib_position('KCN6 P275', 1),
+            self._make_ib_position('KCN6 P270', -1),
+            self._make_ib_position('KCK6 P285', 1),
+            self._make_ib_position('KCK6 P280', -1),
+        ])
+
+        result = await _reconcile_orphaned_theses(mock_ib, trade_ledger, self.tms, self.config)
+        self.assertEqual(result, 0, "Both distinct spreads should be matched")
+
+    async def test_no_ib_positions_all_orphaned(self):
+        """
+        IB has no positions. All active theses should be orphaned.
+        """
+        tid1, tid2 = 'thesis_a', 'thesis_b'
+        self._record_thesis(tid1)
+        self._record_thesis(tid2)
+
+        trade_ledger = pd.DataFrame({
+            'position_id': [tid1, tid1, tid2, tid2],
+            'local_symbol': ['KCN6 P275', 'KCN6 P270', 'KCN6 P275', 'KCN6 P270'],
+            'action': ['BUY', 'SELL', 'BUY', 'SELL'],
+            'quantity': [1, 1, 1, 1],
+            'timestamp': [
+                datetime(2026, 2, 28, 10, 0),
+                datetime(2026, 2, 28, 10, 0),
+                datetime(2026, 3, 1, 10, 0),
+                datetime(2026, 3, 1, 10, 0),
+            ]
+        })
+
+        mock_ib = MagicMock()
+        mock_ib.reqPositionsAsync = AsyncMock(return_value=[])
+
+        result = await _reconcile_orphaned_theses(mock_ib, trade_ledger, self.tms, self.config)
+        self.assertEqual(result, 2, "Both theses should be orphaned")
+
+    async def test_partial_coverage_fail_closed(self):
+        """
+        IB has one leg but not the other for a thesis. Thesis should be kept alive
+        (fail-closed) because partial IB backing suggests something is still live.
+        """
+        tid1 = 'thesis_partial'
+        self._record_thesis(tid1)
+
+        trade_ledger = pd.DataFrame({
+            'position_id': [tid1, tid1],
+            'local_symbol': ['KCN6 P275', 'KCN6 P270'],
+            'action': ['BUY', 'SELL'],
+            'quantity': [1, 1],
+            'timestamp': [
+                datetime(2026, 2, 28, 10, 0),
+                datetime(2026, 2, 28, 10, 0),
+            ]
+        })
+
+        # IB has the long leg but NOT the short leg
+        mock_ib = MagicMock()
+        mock_ib.reqPositionsAsync = AsyncMock(return_value=[
+            self._make_ib_position('KCN6 P275', 1),
+        ])
+
+        result = await _reconcile_orphaned_theses(mock_ib, trade_ledger, self.tms, self.config)
+        self.assertEqual(result, 0, "Partially covered thesis should NOT be orphaned (fail-closed)")
+
+        # Verify thesis remains active
+        active = self.tms.collection.get(where={"active": "true"}, include=['metadatas'])
+        active_ids = {m['trade_id'] for m in active['metadatas']}
+        self.assertIn(tid1, active_ids)
+
+    async def test_timeout_fail_closed(self):
+        """
+        reqPositionsAsync times out. Should return 0, not orphan everything.
+        """
+        tid1 = 'thesis_timeout'
+        self._record_thesis(tid1)
+
+        trade_ledger = pd.DataFrame({
+            'position_id': [tid1],
+            'local_symbol': ['KCN6 P275'],
+            'action': ['BUY'],
+            'quantity': [1],
+            'timestamp': [datetime(2026, 2, 28, 10, 0)],
+        })
+
+        mock_ib = MagicMock()
+        mock_ib.reqPositionsAsync = AsyncMock(side_effect=asyncio.TimeoutError())
+
+        result = await _reconcile_orphaned_theses(mock_ib, trade_ledger, self.tms, self.config)
+        self.assertEqual(result, 0, "Timeout should fail closed, not orphan anything")
+
+        # Thesis should still be active
+        active = self.tms.collection.get(where={"active": "true"}, include=['metadatas'])
+        active_ids = {m['trade_id'] for m in active['metadatas']}
+        self.assertIn(tid1, active_ids)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- **Bug**: When IBKR aggregates multiple spreads on identical contracts (e.g., two bear put spreads both on KCN6 P275/P270) into a single Position with `qty=2`, the old per-position mapping via `_find_position_id_for_contract()` only matched one thesis (FIFO oldest), incorrectly orphaning the second as a "ghost"
- **Impact**: Two live theses (`f42278bf`, `31c4339d`) were wrongly invalidated on 2026-03-02 — both manually reactivated in TMS
- **Fix**: Replace per-position mapping loop with aggregate quantity comparison using FIFO greedy allocation, with fail-closed safety for partial coverage and timeouts

## Test plan

- [x] 6 new tests in `TestReconcileOrphanedThesesAggregation`: two identical spreads both live, one of two closed (FIFO), different spreads unaffected, no IB positions, partial coverage fail-closed, timeout fail-closed
- [x] Full test suite passes (744 passed)
- [ ] Deploy and verify: with 4 live spreads (2× Jul P275/P270, 2× May P285/P280), reconciliation should report all theses matched

🤖 Generated with [Claude Code](https://claude.com/claude-code)