### PR TITLE
fix: status-aware Brier prediction trimming prevents silent data loss

### DIFF
--- a/tests/test_brier_integration.py
+++ b/tests/test_brier_integration.py
@@ -5,9 +5,9 @@ import tempfile
 import json
 import os
 from pathlib import Path
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
-from trading_bot.enhanced_brier import EnhancedBrierTracker
+from trading_bot.enhanced_brier import EnhancedBrierTracker, MAX_RESOLVED_PREDICTIONS, _BACKFILL_PASS2_CUTOFF
 from trading_bot.brier_bridge import _confidence_to_probs
 
 
@@ -88,3 +88,156 @@ class TestBrierIntegration:
         with open(self.data_file, 'r') as f:
             data = json.load(f)
         assert len(data['predictions']) == 50
+
+
+class TestStatusAwareTrimming:
+    """Tests for status-aware prediction trimming (prevents silent data loss)."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.data_file = Path(self.temp_dir) / "brier_data.json"
+
+    def teardown_method(self):
+        import shutil
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def _make_prediction(self, tracker, agent, cycle_id, resolved=False, timestamp=None):
+        """Helper: record a prediction, optionally mark it resolved.
+
+        Directly sets actual_outcome on the prediction object to avoid
+        cycle_id format requirements in resolve_prediction().
+        """
+        prob_bullish, prob_neutral, prob_bearish = _confidence_to_probs("BULLISH", 0.7)
+        tracker.record_prediction(
+            agent=agent,
+            prob_bullish=prob_bullish,
+            prob_neutral=prob_neutral,
+            prob_bearish=prob_bearish,
+            cycle_id=cycle_id,
+            timestamp=timestamp,
+        )
+        if resolved:
+            # Directly mark as resolved (bypasses cycle_id format validation)
+            pred = tracker.predictions[-1]
+            pred.actual_outcome = "BULLISH"
+            pred.resolved_at = datetime.now(timezone.utc)
+
+    def test_pending_predictions_survive_save_trim(self):
+        """Pending predictions must survive a save-reload cycle even when
+        total predictions exceed MAX_RESOLVED_PREDICTIONS."""
+        tracker = EnhancedBrierTracker(data_path=self.data_file)
+
+        # Record 2400 resolved + 100 pending
+        for i in range(2400):
+            self._make_prediction(tracker, "agent_a", f"resolved_{i}", resolved=True)
+        for i in range(100):
+            self._make_prediction(tracker, "agent_a", f"pending_{i}", resolved=False)
+
+        tracker._save()
+
+        # Reload from disk
+        tracker2 = EnhancedBrierTracker(data_path=self.data_file)
+        pending_count = sum(1 for p in tracker2.predictions if p.actual_outcome is None)
+        resolved_count = sum(1 for p in tracker2.predictions if p.actual_outcome is not None)
+
+        assert pending_count == 100, f"Expected 100 pending, got {pending_count}"
+        assert resolved_count <= MAX_RESOLVED_PREDICTIONS, (
+            f"Resolved count {resolved_count} exceeds cap {MAX_RESOLVED_PREDICTIONS}"
+        )
+
+    def test_pending_survive_in_memory_trim(self):
+        """In-memory trim must not drop pending predictions."""
+        tracker = EnhancedBrierTracker(data_path=self.data_file)
+
+        # Fill with resolved predictions to approach the limit
+        for i in range(2800):
+            self._make_prediction(tracker, "agent_a", f"resolved_{i}", resolved=True)
+
+        # Now add pending predictions — this should trigger in-memory trim
+        for i in range(250):
+            self._make_prediction(tracker, "agent_a", f"pending_{i}", resolved=False)
+
+        pending_count = sum(1 for p in tracker.predictions if p.actual_outcome is None)
+        assert pending_count == 250, f"Expected 250 pending, got {pending_count}"
+
+    def test_backfill_pass2_skipped_after_deprecation(self):
+        """After deprecation date, Pass 2 should not create new predictions from CSV."""
+        import pandas as pd
+
+        tracker = EnhancedBrierTracker(data_path=self.data_file)
+
+        # Record one prediction in JSON
+        self._make_prediction(tracker, "agent_a", "existing_cycle", resolved=False)
+        tracker._save()
+
+        # Create a CSV with rows that do NOT exist in JSON
+        csv_path = Path(self.temp_dir) / "agent_accuracy_structured.csv"
+        csv_data = pd.DataFrame([{
+            'cycle_id': f'csv_only_{i}',
+            'timestamp': '2026-01-15T10:00:00+00:00',
+            'agent': 'agent_a',
+            'direction': 'BULLISH',
+            'confidence': 0.8,
+            'actual': 'BULLISH',
+        } for i in range(100)])
+        csv_data.to_csv(csv_path, index=False)
+
+        # Reload tracker
+        tracker2 = EnhancedBrierTracker(data_path=self.data_file)
+        initial_count = len(tracker2.predictions)
+
+        # If we're past the cutoff (we are — it's March 2026), Pass 2 should be skipped
+        if datetime.now(timezone.utc) >= _BACKFILL_PASS2_CUTOFF:
+            tracker2.backfill_from_resolved_csv(structured_csv_path=str(csv_path))
+            # Pass 2 skipped → no new predictions created from CSV
+            assert len(tracker2.predictions) == initial_count, (
+                f"Pass 2 should be skipped after deprecation. "
+                f"Before: {initial_count}, After: {len(tracker2.predictions)}"
+            )
+
+    def test_backfill_does_not_displace_pending(self):
+        """Simulate the KC restart scenario: backfill must not displace pending predictions."""
+        tracker = EnhancedBrierTracker(data_path=self.data_file)
+
+        # Load 800 resolved + 200 pending into JSON
+        for i in range(800):
+            self._make_prediction(tracker, "agent_a", f"res_{i}", resolved=True)
+        for i in range(200):
+            self._make_prediction(tracker, "agent_a", f"pend_{i}", resolved=False)
+
+        tracker._save()
+
+        # Reload and verify pending survive
+        tracker2 = EnhancedBrierTracker(data_path=self.data_file)
+        pending = [p for p in tracker2.predictions if p.actual_outcome is None]
+        assert len(pending) == 200, f"Expected 200 pending after reload, got {len(pending)}"
+
+    def test_chronological_order_preserved(self):
+        """After status-aware trim, predictions must remain in timestamp order."""
+        tracker = EnhancedBrierTracker(data_path=self.data_file)
+        base_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        # Interleave resolved and pending with known timestamps
+        for i in range(2500):
+            prob_bullish, prob_neutral, prob_bearish = _confidence_to_probs("BULLISH", 0.7)
+            tracker.record_prediction(
+                agent="agent_a",
+                prob_bullish=prob_bullish,
+                prob_neutral=prob_neutral,
+                prob_bearish=prob_bearish,
+                cycle_id=f"cycle_{i}",
+                timestamp=base_time + timedelta(minutes=i),
+            )
+            if i % 5 != 0:  # Leave every 5th prediction pending
+                tracker.resolve_prediction(
+                    agent="agent_a",
+                    actual_outcome="BULLISH",
+                    cycle_id=f"cycle_{i}",
+                )
+
+        tracker._save()
+
+        tracker2 = EnhancedBrierTracker(data_path=self.data_file)
+        timestamps = [p.timestamp for p in tracker2.predictions]
+        assert timestamps == sorted(timestamps), "Predictions not in chronological order after trim"

--- a/trading_bot/enhanced_brier.py
+++ b/trading_bot/enhanced_brier.py
@@ -20,6 +20,14 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Status-aware trimming: cap on resolved predictions kept on disk/memory.
+# Pending predictions are NEVER trimmed (orphaning handles their lifecycle).
+MAX_RESOLVED_PREDICTIONS = 2000
+
+# After this date, legacy CSV is frozen — Pass 2 backfill only re-creates
+# historical duplicates and should be skipped to prevent restart inflation.
+_BACKFILL_PASS2_CUTOFF = datetime(2026, 3, 1, tzinfo=timezone.utc)
+
 
 class MarketRegime(Enum):
     """Market regime classification for performance tracking."""
@@ -283,12 +291,19 @@ class EnhancedBrierTracker:
 
         self.predictions.append(pred)
 
-        # FIX (MECE 1.4): Trim to prevent unbounded memory growth
-        # Keep 50% buffer over save limit to reduce trim frequency
-        MAX_IN_MEMORY = 1500
+        # Status-aware trim: prevent unbounded growth while protecting pending predictions.
+        # Pending predictions must survive until resolved or orphaned (7-day lifecycle).
+        MAX_IN_MEMORY = 3000
         if len(self.predictions) > MAX_IN_MEMORY:
-            self.predictions = self.predictions[-1000:]
-            logger.debug(f"Brier tracker trimmed to {len(self.predictions)} predictions")
+            pending = [p for p in self.predictions if p.actual_outcome is None]
+            resolved = [p for p in self.predictions if p.actual_outcome is not None]
+            if len(resolved) > MAX_RESOLVED_PREDICTIONS:
+                resolved = resolved[-MAX_RESOLVED_PREDICTIONS:]
+            self.predictions = sorted(pending + resolved, key=lambda p: p.timestamp)
+            logger.debug(
+                f"Brier tracker trimmed to {len(self.predictions)} predictions "
+                f"({len(pending)} pending, {len(resolved)} resolved)"
+            )
 
         pred_id = f"{agent}_{pred.timestamp.isoformat()}"
 
@@ -423,58 +438,69 @@ class EnhancedBrierTracker:
                     f"Brier={brier_str}"
                 )
 
-        # Pass 2: Create predictions that exist in CSV but not in JSON
-        json_keys = {(p.cycle_id, p.agent) for p in self.predictions}
-        created = 0
-
-        for _, row in csv_df.iterrows():
-            cycle_id = str(row.get('cycle_id', '')).strip()
-            agent = str(row.get('agent', '')).strip()
-            if not cycle_id or not agent or cycle_id in ("nan", "None", "null"):
-                continue
-            if (cycle_id, agent) in json_keys:
-                continue
-
-            # Reconstruct probability distribution from CSV direction + confidence
-            direction = str(row.get('direction', 'NEUTRAL')).strip().upper()
-            confidence = float(row.get('confidence', 0.5)) if pd.notna(row.get('confidence')) else 0.5
-            confidence = max(0.0, min(1.0, confidence))
-
-            from trading_bot.brier_bridge import _confidence_to_probs
-            prob_bullish, prob_neutral, prob_bearish = _confidence_to_probs(direction, confidence)
-
-            # Parse timestamp
-            ts = datetime.now(timezone.utc)
-            if pd.notna(row.get('timestamp')):
-                try:
-                    ts = pd.to_datetime(row['timestamp'], utc=True).to_pydatetime()
-                except Exception:
-                    pass
-
-            pred = ProbabilisticPrediction(
-                timestamp=ts,
-                agent=agent,
-                prob_bullish=prob_bullish,
-                prob_neutral=prob_neutral,
-                prob_bearish=prob_bearish,
-                regime=MarketRegime.NORMAL,
-                contract=str(row.get('contract', '')) if pd.notna(row.get('contract')) else '',
-                cycle_id=cycle_id,
+        # Pass 2: Create predictions from CSV that are missing in JSON.
+        # After legacy deprecation, CSV is frozen — no new rows are written.
+        # Re-creating historical CSV entries on every restart inflates the list
+        # and causes trimming to drop recent JSON-only predictions (the KC bug).
+        skip_pass2 = datetime.now(timezone.utc) >= _BACKFILL_PASS2_CUTOFF
+        if skip_pass2:
+            logger.info(
+                "Backfill Pass 2 skipped (legacy CSV deprecated %s, no new rows to import)",
+                _BACKFILL_PASS2_CUTOFF.date()
             )
 
-            # Resolve immediately if CSV has an outcome
-            actual = str(row.get('actual', 'PENDING')).strip()
-            if actual not in ('PENDING', 'ORPHANED', ''):
-                pred.actual_outcome = actual
-                pred.resolved_at = datetime.now(timezone.utc)
-                brier = pred.calc_brier_score()
-                if brier is not None:
-                    self._update_agent_score(pred.agent, pred.regime.value, brier)
-                    self._update_calibration(pred)
+        created = 0
+        if not skip_pass2:
+            json_keys = {(p.cycle_id, p.agent) for p in self.predictions}
 
-            self.predictions.append(pred)
-            json_keys.add((cycle_id, agent))
-            created += 1
+            for _, row in csv_df.iterrows():
+                cycle_id = str(row.get('cycle_id', '')).strip()
+                agent = str(row.get('agent', '')).strip()
+                if not cycle_id or not agent or cycle_id in ("nan", "None", "null"):
+                    continue
+                if (cycle_id, agent) in json_keys:
+                    continue
+
+                # Reconstruct probability distribution from CSV direction + confidence
+                direction = str(row.get('direction', 'NEUTRAL')).strip().upper()
+                confidence = float(row.get('confidence', 0.5)) if pd.notna(row.get('confidence')) else 0.5
+                confidence = max(0.0, min(1.0, confidence))
+
+                from trading_bot.brier_bridge import _confidence_to_probs
+                prob_bullish, prob_neutral, prob_bearish = _confidence_to_probs(direction, confidence)
+
+                # Parse timestamp
+                ts = datetime.now(timezone.utc)
+                if pd.notna(row.get('timestamp')):
+                    try:
+                        ts = pd.to_datetime(row['timestamp'], utc=True).to_pydatetime()
+                    except Exception:
+                        pass
+
+                pred = ProbabilisticPrediction(
+                    timestamp=ts,
+                    agent=agent,
+                    prob_bullish=prob_bullish,
+                    prob_neutral=prob_neutral,
+                    prob_bearish=prob_bearish,
+                    regime=MarketRegime.NORMAL,
+                    contract=str(row.get('contract', '')) if pd.notna(row.get('contract')) else '',
+                    cycle_id=cycle_id,
+                )
+
+                # Resolve immediately if CSV has an outcome
+                actual = str(row.get('actual', 'PENDING')).strip()
+                if actual not in ('PENDING', 'ORPHANED', ''):
+                    pred.actual_outcome = actual
+                    pred.resolved_at = datetime.now(timezone.utc)
+                    brier = pred.calc_brier_score()
+                    if brier is not None:
+                        self._update_agent_score(pred.agent, pred.regime.value, brier)
+                        self._update_calibration(pred)
+
+                self.predictions.append(pred)
+                json_keys.add((cycle_id, agent))
+                created += 1
 
         # Pass 3: Resolve still-pending predictions from council_history outcomes
         council_path = os.path.join(os.path.dirname(structured_csv_path), "council_history.csv")
@@ -687,6 +713,13 @@ class EnhancedBrierTracker:
 
     def _save(self) -> None:
         """Persist data to disk."""
+        # Status-aware retention: keep ALL pending, trim only resolved
+        pending = [p for p in self.predictions if p.actual_outcome is None]
+        resolved = [p for p in self.predictions if p.actual_outcome is not None]
+        if len(resolved) > MAX_RESOLVED_PREDICTIONS:
+            resolved = resolved[-MAX_RESOLVED_PREDICTIONS:]
+        retained = sorted(pending + resolved, key=lambda p: p.timestamp)
+
         data = {
             # FIX (MECE 3.3): Add schema version for forward compatibility
             'schema_version': self.SCHEMA_VERSION,
@@ -700,11 +733,11 @@ class EnhancedBrierTracker:
                     'prob_bearish': p.prob_bearish,
                     'regime': p.regime.value,
                     'contract': p.contract,
-                    'cycle_id': p.cycle_id,  # NEW
+                    'cycle_id': p.cycle_id,
                     'actual_outcome': p.actual_outcome,
                     'resolved_at': p.resolved_at.isoformat() if p.resolved_at else None
                 }
-                for p in self.predictions[-1000:]  # Keep last 1000
+                for p in retained
             ],
             'agent_scores': {
                 agent: {


### PR DESCRIPTION
## Summary

- **Bug**: Enhanced Brier `_save()` used position-based `[-1000:]` slicing, silently dropping pending (unresolved) predictions on every service restart. KC was actively losing all post-March-1 predictions because its legacy CSV (1779 rows) inflated the list past the cap via backfill Pass 2 on every init.
- **Fix A (defensive)**: `_save()` and `record_prediction()` now partition predictions into pending/resolved, only trimming resolved (cap: 2000). Pending predictions are never dropped — their lifecycle is managed by the existing 7-day auto-orphaning.
- **Fix B (root cause)**: Backfill Pass 2 (creating predictions from frozen legacy CSV) gated after deprecation date (2026-03-01) to stop restart inflation.
- CC and NG are unaffected today but will benefit as their histories grow.

## Test plan

- [x] 5 new tests in `TestStatusAwareTrimming` (pending survive save/reload, pending survive in-memory trim, Pass 2 skipped after deprecation, pending not displaced by backfill, chronological order preserved)
- [x] Full suite: 754 passed, 0 failed
- [ ] Post-deploy: verify `data/KC/enhanced_brier.json` has pending predictions surviving restart
- [ ] Next trading day: verify new predictions appear and are not displaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)