### PR TITLE
fix: topic discovery — bulk fetch, commodity filtering, state pruning

### DIFF
--- a/config.json
+++ b/config.json
@@ -228,6 +228,8 @@
         "auto_apply": true,
         "notify_on_change": true
       },
+      "max_topic_age_hours": 240,
+      "max_consecutive_failures": 50,
       "interest_areas": [
         {
           "name": "US Monetary Policy",
@@ -257,14 +259,15 @@
             {"type": "tag_scan", "tag_id": 100265, "limit": 10},
             {"type": "query", "q": "tariff"},
             {"type": "query", "q": "trade war"},
+            {"type": "query", "q": "trade deal"},
             {"type": "query", "q": "SCOTUS tariff"}
           ],
           "relevance_keywords": [
             "tariff", "trade", "sanction", "import", "export", "customs",
-            "duty", "ieepa", "scotus", "supreme court", "trade war"
+            "duty", "ieepa", "scotus", "supreme court", "trade war", "trade deal"
           ],
           "exclude_keywords": ["crypto", "nft", "sports"],
-          "min_relevance_score": 2,
+          "min_relevance_score": 1,
           "max_topics": 2,
           "default_threshold_pct": 8.0,
           "importance": "macro",
@@ -276,22 +279,25 @@
           "discovery_methods": [
             {"type": "tag_scan", "tag_id": 120, "limit": 20},
             {"type": "query", "q": "recession"},
-            {"type": "query", "q": "US economy"}
+            {"type": "query", "q": "US economy"},
+            {"type": "query", "q": "GDP growth"},
+            {"type": "query", "q": "inflation 2026"}
           ],
           "relevance_keywords": [
             "recession", "gdp", "unemployment", "inflation", "nber",
-            "economy", "growth", "contraction", "downturn"
+            "economy", "growth", "contraction", "downturn", "negative"
           ],
           "exclude_keywords": ["crypto", "bitcoin"],
-          "min_relevance_score": 2,
+          "min_relevance_score": 1,
           "max_topics": 2,
           "default_threshold_pct": 5.0,
           "importance": "macro",
-          "commodity_impact_template": "Economic contraction reduces coffee demand; recession fears drive USD safe-haven flows"
+          "commodity_impact_template": "Economic contraction reduces commodity demand; recession fears drive USD safe-haven flows"
         },
         {
           "name": "Brazil Economy",
           "enabled": true,
+          "commodities": ["KC"],
           "discovery_methods": [
             {"type": "query", "q": "Brazil rate"},
             {"type": "query", "q": "Selic rate"},
@@ -312,6 +318,7 @@
         {
           "name": "LatAm Geopolitics",
           "enabled": true,
+          "commodities": ["KC"],
           "llm_validation_required": true,
           "discovery_methods": [
             {"type": "tag_scan", "tag_id": 100265, "limit": 15},
@@ -334,6 +341,29 @@
           "default_threshold_pct": 5.0,
           "importance": "supply_chain",
           "commodity_impact_template": "LatAm geopolitical instability threatens commodity supply chains from origin countries"
+        },
+        {
+          "name": "Energy Geopolitics",
+          "enabled": true,
+          "commodities": ["NG"],
+          "discovery_methods": [
+            {"type": "query", "q": "Russia Ukraine ceasefire"},
+            {"type": "query", "q": "Iran sanctions"},
+            {"type": "query", "q": "Strait of Hormuz"},
+            {"type": "query", "q": "natural gas pipeline"},
+            {"type": "query", "q": "OPEC production"}
+          ],
+          "relevance_keywords": [
+            "russia", "ukraine", "ceasefire", "iran", "hormuz",
+            "sanctions", "pipeline", "lng", "natural gas", "opec",
+            "nord stream", "energy", "oil embargo", "gas supply"
+          ],
+          "exclude_keywords": ["crypto", "bitcoin", "sports", "football"],
+          "min_relevance_score": 1,
+          "max_topics": 3,
+          "default_threshold_pct": 8.0,
+          "importance": "supply_chain",
+          "commodity_impact_template": "Energy geopolitics affect natural gas supply routes, sanctions on producers, and global energy pricing"
         },
         {
           "name": "Fed Leadership",

--- a/tests/test_prediction_market_sentinel.py
+++ b/tests/test_prediction_market_sentinel.py
@@ -1,8 +1,12 @@
 import pytest
 import asyncio
+import json
+import os
+import tempfile
 from unittest.mock import AsyncMock, patch, MagicMock
 from datetime import datetime, timezone, timedelta
 from trading_bot.sentinels import PredictionMarketSentinel, SentinelTrigger
+from trading_bot.state_manager import StateManager
 
 
 @pytest.fixture(autouse=True)
@@ -363,3 +367,152 @@ async def test_hwm_decay_check():
 
     # None - should not decay
     assert sentinel._should_decay_hwm(None) is False
+
+
+# === Tests for state pruning, failure persistence, and topic staleness ===
+
+
+@pytest.mark.asyncio
+async def test_state_pruning_calls_delete_state_keys(mock_config):
+    """Orphaned state entries trigger StateManager.delete_state_keys."""
+    sentinel = PredictionMarketSentinel(mock_config)
+
+    # Inject orphaned entry into state_cache
+    sentinel.state_cache["Stale Tariff Topic"] = {
+        "slug": "tariff-old", "price": 0.1,
+        "timestamp": "2025-01-01T00:00:00+00:00"
+    }
+
+    with patch.object(StateManager, 'delete_state_keys') as mock_delete, \
+         patch.object(sentinel, '_save_state_cache'):
+        sentinel.reload_topics()
+
+    # Should have called delete_state_keys with the orphaned key
+    mock_delete.assert_called_once_with(
+        "prediction_market_state", ["Stale Tariff Topic"]
+    )
+    assert "Stale Tariff Topic" not in sentinel.state_cache
+
+
+@pytest.mark.asyncio
+async def test_failure_count_persisted_across_restarts(mock_config):
+    """Failure counts survive sentinel restarts via state_cache."""
+    sentinel = PredictionMarketSentinel(mock_config)
+    query = 'Federal Reserve Interest Rate'
+
+    # Mock StateManager returning persisted state with failure_count
+    persisted_state = {
+        query: {
+            'slug': 'fed-test', 'price': 0.5,
+            'timestamp': datetime.now(timezone.utc).isoformat(),
+            'severity_hwm': 0, 'hwm_timestamp': None,
+            'failure_count': 10
+        }
+    }
+
+    sentinel._topic_failure_counts = {}
+    with patch.object(StateManager, 'load_state_raw', return_value=persisted_state):
+        sentinel._load_state_cache()
+
+    assert sentinel._topic_failure_counts.get(query) == 10
+
+
+@pytest.mark.asyncio
+async def test_failure_threshold_sends_notification(mock_config):
+    """When topic hits max failures, notification is sent."""
+    mock_config['sentinels']['prediction_markets']['max_consecutive_failures'] = 3
+    sentinel = PredictionMarketSentinel(mock_config)
+    query = 'Federal Reserve Interest Rate'
+
+    # Pre-set failure count just below threshold
+    sentinel._topic_failure_counts[query] = 2
+
+    # Mock API returning no results
+    with patch('aiohttp.ClientSession.get') as mock_get:
+        mock_ctx = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=[])  # No events
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        mock_get.return_value = mock_ctx
+
+        with patch('trading_bot.sentinels.send_pushover_notification') as mock_notify, \
+             patch('trading_bot.utils.is_trading_day', return_value=True), \
+             patch('trading_bot.utils.is_market_open', return_value=True):
+            await sentinel.check()
+
+    # Should have sent notification about topic disablement
+    assert mock_notify.called
+    call_args = mock_notify.call_args
+    assert 'disabled' in call_args[0][1].lower() or 'Disabled' in call_args[0][1]
+
+
+@pytest.mark.asyncio
+async def test_stale_discovered_topics_pruned(mock_config, tmp_path):
+    """Discovered topics older than max_topic_age_hours are pruned."""
+    mock_config['sentinels']['prediction_markets']['max_topic_age_hours'] = 48
+    mock_config['data_dir'] = str(tmp_path)
+
+    # Create discovered topics file with one fresh and one stale
+    discovered = [
+        {
+            "query": "Fresh Topic",
+            "tag": "D_FRESH",
+            "display_name": "Fresh Topic",
+            "_discovery": {
+                "discovered_at": datetime.now(timezone.utc).isoformat(),
+                "slug": "fresh-topic"
+            }
+        },
+        {
+            "query": "Stale Topic",
+            "tag": "D_STALE",
+            "display_name": "Stale Topic",
+            "_discovery": {
+                "discovered_at": (datetime.now(timezone.utc) - timedelta(hours=100)).isoformat(),
+                "slug": "stale-topic"
+            }
+        }
+    ]
+    discovered_file = tmp_path / "discovered_topics.json"
+    discovered_file.write_text(json.dumps(discovered))
+
+    sentinel = PredictionMarketSentinel(mock_config)
+    sentinel._prune_stale_discovered_topics()
+
+    with open(discovered_file) as f:
+        remaining = json.load(f)
+
+    assert len(remaining) == 1
+    assert remaining[0]['query'] == "Fresh Topic"
+
+
+def test_delete_state_keys(tmp_path):
+    """StateManager.delete_state_keys removes keys from namespace."""
+    # Use set_data_dir to point StateManager at tmp_path
+    StateManager.set_data_dir(str(tmp_path))
+    try:
+        state_file = tmp_path / "state.json"
+        initial = {
+            "test_ns": {
+                "keep_me": {"data": {"val": 1}, "timestamp": 100},
+                "delete_me": {"data": {"val": 2}, "timestamp": 200},
+                "also_delete": {"data": {"val": 3}, "timestamp": 300}
+            }
+        }
+        state_file.write_text(json.dumps(initial))
+
+        StateManager.delete_state_keys("test_ns", ["delete_me", "also_delete"])
+
+        with open(state_file) as f:
+            result = json.load(f)
+
+        assert "keep_me" in result["test_ns"]
+        assert "delete_me" not in result["test_ns"]
+        assert "also_delete" not in result["test_ns"]
+    finally:
+        # Reset to default
+        StateManager.set_data_dir(os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), 'data', 'KC'
+        ))

--- a/trading_bot/sentinels.py
+++ b/trading_bot/sentinels.py
@@ -2083,6 +2083,10 @@ class PredictionMarketSentinel(Sentinel):
         """Reload topics from config + discovered topics, pruning orphaned cache entries."""
         logger.info("Reloading prediction market topics...")
         static_topics = self.sentinel_config.get('topics_to_watch', [])
+
+        # Prune stale discovered topics before merging
+        self._prune_stale_discovered_topics()
+
         self.topics = self._merge_discovered_topics(static_topics)
 
         # Prune orphaned cache entries for topics no longer active
@@ -2094,9 +2098,43 @@ class PredictionMarketSentinel(Sentinel):
 
         if orphaned:
             self._save_state_cache()
-            logger.info(f"Pruned {len(orphaned)} orphaned cache entries")
+            # Also delete from StateManager (save_state merges, won't remove keys)
+            StateManager.delete_state_keys("prediction_market_state", orphaned)
+            logger.info(f"Pruned {len(orphaned)} orphaned cache entries from state")
 
         logger.info(f"Topics reloaded: {len(self.topics)}")
+
+    def _prune_stale_discovered_topics(self):
+        """Remove discovered topics older than max_topic_age_hours."""
+        max_age_hours = self.sentinel_config.get('max_topic_age_hours', 240)  # 10 days default
+        data_dir = self.config.get('data_dir', 'data')
+        discovered_file = os.path.join(data_dir, "discovered_topics.json")
+        if not os.path.exists(discovered_file):
+            return
+        try:
+            with open(discovered_file, 'r') as f:
+                topics = json.load(f)
+            now = datetime.now(timezone.utc)
+            kept = []
+            pruned = []
+            for topic in topics:
+                discovered_at = topic.get('_discovery', {}).get('discovered_at')
+                if discovered_at:
+                    try:
+                        dt = datetime.fromisoformat(discovered_at)
+                        age_hours = (now - dt).total_seconds() / 3600
+                        if age_hours > max_age_hours:
+                            pruned.append(topic.get('display_name', topic.get('query', '?')))
+                            continue
+                    except (ValueError, TypeError):
+                        pass
+                kept.append(topic)
+            if pruned:
+                with open(discovered_file, 'w') as f:
+                    json.dump(kept, f, indent=2)
+                logger.info(f"Pruned {len(pruned)} stale discovered topics (>{max_age_hours}h): {pruned}")
+        except Exception as e:
+            logger.warning(f"Failed to prune stale discovered topics: {e}")
 
     def _load_state_cache(self):
         try:
@@ -2106,6 +2144,11 @@ class PredictionMarketSentinel(Sentinel):
                 for key, value in cached.items():
                     if isinstance(value, dict): validated[key] = value
                 self.state_cache = validated
+                # Restore persisted failure counts
+                for key, value in self.state_cache.items():
+                    fc = value.get('failure_count', 0)
+                    if fc > 0:
+                        self._topic_failure_counts[key] = fc
                 logger.info(f"Loaded state for {len(self.state_cache)} prediction market topics")
         except Exception as e:
             logger.warning(f"Failed to load prediction market state: {e}")
@@ -2398,11 +2441,24 @@ class PredictionMarketSentinel(Sentinel):
                 if not market_data:
                     self._topic_failure_counts[query] = self._topic_failure_counts.get(query, 0) + 1
                     fail_count = self._topic_failure_counts[query]
-                    _sentinel_diag.warning(f"  PredictionMarket: no data for '{display_name}' (failures={fail_count})")
-                    MAX_CONSECUTIVE_FAILURES = 50
-                    if fail_count >= MAX_CONSECUTIVE_FAILURES:
+                    max_failures = self.sentinel_config.get('max_consecutive_failures', 50)
+                    _sentinel_diag.warning(f"  PredictionMarket: no data for '{display_name}' (failures={fail_count}/{max_failures})")
+                    if fail_count >= max_failures:
                         topic['enabled'] = False
-                        continue
+                        logger.warning(
+                            f"PredictionMarket: topic '{display_name}' disabled after "
+                            f"{fail_count} consecutive failures (no active market found)"
+                        )
+                        try:
+                            send_pushover_notification(
+                                self.config.get('notifications', {}),
+                                f"Prediction Market Topic Disabled",
+                                f"'{display_name}' disabled after {fail_count} failures. "
+                                f"No active Polymarket market found.",
+                                priority=-1
+                            )
+                        except Exception:
+                            pass
                     continue
                 self._topic_failure_counts[query] = 0
                 current_slug = market_data['slug']
@@ -2462,6 +2518,10 @@ class PredictionMarketSentinel(Sentinel):
             except Exception as topic_error:
                 logger.warning(f"Error processing prediction market topic '{query}': {topic_error}")
                 continue
+        # Persist failure counts alongside state cache
+        for query_key, fail_count in self._topic_failure_counts.items():
+            if query_key in self.state_cache:
+                self.state_cache[query_key]['failure_count'] = fail_count
         self._save_state_cache()
         if triggers:
             triggers.sort(key=lambda t: t.severity, reverse=True)

--- a/trading_bot/state_manager.py
+++ b/trading_bot/state_manager.py
@@ -240,6 +240,21 @@ class StateManager:
         cls._with_state_lock(_do_save)
 
     @classmethod
+    def delete_state_keys(cls, namespace: str, keys: list):
+        """Delete specific keys from a namespace. Uses global lock."""
+        if not keys:
+            return
+
+        def _do_delete():
+            state = cls._load_raw_sync()
+            ns = state.get(namespace, {})
+            for key in keys:
+                ns.pop(key, None)
+            cls._save_raw_sync(state)
+
+        cls._with_state_lock(_do_delete)
+
+    @classmethod
     async def save_state_async(cls, updates: Dict[str, Any], namespace: str = "reports"):
         """Async save wrapper."""
         async with cls._async_lock:

--- a/trading_bot/topic_discovery.py
+++ b/trading_bot/topic_discovery.py
@@ -38,6 +38,9 @@ class TopicDiscoveryAgent:
         self.discovery_config = self.sentinel_config.get('discovery_agent', {})
         self.interest_areas = self.sentinel_config.get('interest_areas', [])
 
+        # Active commodity ticker for filtering commodity-specific interest areas
+        self._commodity_ticker = config.get('commodity', {}).get('ticker', config.get('symbol', 'KC'))
+
         self.enabled = self.discovery_config.get('enabled', False)
         self.api_url = self.sentinel_config.get('providers', {}).get('polymarket', {}).get('api_url', "https://gamma-api.polymarket.com/events")
 
@@ -61,6 +64,9 @@ class TopicDiscoveryAgent:
 
         # Budget Guard (Dependency Injection)
         self._budget_guard = budget_guard
+
+        # Per-scan bulk event cache (reset in run_scan)
+        self._bulk_events_cache = None
 
         # Anthropic Client
         api_key = config.get('anthropic', {}).get('api_key')
@@ -89,15 +95,30 @@ class TopicDiscoveryAgent:
         logger.info("Starting Topic Discovery Scan...")
         self._llm_calls_this_scan = 0
         self._llm_consecutive_failures = 0  # Reset circuit breaker each scan
+        self._bulk_events_cache = None  # Reset per-scan cache
         discovered_raw = []
 
         # 1. Discover Candidates
+        area_results = []
         for area in self.interest_areas:
             if not area.get('enabled', True):
+                logger.info(f"  Area '{area.get('name', '?')}': DISABLED, skipping")
+                continue
+
+            # Commodity filter: skip areas not relevant to the active commodity
+            applicable = area.get('commodities')
+            if applicable and self._commodity_ticker not in applicable:
+                logger.info(f"  Area '{area.get('name', '?')}': not applicable to {self._commodity_ticker}, skipping")
                 continue
 
             area_candidates = await self._scan_area(area)
             discovered_raw.extend(area_candidates)
+            area_results.append((area.get('name', '?'), len(area_candidates)))
+            if area_candidates:
+                titles = [c.get('title', '?')[:60] for c in area_candidates]
+                logger.info(f"  Area '{area.get('name', '?')}': {len(area_candidates)} candidates — {titles}")
+            else:
+                logger.info(f"  Area '{area.get('name', '?')}': 0 candidates (no markets matched filters)")
 
         # 2. Global Deduplication (by slug)
         # Keep the one with highest relevance score, or merge?
@@ -157,6 +178,14 @@ class TopicDiscoveryAgent:
             if self.discovery_config.get('notify_on_change', True):
                 self._notify_changes(changes)
 
+        # 8. Summary log
+        area_summary = ", ".join(f"{name}={count}" for name, count in area_results)
+        logger.info(
+            f"Topic Discovery complete: {len(sentinel_topics)} topics from "
+            f"{len(discovered_raw)} raw candidates. "
+            f"Areas: [{area_summary}]. LLM calls: {self._llm_calls_this_scan}"
+        )
+
         return {
             'status': 'success',
             'changes': changes,
@@ -170,20 +199,28 @@ class TopicDiscoveryAgent:
         """Scan a specific interest area using defined methods."""
         candidates = []
         methods = area.get('discovery_methods', [])
+        area_name = area.get('name', '?')
 
         for method in methods:
             try:
+                method_desc = f"{method['type']}:{method.get('tag_id', method.get('q', '?'))}"
                 if method['type'] == 'tag_scan':
                     events = await self._fetch_events(tag_id=method.get('tag_id'), limit=method.get('limit', 10))
                 elif method['type'] == 'query':
-                    events = await self._fetch_events(query=method.get('q'), limit=20) # Limit query results
+                    events = await self._fetch_events(query=method.get('q'), limit=20)
                 else:
                     continue
+
+                events_fetched = len(events)
+                filtered_liquidity = 0
+                filtered_excluded = 0
+                filtered_relevance = 0
 
                 for event in events:
                     # === AMENDMENT D & B: Extract Best Market + Event ID ===
                     market_data = self._extract_market_data(event)
                     if not market_data:
+                        filtered_liquidity += 1
                         continue
 
                     # Filter by Keywords (Layer 1)
@@ -191,6 +228,7 @@ class TopicDiscoveryAgent:
 
                     # Filter by Exclude Keywords (now includes global excludes)
                     if self._check_exclusions(market_data['title'], area):
+                        filtered_excluded += 1
                         continue
 
                     # LLM Assessment (Layer 2)
@@ -235,35 +273,104 @@ class TopicDiscoveryAgent:
                         )
 
                         candidates.append(market_data)
+                    else:
+                        filtered_relevance += 1
+
+                # Per-method summary
+                accepted = len(candidates)  # cumulative, but gives visibility
+                logger.debug(
+                    f"    [{area_name}] {method_desc}: "
+                    f"{events_fetched} events, "
+                    f"{filtered_liquidity} low-liquidity, "
+                    f"{filtered_excluded} excluded, "
+                    f"{filtered_relevance} low-relevance"
+                )
 
             except Exception as e:
-                logger.error(f"Error scanning area '{area['name']}' method '{method}': {e}")
+                logger.error(f"Error scanning area '{area_name}' method '{method}': {e}")
 
         return candidates
 
-    async def _fetch_events(self, tag_id: int = None, query: str = None, limit: int = 10) -> List[Dict]:
-        """Fetch events from Gamma API."""
-        params = {
-            'limit': limit,
-            'closed': 'false',
-            'active': 'true'
-        }
-        if tag_id:
-            params['tag_id'] = tag_id
-        if query:
-            params['q'] = query
+    async def _fetch_all_active_events(self) -> List[Dict]:
+        """Fetch active events via pagination, cached per scan.
 
+        The Gamma API 'q' parameter is unreliable for text search (returns
+        unrelated events regardless of query). Instead, we bulk-fetch active
+        events once per scan and filter client-side by keywords.
+
+        3 pages (600 events) captures all relevant targets based on empirical
+        testing. Pages 4-5 add zero new targets — those markets are already
+        covered by tag_scan discovery methods.
+        """
+        if self._bulk_events_cache is not None:
+            return self._bulk_events_cache
+
+        all_events = []
+        max_pages = self.discovery_config.get('bulk_fetch_pages', 3)
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.get(self.api_url, params=params) as response:
-                    if response.status == 200:
-                        return await response.json()
-                    else:
-                        logger.warning(f"Gamma API error: {response.status}")
-                        return []
+                for page in range(max_pages):
+                    params = {
+                        'limit': 200,
+                        'offset': page * 200,
+                        'closed': 'false',
+                        'active': 'true'
+                    }
+                    async with session.get(self.api_url, params=params) as response:
+                        if response.status != 200:
+                            logger.warning(f"Gamma API bulk fetch page {page+1}: HTTP {response.status}")
+                            break
+                        events = await response.json()
+                        if not events:
+                            break
+                        all_events.extend(events)
+                        if len(events) < 200:
+                            break
+            logger.info(f"Bulk fetched {len(all_events)} active events from Polymarket ({max_pages} pages)")
         except Exception as e:
-            logger.error(f"Gamma API fetch failed: {e}")
-            return []
+            logger.error(f"Gamma API bulk fetch failed: {e}")
+
+        self._bulk_events_cache = all_events
+        return all_events
+
+    async def _fetch_events(self, tag_id: int = None, query: str = None, limit: int = 10) -> List[Dict]:
+        """Fetch events from Gamma API.
+
+        For tag_id: uses the API tag filter (reliable).
+        For query: filters bulk-cached events client-side (the API 'q'
+        parameter is unreliable — returns unrelated results).
+        """
+        if tag_id:
+            params = {
+                'limit': limit,
+                'closed': 'false',
+                'active': 'true',
+                'tag_id': tag_id
+            }
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(self.api_url, params=params) as response:
+                        if response.status == 200:
+                            return await response.json()
+                        else:
+                            logger.warning(f"Gamma API error: {response.status}")
+                            return []
+            except Exception as e:
+                logger.error(f"Gamma API fetch failed: {e}")
+                return []
+
+        if query:
+            # Client-side filtering from bulk cache
+            all_events = await self._fetch_all_active_events()
+            query_words = [w.lower() for w in query.split() if len(w) > 2]
+            matched = []
+            for event in all_events:
+                title = event.get('title', '').lower()
+                if any(word_boundary_match(w, title) for w in query_words):
+                    matched.append(event)
+            return matched[:limit]
+
+        return []
 
     def _extract_market_data(self, event: Dict[str, Any]) -> Optional[Dict]:
         """


### PR DESCRIPTION
## Summary

- **Polymarket API `q` param broken**: Returns identical events regardless of search term. Replaced with bulk fetch (600 events, 3 pages) + client-side keyword filtering. Discovered topics: 2 → 12+
- **Commodity-aware interest areas**: Brazil Economy/LatAm Geopolitics scoped to KC only; new Energy Geopolitics area for NG (Russia/Ukraine/Iran/OPEC); CC gets macro-only areas (no West Africa markets on Polymarket)
- **State pruning fixes**: `StateManager.delete_state_keys()` removes orphaned entries that `save_state()` merge could never delete; stale discovered topics pruned after 240h
- **Silent failure alerting**: Configurable `max_consecutive_failures` with Pushover notification on topic disablement, failure counts persisted across restarts
- **Config improvements**: Trade Policy gets "trade deal" query/keyword; US Economic Health gets GDP/inflation queries and commodity-agnostic template

## Commodity area mapping

| Commodity | Areas |
|-----------|-------|
| KC (Coffee) | US Monetary Policy, Trade Policy, US Economic Health, Brazil Economy, LatAm Geopolitics, Fed Leadership |
| CC (Cocoa) | US Monetary Policy, Trade Policy, US Economic Health, Fed Leadership |
| NG (Natural Gas) | US Monetary Policy, Trade Policy, US Economic Health, Energy Geopolitics, Fed Leadership |

## Test plan

- [x] Full test suite: 749 passed, 0 failed
- [x] 5 new tests for state pruning, failure persistence, notification, staleness, delete_state_keys
- [x] Verified commodity filtering produces correct area sets for KC/CC/NG
- [ ] Production validation: run discovery scan on each commodity engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)