### PR TITLE
fix: state sync discovers theses hidden by IBKR aggregation

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1587,6 +1587,10 @@ def _group_positions_by_thesis(
         }
 
     Design: Commodity-agnostic — works for any multi-leg strategy.
+
+    v3.2: After initial FIFO grouping, discovers active TMS theses that
+    share contracts with existing groups due to IBKR position aggregation
+    (e.g., two bear put spreads on the same strikes → qty=2 in IBKR).
     """
     groups = {}  # position_id → {thesis, legs}
     unmapped = []  # Legs we couldn't map
@@ -1616,6 +1620,53 @@ def _group_positions_by_thesis(
             f"Position audit: {len(unmapped)} legs could not be mapped to a thesis: "
             f"{[p.contract.localSymbol for p in unmapped]}"
         )
+
+    # v3.2: Find active TMS theses not yet grouped that share contracts with
+    # existing groups (IBKR aggregates identical contracts across theses).
+    try:
+        active_theses = tms.collection.get(
+            where={"active": "true"}, include=['metadatas']
+        )
+        active_ids = {
+            m['trade_id'] for m in active_theses.get('metadatas', [])
+            if 'trade_id' in m
+        }
+        ungrouped = active_ids - set(groups.keys())
+
+        if ungrouped and not trade_ledger.empty and 'position_id' in trade_ledger.columns:
+            # Build set of contract symbols already in groups
+            grouped_symbols = {
+                leg.contract.localSymbol
+                for g in groups.values() for leg in g['legs']
+            }
+
+            for tid in ungrouped:
+                tid_rows = trade_ledger[trade_ledger['position_id'] == tid]
+                if tid_rows.empty:
+                    continue
+                tid_symbols = set(tid_rows['local_symbol'].unique())
+                # If this thesis's contracts overlap with grouped legs,
+                # it's part of an IBKR aggregate position
+                if tid_symbols & grouped_symbols:
+                    thesis = tms.retrieve_thesis(tid)
+                    # Find the matching grouped legs (shared contracts)
+                    shared_legs = [
+                        leg for g in groups.values() for leg in g['legs']
+                        if leg.contract.localSymbol in tid_symbols
+                    ]
+                    groups[tid] = {
+                        'thesis': thesis,
+                        'legs': shared_legs,
+                        'position_id': tid,
+                        '_aggregate': True,  # Mark as aggregate-discovered
+                    }
+                    logger.info(
+                        f"Aggregate grouping: thesis {tid[:8]} shares "
+                        f"IBKR legs with existing group (contracts: "
+                        f"{tid_symbols & grouped_symbols})"
+                    )
+    except Exception as e:
+        logger.warning(f"Aggregate thesis discovery failed (non-fatal): {e}")
 
     return groups
 

--- a/tests/test_exit_integration.py
+++ b/tests/test_exit_integration.py
@@ -25,6 +25,7 @@ from trading_bot.strategy import validate_iron_condor_risk
 from orchestrator import (
     _validate_thesis,
     _find_position_id_for_contract,
+    _group_positions_by_thesis,
     _reconcile_orphaned_theses,
     run_position_audit_cycle
 )
@@ -680,6 +681,124 @@ class TestReconcileOrphanedThesesAggregation(unittest.IsolatedAsyncioTestCase):
         active = self.tms.collection.get(where={"active": "true"}, include=['metadatas'])
         active_ids = {m['trade_id'] for m in active['metadatas']}
         self.assertIn(tid1, active_ids)
+
+
+class TestGroupPositionsByThesisAggregation(unittest.TestCase):
+    """
+    Tests that _group_positions_by_thesis correctly discovers theses hidden
+    behind IBKR's position aggregation (identical contracts across theses).
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.tms = TransactiveMemory(persist_path=self.temp_dir)
+        self.config = {'symbol': 'KC', 'exchange': 'NYBOT'}
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _make_position(self, local_symbol, qty, conId=0):
+        pos = MagicMock()
+        pos.contract.localSymbol = local_symbol
+        pos.contract.conId = conId
+        pos.position = qty
+        return pos
+
+    def _store_thesis(self, trade_id, strategy='BEAR_PUT_SPREAD'):
+        doc = json.dumps({
+            'trade_id': trade_id,
+            'strategy_type': strategy,
+            'active': True,
+        })
+        self.tms.collection.add(
+            ids=[f'thesis_{trade_id}'],
+            documents=[doc],
+            metadatas=[{
+                'trade_id': trade_id,
+                'active': 'true',
+                'strategy_type': strategy,
+                'entry_timestamp': datetime.now(timezone.utc).isoformat(),
+            }]
+        )
+
+    def test_aggregate_theses_discovered(self):
+        """Two theses with identical contracts (IBKR aggregates qty) should both appear in groups."""
+        tid1 = 'aaaa1111-0000-0000-0000-000000000001'
+        tid2 = 'aaaa1111-0000-0000-0000-000000000002'
+        self._store_thesis(tid1)
+        self._store_thesis(tid2)
+
+        # Both theses have the same contracts in the ledger
+        trade_ledger = pd.DataFrame([
+            {'position_id': tid1, 'local_symbol': 'KOK6 P2.85', 'action': 'BUY', 'quantity': 1.0, 'timestamp': '2026-03-02 11:00:00'},
+            {'position_id': tid1, 'local_symbol': 'KOK6 P2.8', 'action': 'SELL', 'quantity': 1.0, 'timestamp': '2026-03-02 11:00:00'},
+            {'position_id': tid2, 'local_symbol': 'KOK6 P2.85', 'action': 'BUY', 'quantity': 1.0, 'timestamp': '2026-03-02 15:00:00'},
+            {'position_id': tid2, 'local_symbol': 'KOK6 P2.8', 'action': 'SELL', 'quantity': 1.0, 'timestamp': '2026-03-02 15:00:00'},
+        ])
+
+        # IBKR aggregates: qty=2 for each contract
+        positions = [
+            self._make_position('KOK6 P2.85', +2, conId=111),
+            self._make_position('KOK6 P2.8', -2, conId=222),
+        ]
+
+        groups = _group_positions_by_thesis(positions, trade_ledger, self.tms)
+
+        # Both theses should be in groups
+        self.assertIn(tid1, groups)
+        self.assertIn(tid2, groups)
+        self.assertEqual(len(groups), 2)
+
+    def test_no_false_aggregate_for_different_contracts(self):
+        """Theses with different contracts should NOT be grouped together."""
+        tid1 = 'bbbb2222-0000-0000-0000-000000000001'
+        tid2 = 'bbbb2222-0000-0000-0000-000000000002'
+        self._store_thesis(tid1)
+        self._store_thesis(tid2)
+
+        trade_ledger = pd.DataFrame([
+            {'position_id': tid1, 'local_symbol': 'KOK6 P2.85', 'action': 'BUY', 'quantity': 1.0, 'timestamp': '2026-03-02 11:00:00'},
+            {'position_id': tid1, 'local_symbol': 'KOK6 P2.8', 'action': 'SELL', 'quantity': 1.0, 'timestamp': '2026-03-02 11:00:00'},
+            {'position_id': tid2, 'local_symbol': 'KON6 P2.75', 'action': 'BUY', 'quantity': 1.0, 'timestamp': '2026-03-02 15:00:00'},
+            {'position_id': tid2, 'local_symbol': 'KON6 P2.7', 'action': 'SELL', 'quantity': 1.0, 'timestamp': '2026-03-02 15:00:00'},
+        ])
+
+        # Different contracts — no aggregation
+        positions = [
+            self._make_position('KOK6 P2.85', +1, conId=111),
+            self._make_position('KOK6 P2.8', -1, conId=222),
+            self._make_position('KON6 P2.75', +1, conId=333),
+            self._make_position('KON6 P2.7', -1, conId=444),
+        ]
+
+        groups = _group_positions_by_thesis(positions, trade_ledger, self.tms)
+
+        # Both should be found via normal FIFO, not aggregate discovery
+        self.assertEqual(len(groups), 2)
+        self.assertIn(tid1, groups)
+        self.assertIn(tid2, groups)
+        # Neither should be marked as aggregate
+        self.assertFalse(groups[tid1].get('_aggregate', False))
+        self.assertFalse(groups[tid2].get('_aggregate', False))
+
+    def test_single_thesis_no_aggregate(self):
+        """Single thesis with qty=1 should work normally without aggregate logic."""
+        tid1 = 'cccc3333-0000-0000-0000-000000000001'
+        self._store_thesis(tid1)
+
+        trade_ledger = pd.DataFrame([
+            {'position_id': tid1, 'local_symbol': 'KOK6 P2.85', 'action': 'BUY', 'quantity': 1.0, 'timestamp': '2026-03-02 11:00:00'},
+            {'position_id': tid1, 'local_symbol': 'KOK6 P2.8', 'action': 'SELL', 'quantity': 1.0, 'timestamp': '2026-03-02 11:00:00'},
+        ])
+
+        positions = [
+            self._make_position('KOK6 P2.85', +1, conId=111),
+            self._make_position('KOK6 P2.8', -1, conId=222),
+        ]
+
+        groups = _group_positions_by_thesis(positions, trade_ledger, self.tms)
+        self.assertEqual(len(groups), 1)
+        self.assertIn(tid1, groups)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- **Root cause**: `_group_positions_by_thesis()` uses `_find_position_id_for_contract()` which returns ONE thesis per IBKR leg via FIFO. When IBKR aggregates identical contracts from multiple theses (e.g., two bear put spreads on KOK6 P285/P280 → qty=2), only the FIFO-first thesis is grouped. The remaining theses appear as "extra" TMS entries, triggering false-positive State Sync Warning notifications.
- **Fix**: After the initial FIFO pass, the function now queries TMS for active theses not yet grouped, and checks if their ledger contracts overlap with already-grouped IBKR legs. Matching theses are added as aggregate-discovered groups.
- **Impact**: Eliminates the spurious "[KC] State Sync Warning: IBKR has 3 thesis groups (5 legs) but TMS has 5 active theses" notification. No changes to position audit behavior — aggregate groups share the same IBKR legs and are marked with `_aggregate=True`.

## Test plan
- [x] `test_aggregate_theses_discovered` — two theses with identical contracts, IBKR qty=2, both found
- [x] `test_no_false_aggregate_for_different_contracts` — different contracts, no false aggregate
- [x] `test_single_thesis_no_aggregate` — single thesis, normal behavior
- [x] Full suite: 763 passed, 0 failed


🤖 Generated with [Claude Code](https://claude.com/claude-code)