### PR TITLE
fix: strip whitespace from Polymarket titles, remove dead topics

### DIFF
--- a/trading_bot/topic_discovery.py
+++ b/trading_bot/topic_discovery.py
@@ -434,7 +434,7 @@ class TopicDiscoveryAgent:
         return {
             'event_id': str(event.get('id', '')),  # AMENDMENT B: Stable identifier
             'slug': event.get('slug', ''),
-            'title': event.get('title', ''),
+            'title': event.get('title', '').strip(),
             'price': price,
             'liquidity': liquidity,
             'volume': volume,
@@ -652,9 +652,9 @@ Answer ONLY with a JSON object: {{"relevant": true/false, "score": 0-5, "reasoni
         from the interest area so the sentinel can filter at resolution time.
         """
         return {
-            "query": cand['title'], # Using title as query for Sentinel is safe as it will resolve it
+            "query": cand['title'].strip(), # Using title as query for Sentinel is safe as it will resolve it
             "tag": cand['tag'],
-            "display_name": cand['title'][:50], # Truncate for display
+            "display_name": cand['title'].strip()[:50], # Truncate for display
             "trigger_threshold_pct": cand['default_threshold_pct'],
             "importance": cand['importance'],
             "commodity_impact": cand['commodity_impact_template'],


### PR DESCRIPTION
## Summary

- **Leading whitespace**: Polymarket API returns some titles with leading spaces (e.g., `" Colombia Presidential Election 1st round winner?"`). Added `.strip()` at extraction in `_extract_market_data()` and in `_convert_to_sentinel_config()` to prevent query/display_name corruption.
- **Dead topics removed from production**: `Negative GDP growth in 2026?` (delisted, failing on all 3 engines) and `Colombia Presidential Election 1st round winner?` (invalid slug) manually removed from `data/{KC,CC,NG}/discovered_topics.json`.

## Test plan

- [x] `test_prediction_market_sentinel.py`: 14 passed
- [x] Production data files cleaned (KC: 12→10, CC: 12→11, NG: 12→11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)