### PR TITLE
🎨 Palette: Enhance Council traceability and scannability

### DIFF
--- a/pages/3_The_Council.py
+++ b/pages/3_The_Council.py
@@ -109,7 +109,20 @@ else:
 row = council_df.loc[selected_idx]
 
 # Display details for selected decision
-st.caption(f"📍 **Selected Decision:** {row['timestamp'].strftime('%Y-%m-%d %H:%M:%S UTC')} ({_relative_time(row['timestamp'])})")
+meta_col1, meta_col2 = st.columns([4, 1])
+with meta_col1:
+    st.caption(f"📍 **Selected Decision:** {row['timestamp'].strftime('%Y-%m-%d %H:%M:%S UTC')} ({_relative_time(row['timestamp'])})")
+with meta_col2:
+    # UX Improvement: Copy Cycle ID for traceability
+    cycle_id = row.get('cycle_id', 'UNKNOWN')
+    label = f"🆔 {str(cycle_id)[:8]}"
+    if hasattr(st, "popover"):
+        with st.popover(label, width="stretch"):
+            st.code(cycle_id, language=None)
+            st.caption("Full Cycle ID")
+    else:
+        with st.expander(label):
+            st.code(cycle_id, language=None)
 
 # === SIDEBAR: Consensus Meter ===
 with st.sidebar:
@@ -319,19 +332,19 @@ if vote_breakdown_raw and pd.notna(vote_breakdown_raw) and str(vote_breakdown_ra
             # Metrics row
             metric_cols = st.columns(4)
             with metric_cols[0]:
-                st.metric("Dominant Agent", row.get('dominant_agent', 'Unknown'),
+                st.metric("👑 Dominant Agent", row.get('dominant_agent', 'Unknown'),
                           help="The agent whose vote had the highest influence on the final decision.")
             with metric_cols[1]:
                 ws = row.get('weighted_score', 0)
-                st.metric("Weighted Score", f"{float(ws):.4f}" if ws else "N/A",
+                st.metric("⚖️ Weighted Score", f"{float(ws):.4f}" if ws else "N/A",
                           help="The final consensus score (-1.0 to 1.0) calculated from all agent votes.")
             with metric_cols[2]:
                 active = len([v for v in vote_data if v.get('direction') != 'NEUTRAL'])
-                st.metric("Active Voters", f"{active}/{len(vote_data)}",
+                st.metric("🗳️ Active Voters", f"{active}/{len(vote_data)}",
                           help="Number of agents who provided a non-neutral sentiment.")
             with metric_cols[3]:
                 trigger = row.get('trigger_type', 'scheduled')
-                st.metric("Trigger", trigger.replace('_', ' ').title(),
+                st.metric("⚡ Trigger", trigger.replace('_', ' ').title(),
                           help="The event or schedule that initiated this Council deliberation.")
         else:
             st.info("ℹ️ Vote breakdown is empty for this decision")
@@ -477,13 +490,13 @@ with master_cols[1]:
         confidence = 0.0
     else:
         confidence = float(confidence)
-    st.metric("Confidence", f"{confidence:.1%}",
+    st.metric("🎯 Confidence", f"{confidence:.1%}",
               help="The Master Strategist's certainty level in the chosen strategy.")
 
 with master_cols[2]:
     approved = row.get('compliance_approved', True)
     status = "✅ Approved" if approved else "❌ Vetoed"
-    st.metric("Compliance", status,
+    st.metric("🛡️ Compliance", status,
               help="Whether the trade passed all safety and risk guardrails.")
 
 with master_cols[3]:
@@ -492,12 +505,12 @@ with master_cols[3]:
         try:
             conv_val = round(float(conviction), 2)
             conv_label = {1.0: "✅ Aligned", 0.75: "⚠️ Partial", 0.70: "🔻 Divergent", 0.65: "🔻 Divergent", 0.5: "🔻 Divergent"}.get(conv_val, f"{conv_val:.2f}")
-            st.metric("Consensus", conv_label,
+            st.metric("🤝 Consensus", conv_label,
                       help="Degree of alignment among voting agents.")
         except (ValueError, TypeError):
-            st.metric("Consensus", "N/A", help="Degree of alignment among voting agents.")
+            st.metric("🤝 Consensus", "N/A", help="Degree of alignment among voting agents.")
     else:
-        st.metric("Consensus", "N/A", help="Degree of alignment among voting agents.")
+        st.metric("🤝 Consensus", "N/A", help="Degree of alignment among voting agents.")
 
 # Reasoning
 st.markdown("**Master Reasoning:**")
@@ -533,16 +546,16 @@ if pd.notna(actual_trend) and actual_trend:
 
     with outcome_cols[1]:
         trend_icon = "📈" if actual_trend == "UP" else "📉"
-        st.metric("Market Move", f"{trend_icon} {actual_trend}",
+        st.metric("📉 Market Move", f"{trend_icon} {actual_trend}",
                   help="The actual realized direction of the market after the decision.")
 
     with outcome_cols[2]:
         exit_price = row.get('exit_price', None)
         if pd.notna(exit_price):
-            st.metric("Exit Price", f"${float(exit_price):.2f}",
+            st.metric("🚪 Exit Price", f"${float(exit_price):.2f}",
                       help="The price at which the position was closed.")
         else:
-            st.metric("Exit Price", "Pending",
+            st.metric("🚪 Exit Price", "Pending",
                       help="The price at which the position was closed.")
 
     with outcome_cols[3]:
@@ -550,10 +563,10 @@ if pd.notna(actual_trend) and actual_trend:
         if pd.notna(pnl):
             pnl_val = float(pnl)
             delta_color = "normal" if pnl_val >= 0 else "inverse"
-            st.metric("P&L", f"${pnl_val:.2f}", delta_color=delta_color,
+            st.metric("💰 P&L", f"${pnl_val:.2f}", delta_color=delta_color,
                       help="Realized Profit and Loss for this trade.")
         else:
-            st.metric("P&L", "Pending",
+            st.metric("💰 P&L", "Pending",
                       help="Realized Profit and Loss for this trade.")
 else:
     st.info("⏳ Decision pending reconciliation (T+1)")

--- a/tests/test_ui_ux.py
+++ b/tests/test_ui_ux.py
@@ -237,8 +237,8 @@ class TestCouncilUX(unittest.TestCase):
             tree = ast.parse(f.read())
 
         target_metrics = [
-            "Dominant Agent", "Weighted Score", "Active Voters", "Trigger",
-            "Confidence", "Compliance", "Consensus", "Market Move", "Exit Price", "P&L"
+            "👑 Dominant Agent", "⚖️ Weighted Score", "🗳️ Active Voters", "⚡ Trigger",
+            "🎯 Confidence", "🛡️ Compliance", "🤝 Consensus", "📉 Market Move", "🚪 Exit Price", "💰 P&L"
         ]
         found_metrics = {m: False for m in target_metrics}
 


### PR DESCRIPTION
### 🎨 Palette: Traceability & Scannability Enhancement

#### 💡 What
- Added a `Cycle ID` popover in `pages/3_The_Council.py` that provides a copyable unique identifier for each trading decision.
- Added semantic icons (👑, ⚖️, 🎯, 🗳️, etc.) to all `st.metric` components on the Council page.
- Updated UX unit tests in `tests/test_ui_ux.py` to match the new icon-inclusive labels.

#### 🎯 Why
- **Traceability:** Developers and power users often need to trace a dashboard decision back to logs or raw data. Hiding the `cycle_id` in a popover keeps the UI clean while providing instant access for forensic analysis.
- **Scannability:** Dashboard users process icons faster than text. The icons provide immediate context (e.g., 💰 for P&L, 🛡️ for Compliance) before the user even reads the label.

#### ♿ Accessibility & Standards
- Maintained all existing `help` tooltips for metrics.
- Used `hasattr(st, "popover")` to ensure backward compatibility for older Streamlit deployments.
- Kept changes under 50 lines.

#### 📸 Verification
- Ran full test suite: `744 passed`.
- Verified UI via Playwright (screenshots generated showing popover and icons).


---
*PR created automatically by Jules for task [13484473690667846136](https://jules.google.com/task/13484473690667846136) started by @cristobalmoena*