### PR TITLE
🎨 Palette: Add help tooltips to key metrics in Cockpit

### DIFF
--- a/pages/1_Cockpit.py
+++ b/pages/1_Cockpit.py
@@ -175,9 +175,10 @@ def render_thesis_card_enhanced(thesis: dict, live_data: dict, config: dict = No
                     f"${unrealized_pnl:+,.2f}",
                     delta=f"${unrealized_pnl:+,.2f}",
                     delta_color="normal",
+                    help="Current open profit/loss on active positions"
                 )
             else:
-                st.metric("Unrealized P&L", "N/A")
+                st.metric("Unrealized P&L", "N/A", help="Current open profit/loss on active positions")
 
         with cols[2]:
             stop_help = "Calculated from invalidation triggers"
@@ -243,7 +244,7 @@ def render_portfolio_risk_summary(live_data: dict):
                 help="Percentage of Net Liquidation currently used for maintenance margin"
             )
         else:
-            st.metric("Margin Util", "N/A")
+            st.metric("Margin Util", "N/A", help="Percentage of Net Liquidation currently used for maintenance margin")
 
     with cols[2]:
         import math
@@ -944,13 +945,13 @@ if config:
             st.caption(f"Portfolio VaR (:{stale_color}[{stale_label}])")
             var_cols = st.columns(4)
             with var_cols[0]:
-                st.metric("VaR(95%)", f"{var_95_pct:.1%}", f"${var_95_usd:,.0f}")
+                st.metric("VaR(95%)", f"{var_95_pct:.1%}", f"${var_95_usd:,.0f}", help="Value at Risk (95% confidence): Estimated maximum loss over 1 day in normal market conditions.")
             with var_cols[1]:
-                st.metric("VaR(99%)", f"{var_99_pct:.1%}", f"${var_99_usd:,.0f}")
+                st.metric("VaR(99%)", f"{var_99_pct:.1%}", f"${var_99_usd:,.0f}", help="Value at Risk (99% confidence): Estimated maximum loss over 1 day in extreme market conditions.")
             with var_cols[2]:
-                st.metric("Utilization", f":{util_color}[{util:.0%}]")
+                st.metric("Utilization", f":{util_color}[{util:.0%}]", help="Percentage of the VaR limit currently being used.")
             with var_cols[3]:
-                st.metric("Positions", f"{pos_count} ({', '.join(commodities)})")
+                st.metric("Positions", f"{pos_count} ({', '.join(commodities)})", help="Total number of open positions and active commodities.")
 
             # Failure indicator
             if status == "FAILED":
@@ -997,7 +998,7 @@ if config:
     st.caption("Market Benchmarks")
     bench_cols = st.columns(min(1 + len(_all_commodities), 6))
     with bench_cols[0]:
-        st.metric("S&P 500", f"{benchmarks.get('SPY', 0):+.2f}%")
+        st.metric("S&P 500", f"{benchmarks.get('SPY', 0):+.2f}%", help="Year-to-date performance of the S&P 500 index.")
     for _bi, _bt in enumerate(_all_commodities):
         if _bi + 1 >= len(bench_cols):
             break
@@ -1005,7 +1006,7 @@ if config:
             _pct = benchmarks.get(_bt, 0)
             # Highlight selected commodity
             _label = f"**{_bt}**" if _bt == ticker else _bt
-            st.metric(_label, f"{_pct:+.2f}%")
+            st.metric(_label, f"{_pct:+.2f}%", help=f"Year-to-date performance of the {_bt} commodity.")
 
     # Rolling Win Rate Sparkline
     st.markdown("---")
@@ -1303,7 +1304,8 @@ try:
         with router_cols[3]:
             st.metric(
                 "Since Reset",
-                metrics.get('last_reset', 'N/A')[:10] if metrics.get('last_reset') else 'N/A'
+                metrics.get('last_reset', 'N/A')[:10] if metrics.get('last_reset') else 'N/A',
+                help="Date when the router metrics were last reset"
             )
 
         # Provider breakdown

--- a/tests/test_ui_ux.py
+++ b/tests/test_ui_ux.py
@@ -105,6 +105,35 @@ class TestCockpitUX(unittest.TestCase):
         self.assertTrue(found_utc, "Could not find 'UTC Time' metric call")
         self.assertTrue(found_ny, "Could not find 'New York Time (Market)' metric call")
 
+    def test_cockpit_metric_tooltips(self):
+        """Verify that key metrics in pages/1_Cockpit.py have help tooltips."""
+        file_path = os.path.join(os.path.dirname(__file__), '..', 'pages', '1_Cockpit.py')
+        with open(file_path, 'r') as f:
+            tree = ast.parse(f.read())
+
+        target_metrics = [
+            "Unrealized P&L", "Margin Util", "VaR(95%)", "VaR(99%)",
+            "Utilization", "Positions", "Since Reset"
+        ]
+        found_metrics = {m: False for m in target_metrics}
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == 'metric':
+                if not node.args:
+                    continue
+
+                label = None
+                if isinstance(node.args[0], ast.Constant):
+                    label = node.args[0].value
+
+                if label in found_metrics:
+                    found_metrics[label] = True
+                    has_help = any(kw.arg == 'help' for kw in node.keywords)
+                    self.assertTrue(has_help, f"Metric '{label}' in Cockpit is missing 'help' tooltip")
+
+        for metric, found in found_metrics.items():
+            self.assertTrue(found, f"Could not find metric '{metric}' in pages/1_Cockpit.py")
+
 
 class TestDashboardUX(unittest.TestCase):
     def test_dashboard_metric_tooltips(self):


### PR DESCRIPTION
💡 **What:** Added `help` tooltips to several complex and data-dense metrics on the Cockpit page (`pages/1_Cockpit.py`), including "Unrealized P&L", "Margin Util", "VaR", "Utilization", "Positions", "S&P 500", and "Since Reset".
🎯 **Why:** To provide immediate context for these high-impact metrics to new or stressed users without cluttering the visual interface, following the "just-in-time" documentation pattern.
♿ **Accessibility:** Increases cognitive accessibility by ensuring users do not need to look up documentation to understand what these values represent. It explicitly improves the user experience by clarifying ambiguous metrics.
Additionally added tests in `test_ui_ux.py` to assert that these UI changes do not regress.

---
*PR created automatically by Jules for task [2459089261838692197](https://jules.google.com/task/2459089261838692197) started by @rozavala*