### PR TITLE
fix: install deps in claude-fix workflow and gate on priority

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -30,6 +30,13 @@ jobs:
         with:
           fetch-depth: 50
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -348,6 +348,14 @@ jobs:
               return;
             }
 
+            // Only auto-fix critical/high priority issues to avoid wasting
+            // CI minutes on routine errors that are often already fixed.
+            const priority = triage.priority || '${{ steps.triage.outputs.priority }}';
+            if (priority !== 'critical' && priority !== 'high') {
+              console.log(`Skipping claude-fix for priority: ${priority} (only critical/high auto-fixed)`);
+              return;
+            }
+
             // Ensure label exists
             try {
               await github.rest.issues.getLabel({


### PR DESCRIPTION
## Summary
- Add `setup-python` + `pip install -r requirements.txt` to `claude-fix.yml` so the agent can actually run tests instead of burning 30 turns on missing imports
- Gate `claude-fix` label in `issue-triage.yml` to only critical/high priority issues — routine daily error summaries (like #1143) don't need a $2 auto-fix attempt

## Context
Issue #1143 (Error 478, already fixed in PR #1142) triggered the claude-fix workflow. The agent spent all 31 turns installing `holidays`, `scipy`, etc. one at a time, hit `max_turns`, and failed — wasting $1.93.

## Test plan
- [ ] Next error report creates an issue → triage assigns priority → verify `claude-fix` only added for critical/high
- [ ] If `claude-fix` triggers, verify tests run successfully with deps installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)