### PR TITLE
fix: hybrid tick/percentage liquidity filter

### DIFF
--- a/config.json
+++ b/config.json
@@ -54,7 +54,10 @@
     "iron_condor_wing_strikes_apart": 2,
     "slippage_spread_percentage": 0.5,
     "order_type": "LMT",
-    "max_liquidity_spread_percentage": 0.45,
+    "max_liquidity_spread_percentage": 0.75,
+    "max_liquidity_spread_ticks": 60,
+    "min_book_depth_multiplier": 3,
+    "max_single_leg_spread_pct": 0.5,
     "fixed_slippage_cents": 0.5
   },
   "risk_management": {
@@ -633,7 +636,8 @@
   "commodity_overrides": {
     "KC": {
       "strategy_tuning": {
-        "max_liquidity_spread_percentage": 1.25,
+        "max_liquidity_spread_percentage": 0.75,
+        "max_liquidity_spread_ticks": 80,
         "cap_timeout_seconds": 1800,
         "monitoring_duration_seconds": 2400
       }
@@ -650,7 +654,8 @@
         "max_open_positions": 3
       },
       "strategy_tuning": {
-        "max_liquidity_spread_percentage": 0.50,
+        "max_liquidity_spread_percentage": 0.75,
+        "max_liquidity_spread_ticks": 30,
         "cap_timeout_seconds": 900,
         "monitoring_duration_seconds": 1800
       }
@@ -668,7 +673,8 @@
         "max_open_positions": 3
       },
       "strategy_tuning": {
-        "max_liquidity_spread_percentage": 0.35,
+        "max_liquidity_spread_percentage": 0.75,
+        "max_liquidity_spread_ticks": 80,
         "cap_timeout_seconds": 900,
         "monitoring_duration_seconds": 1800
       }

--- a/config/commodity_profiles.py
+++ b/config/commodity_profiles.py
@@ -147,6 +147,13 @@ class CommodityProfile:
     price_move_alert_pct: float = 2.0
     straddle_risk_threshold: float = 10000.0  # Max straddle risk per contract (v3.1)
 
+    # Liquidity filter: hybrid tick/percentage model
+    # Spread must be ≤ max(tick_allowance, pct_allowance)
+    # Tick floor protects cheap OTM options from ratio inflation
+    # Percentage ceiling caps slippage on expensive ITM options
+    max_liquidity_spread_pct: float = 0.75       # 75% of abs(theoretical price)
+    max_liquidity_spread_ticks: int = 60          # Absolute floor in tick units
+
     # M1, M3, M7, E4 FIXES:
     fallback_iv: float = 0.35  # Default 35% (commodity-specific)
     risk_free_rate: float = 0.04  # M3 fix
@@ -448,6 +455,8 @@ COFFEE_ARABICA_PROFILE = CommodityProfile(
     volatility_low_iv_rank=0.30,
     price_move_alert_pct=2.0,
     straddle_risk_threshold=10000.0,
+    max_liquidity_spread_pct=0.75,
+    max_liquidity_spread_ticks=80,   # 80 × 0.05 = 4.00 c/lb floor
     fallback_iv=0.35,
     risk_free_rate=0.04,
     default_starting_capital=50000.0,
@@ -611,6 +620,8 @@ COCOA_PROFILE = CommodityProfile(
     volatility_low_iv_rank=0.25,
     price_move_alert_pct=3.0,
     straddle_risk_threshold=8000.0,
+    max_liquidity_spread_pct=0.75,
+    max_liquidity_spread_ticks=30,   # 30 × 1.0 = 30 $/ton floor
 
     research_prompts={
         "agronomist": "Search for 'Côte d Ivoire cocoa harvest forecast' and 'Ghana cocoa rainfall anomaly'. Analyze if conditions favor or threaten the main crop.",
@@ -788,6 +799,8 @@ def _load_profile_from_json(path: str) -> CommodityProfile:
         }),
         # Risk/pricing fields (must match dataclass — JSON profiles need these)
         straddle_risk_threshold=data.get('straddle_risk_threshold', 10000.0),
+        max_liquidity_spread_pct=data.get('max_liquidity_spread_pct', 0.75),
+        max_liquidity_spread_ticks=data.get('max_liquidity_spread_ticks', 60),
         fallback_iv=data.get('fallback_iv', 0.35),
         risk_free_rate=data.get('risk_free_rate', 0.04),
         default_starting_capital=data.get('default_starting_capital', 50000.0),

--- a/config/profiles/ng.json
+++ b/config/profiles/ng.json
@@ -144,6 +144,8 @@
         "gold": "GC=F",
         "wheat": "ZW=F"
     },
+    "max_liquidity_spread_pct": 0.75,
+    "max_liquidity_spread_ticks": 80,
     "tms_decay_rates": {
         "weather": 0.25,
         "logistics": 0.08,

--- a/scripts/calibrate_liquidity_thresholds.py
+++ b/scripts/calibrate_liquidity_thresholds.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""
+Calibrate liquidity filter thresholds from observed spread distributions.
+
+Reads [liquidity_metric: ...] log lines and computes per-commodity statistics
+for both tick-based and percentage-based spread metrics.
+
+Usage:
+    python scripts/calibrate_liquidity_thresholds.py --log-dir logs/ --percentile 95
+    python scripts/calibrate_liquidity_thresholds.py --log-dir logs/ --fail-only
+    python scripts/calibrate_liquidity_thresholds.py --log-dir logs/ --output json
+"""
+import argparse
+import re
+import os
+import json as json_mod
+import statistics
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+
+def parse_liquidity_metrics(log_dir: str, lookback_days: int = 14,
+                            fail_only: bool = False) -> dict:
+    """Extract spread metrics from PASS and FAIL log lines.
+
+    Supports two log formats:
+      - v2.2 enriched: [liquidity_metric: contract=X, ..., hour_utc=H]
+      - v1 legacy: [liquidity_metric: contract=X, spread_pct=P, hour_utc=H]
+    """
+    # v2.2 enriched pattern — uses alternation groups for inf-capable fields
+    pattern_v2 = re.compile(
+        r'\[liquidity_metric: contract=(\w+), expiry=(\S+), '
+        r'spread_pct=([0-9.]+|inf), spread_ticks=([0-9.]+|inf), '
+        r'abs_spread=([0-9.]+), theo=(-?[0-9.]+), '
+        r'allowed=([0-9.]+), binding=(\w+), '
+        r'tick_allow=([0-9.]+), pct_allow=([0-9.]+), '
+        r'hour_utc=(\d+)\]'
+    )
+    # v1 fallback pattern
+    pattern_v1 = re.compile(
+        r'\[liquidity_metric: contract=(\w+), expiry=\S+, '
+        r'spread_pct=([0-9.]+), hour_utc=(\d+)\]'
+    )
+
+    cutoff = datetime.now(tz=None) - timedelta(days=lookback_days)
+    metrics = defaultdict(list)
+
+    for filename in sorted(os.listdir(log_dir)):
+        if not filename.endswith('.log'):
+            continue
+        filepath = os.path.join(log_dir, filename)
+        with open(filepath, 'r') as f:
+            for line in f:
+                if 'liquidity_metric' not in line:
+                    continue
+
+                # Filter by status
+                is_fail = 'FILTER FAILED' in line
+                if fail_only and not is_fail:
+                    continue
+
+                # Extract timestamp
+                try:
+                    ts_str = line[:19]
+                    ts = datetime.strptime(ts_str, '%Y-%m-%d %H:%M:%S')
+                    if ts < cutoff:
+                        continue
+                except (ValueError, IndexError):
+                    continue
+
+                # Try v2.2 first, fall back to v1
+                m = pattern_v2.search(line)
+                if m:
+                    entry = {
+                        'contract': m.group(1),
+                        'expiry': m.group(2),
+                        'spread_pct': float(m.group(3)) if m.group(3) != 'inf' else float('inf'),
+                        'spread_ticks': float(m.group(4)) if m.group(4) != 'inf' else float('inf'),
+                        'abs_spread': float(m.group(5)),
+                        'theo': float(m.group(6)),
+                        'allowed': float(m.group(7)),
+                        'binding': m.group(8),
+                        'tick_allow': float(m.group(9)),
+                        'pct_allow': float(m.group(10)),
+                        'hour_utc': int(m.group(11)),
+                        'status': 'FAIL' if is_fail else 'PASS',
+                        'format': 'v2'
+                    }
+                else:
+                    m = pattern_v1.search(line)
+                    if m:
+                        entry = {
+                            'contract': m.group(1),
+                            'spread_pct': float(m.group(2)),
+                            'hour_utc': int(m.group(3)),
+                            'status': 'FAIL' if is_fail else 'PASS',
+                            'format': 'v1'
+                        }
+                    else:
+                        continue
+
+                metrics[entry['contract']].append(entry)
+
+    return metrics
+
+
+def compute_thresholds(metrics: dict, percentile: float = 95.0) -> dict:
+    """Compute suggested thresholds at the given percentile.
+
+    Analyzes BOTH absolute spreads (for tick calibration) and
+    percentage ratios (for pct calibration) to avoid moneyness skew.
+    """
+    suggestions = {}
+    for contract, observations in sorted(metrics.items()):
+        n = len(observations)
+
+        # Separate v2 (enriched) from v1 (legacy) entries
+        v2_entries = [e for e in observations if e.get('format') == 'v2']
+        has_v2 = len(v2_entries) > 0
+
+        # --- Percentage ratio analysis (always available) ---
+        finite_ratios = sorted([e['spread_pct'] for e in observations
+                                if e['spread_pct'] != float('inf')])
+        if not finite_ratios:
+            finite_ratios = [0.0]
+
+        p_idx = min(int(len(finite_ratios) * percentile / 100), len(finite_ratios) - 1)
+        ratio_at_p = finite_ratios[p_idx]
+
+        result = {
+            'observations': n,
+            'pass_count': sum(1 for e in observations if e['status'] == 'PASS'),
+            'fail_count': sum(1 for e in observations if e['status'] == 'FAIL'),
+            'ratio_median': round(statistics.median(finite_ratios), 3),
+            f'ratio_p{int(percentile)}': round(ratio_at_p, 3),
+            'suggested_max_spread_pct': round(ratio_at_p * 1.20, 2),
+        }
+
+        # --- Absolute tick analysis (v2 only) ---
+        if has_v2:
+            finite_ticks = sorted([e['spread_ticks'] for e in v2_entries
+                                   if e['spread_ticks'] != float('inf')])
+            all_abs = sorted([e['abs_spread'] for e in v2_entries])
+
+            if not finite_ticks:
+                finite_ticks = [0.0]
+
+            t_n = len(finite_ticks)
+            t_idx = min(int(t_n * percentile / 100), t_n - 1)
+            a_idx = min(int(len(all_abs) * percentile / 100), len(all_abs) - 1)
+
+            ticks_at_p = finite_ticks[t_idx]
+            abs_at_p = all_abs[a_idx]
+
+            # Binding constraint distribution
+            tick_bound = sum(1 for e in v2_entries if e.get('binding') == 'TICK_FLOOR')
+            pct_bound = sum(1 for e in v2_entries if e.get('binding') == 'PCT_CEILING')
+
+            result.update({
+                'v2_observations': len(v2_entries),
+                'tick_median': round(statistics.median(finite_ticks), 1),
+                f'tick_p{int(percentile)}': round(ticks_at_p, 1),
+                'suggested_max_spread_ticks': int(ticks_at_p * 1.20) + 1,
+                'abs_spread_median': round(statistics.median(all_abs), 4),
+                f'abs_spread_p{int(percentile)}': round(abs_at_p, 4),
+                'binding_tick_floor_pct': round(tick_bound / len(v2_entries) * 100, 1) if v2_entries else 0,
+                'binding_pct_ceiling_pct': round(pct_bound / len(v2_entries) * 100, 1) if v2_entries else 0,
+            })
+
+            # Credit spread analysis
+            credit_entries = [e for e in v2_entries if e.get('theo', 0) < 0]
+            if credit_entries:
+                result['credit_spread_count'] = len(credit_entries)
+                result['credit_spread_pass_count'] = sum(1 for e in credit_entries if e['status'] == 'PASS')
+
+        # Hour distribution (worst hours for failures)
+        hour_fail_counts = defaultdict(int)
+        for e in observations:
+            if e['status'] == 'FAIL':
+                hour_fail_counts[e['hour_utc']] += 1
+
+        result['worst_hours_utc'] = sorted(
+            hour_fail_counts.keys(),
+            key=lambda h: hour_fail_counts[h],
+            reverse=True
+        )[:3]
+
+        suggestions[contract] = result
+
+    return suggestions
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Calibrate liquidity thresholds')
+    parser.add_argument('--log-dir', default='logs/', help='Directory containing log files')
+    parser.add_argument('--lookback-days', type=int, default=14, help='Days of history')
+    parser.add_argument('--percentile', type=float, default=95.0, help='Target percentile')
+    parser.add_argument('--fail-only', action='store_true',
+                        help='Analyze only FAIL entries (use before PASS logging is deployed)')
+    parser.add_argument('--output', choices=['text', 'json'], default='text',
+                        help='Output format (json produces ready-to-paste config snippets)')
+    args = parser.parse_args()
+
+    metrics = parse_liquidity_metrics(args.log_dir, args.lookback_days, args.fail_only)
+
+    if not metrics:
+        print("No liquidity_metric entries found in logs.")
+        if not args.fail_only:
+            print("Try --fail-only to analyze existing FAIL logs before PASS logging is deployed.")
+        return
+
+    suggestions = compute_thresholds(metrics, args.percentile)
+
+    if args.output == 'json':
+        config_snippets = {}
+        for contract, data in suggestions.items():
+            snippet = {
+                'max_liquidity_spread_percentage': data['suggested_max_spread_pct'],
+            }
+            if 'suggested_max_spread_ticks' in data:
+                snippet['max_liquidity_spread_ticks'] = data['suggested_max_spread_ticks']
+            config_snippets[contract] = snippet
+
+        print(json_mod.dumps({
+            'calibration_report': {
+                'generated': datetime.now(tz=None).isoformat() + 'Z',
+                'lookback_days': args.lookback_days,
+                'percentile': args.percentile,
+                'fail_only': args.fail_only,
+            },
+            'suggested_overrides': config_snippets,
+            'details': suggestions
+        }, indent=2))
+        return
+
+    # Text output
+    print(f"\n{'='*70}")
+    print(f"Liquidity Threshold Calibration Report (Hybrid Tick/Percentage)")
+    print(f"Lookback: {args.lookback_days} days | Percentile: {args.percentile}%"
+          f"{' | FAIL-only' if args.fail_only else ''}")
+    print(f"{'='*70}\n")
+
+    for contract, data in suggestions.items():
+        print(f"  {contract}:")
+        print(f"    Observations: {data['observations']} "
+              f"({data['pass_count']} pass, {data['fail_count']} fail)")
+        print(f"    Ratio (spread/theo):  median={data['ratio_median']}, "
+              f"P{int(args.percentile)}={data[f'ratio_p{int(args.percentile)}']}")
+        print(f"    -> Suggested max_spread_pct: {data['suggested_max_spread_pct']}")
+
+        if 'v2_observations' in data:
+            p_key = f'tick_p{int(args.percentile)}'
+            print(f"    Ticks (abs spread/tick): median={data['tick_median']}, "
+                  f"P{int(args.percentile)}={data[p_key]}")
+            print(f"    -> Suggested max_spread_ticks: {data['suggested_max_spread_ticks']}")
+            print(f"    Binding: tick_floor={data['binding_tick_floor_pct']:.0f}%, "
+                  f"pct_ceiling={data['binding_pct_ceiling_pct']:.0f}%")
+            if 'credit_spread_count' in data:
+                print(f"    Credit spreads: {data['credit_spread_count']} "
+                      f"({data['credit_spread_pass_count']} pass)")
+        else:
+            print(f"    (No v2 enriched data -- tick analysis unavailable)")
+
+        if data['worst_hours_utc']:
+            print(f"    Worst hours (UTC): {data['worst_hours_utc']}")
+        print()
+
+    print("To apply, update config.json commodity_overrides -> strategy_tuning")
+    print("or CommodityProfile defaults in config/commodity_profiles.py\n")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_ib_interface.py
+++ b/tests/test_ib_interface.py
@@ -10,6 +10,7 @@ from trading_bot.ib_interface import (
     build_option_chain,
     create_combo_order_object,
     place_order,
+    _check_combo_liquidity,
 )
 
 
@@ -355,6 +356,99 @@ class TestIbInterface(unittest.TestCase):
             self.assertEqual(futures[1].localSymbol, 'KC_NextYear')
 
         asyncio.run(run_test())
+
+
+class TestCheckComboLiquidity(unittest.TestCase):
+    """Direct unit tests for _check_combo_liquidity helper."""
+
+    def test_tick_floor_passes_cheap_otm(self):
+        """Cheap OTM: high ratio but tick floor saves it."""
+        passed, meta = _check_combo_liquidity(
+            market_spread=0.50, net_theoretical_price=0.10, tick_size=0.05,
+            max_spread_pct=0.75, max_spread_ticks=80,
+            contract_sym='KON6', expiry='202609'
+        )
+        self.assertTrue(passed)
+        self.assertEqual(meta['binding'], 'TICK_FLOOR')
+        self.assertAlmostEqual(meta['tick_allow'], 4.00)
+
+    def test_pct_ceiling_blocks_predatory_spread(self):
+        """Expensive ITM: tick floor is too loose, pct ceiling catches it."""
+        passed, meta = _check_combo_liquidity(
+            market_spread=150.0, net_theoretical_price=50.0, tick_size=1.0,
+            max_spread_pct=0.75, max_spread_ticks=30,
+            contract_sym='COK6', expiry='202605'
+        )
+        self.assertFalse(passed)
+        self.assertEqual(meta['binding'], 'PCT_CEILING')
+        self.assertAlmostEqual(meta['pct_allow'], 37.50)
+
+    def test_credit_spread_uses_abs_theo(self):
+        """Credit spread (negative theo) should use abs() for pct allowance."""
+        passed, meta = _check_combo_liquidity(
+            market_spread=2.80, net_theoretical_price=-3.50, tick_size=0.05,
+            max_spread_pct=0.75, max_spread_ticks=80,
+            contract_sym='KON6', expiry='202609'
+        )
+        self.assertTrue(passed)
+        self.assertAlmostEqual(meta['pct_allow'], 2.625, places=3)
+
+    def test_credit_spread_blocked_when_toxic(self):
+        """Expensive credit spread with predatory widening should be blocked."""
+        passed, meta = _check_combo_liquidity(
+            market_spread=45.0, net_theoretical_price=-50.0, tick_size=1.0,
+            max_spread_pct=0.75, max_spread_ticks=30,
+            contract_sym='COK6', expiry='202605'
+        )
+        # allowed = max(30, abs(-50)*0.75=37.50) = 37.50
+        # 45.0 > 37.50 -> FAIL
+        self.assertFalse(passed)
+        self.assertEqual(meta['binding'], 'PCT_CEILING')
+
+    def test_zero_theo_uses_tick_floor_only(self):
+        """Zero theoretical (edge case) should default to tick floor."""
+        passed, meta = _check_combo_liquidity(
+            market_spread=0.10, net_theoretical_price=0.0, tick_size=0.05,
+            max_spread_pct=0.75, max_spread_ticks=80,
+            contract_sym='KON6', expiry='202609'
+        )
+        self.assertTrue(passed)  # 0.10 < 4.00 tick floor
+        self.assertEqual(meta['binding'], 'TICK_FLOOR')
+        self.assertAlmostEqual(meta['pct_allow'], 0.0)
+
+    def test_ng_cheap_otm_passes(self):
+        """NG deep OTM: tiny theo, normal spread, tick floor saves it."""
+        passed, meta = _check_combo_liquidity(
+            market_spread=0.015, net_theoretical_price=0.005, tick_size=0.001,
+            max_spread_pct=0.75, max_spread_ticks=80,
+            contract_sym='LNE', expiry='202607'
+        )
+        self.assertTrue(passed)
+        self.assertEqual(meta['binding'], 'TICK_FLOOR')
+        self.assertAlmostEqual(meta['tick_allow'], 0.08)
+
+    def test_kc_observed_case_passes(self):
+        """Reproduces the exact KC case from 2026-02-05 logs."""
+        passed, meta = _check_combo_liquidity(
+            market_spread=2.95, net_theoretical_price=2.42, tick_size=0.05,
+            max_spread_pct=0.75, max_spread_ticks=80,
+            contract_sym='KON6', expiry='202609'
+        )
+        self.assertTrue(passed)
+        self.assertAlmostEqual(meta['allowed'], 4.00)
+
+    def test_zero_tick_size_falls_back_to_pure_pct(self):
+        """tick_size=0 should not crash; falls back to pure percentage filter."""
+        passed, meta = _check_combo_liquidity(
+            market_spread=0.50, net_theoretical_price=1.00, tick_size=0.0,
+            max_spread_pct=0.75, max_spread_ticks=80,
+            contract_sym='TEST', expiry='202612'
+        )
+        # tick_allowance ~ 0 (80 * ~1e-9), pct_allowance = 0.75
+        # allowed = max(~0, 0.75) = 0.75 -> 0.50 < 0.75 -> PASS
+        self.assertTrue(passed)
+        self.assertEqual(meta['binding'], 'PCT_CEILING')
+        self.assertAlmostEqual(meta['pct_allow'], 0.75)
 
 
 if __name__ == '__main__':

--- a/trading_bot/ib_interface.py
+++ b/trading_bot/ib_interface.py
@@ -20,6 +20,75 @@ from trading_bot.utils import (
 )
 
 
+def _check_combo_liquidity(
+    market_spread: float,
+    net_theoretical_price: float,
+    tick_size: float,
+    max_spread_pct: float,
+    max_spread_ticks: int,
+    contract_sym: str,
+    expiry: str,
+) -> tuple[bool, dict]:
+    """
+    Hybrid Tick/Percentage Liquidity Filter.
+
+    Determines if a combo order's market spread is acceptable using:
+        allowed = max(tick_allowance, pct_allowance)
+
+    - Tick floor protects cheap OTM options from ratio inflation.
+    - Percentage ceiling (using abs(theo)) caps slippage on expensive options.
+    - abs() handles both debit spreads (theo > 0) and credit spreads (theo < 0).
+
+    Credit spreads (SELL, theo < 0) were previously UNFILTERED (the old
+    ``if theo > 0 and ...`` skipped them entirely). They are now subject to
+    the hybrid filter using abs(theo) for the percentage term.
+
+    Returns:
+        (passed, metadata) -- metadata includes all fields for enriched
+        logging and calibration.
+    """
+    from datetime import datetime as _dt, timezone as _tz
+
+    # Domain safety: prevent division by zero on tick_size
+    safe_tick = max(tick_size, 1e-9)
+
+    # Hybrid allowance: max(absolute_tick_floor, percentage_of_abs_theoretical)
+    absolute_tick_allowance = max_spread_ticks * safe_tick
+
+    # Use abs() to correctly handle credit spreads (negative theo).
+    # Market spread is always positive (ask - bid), so the allowance must be too.
+    # The inverted-spread guard upstream catches broken sign mismatches.
+    percentage_allowance = abs(net_theoretical_price) * max_spread_pct
+
+    allowed_spread = max(absolute_tick_allowance, percentage_allowance)
+
+    # Compute metadata (used in both PASS and FAIL logging)
+    abs_theo = abs(net_theoretical_price) if net_theoretical_price != 0 else 0.0
+    spread_pct_raw = (market_spread / abs_theo) if abs_theo > 0 else float('inf')
+    spread_ticks = (market_spread / safe_tick) if safe_tick > 0 else float('inf')
+    hour_utc = _dt.now(_tz.utc).hour
+    binding = 'TICK_FLOOR' if absolute_tick_allowance >= percentage_allowance else 'PCT_CEILING'
+
+    passed = market_spread <= allowed_spread
+
+    metadata = {
+        'contract': contract_sym,
+        'expiry': expiry,
+        'spread_pct': round(spread_pct_raw, 3),
+        'spread_ticks': round(spread_ticks, 1),
+        'abs_spread': round(market_spread, 4),
+        'theo': round(net_theoretical_price, 4),
+        'allowed': round(allowed_spread, 4),
+        'binding': binding,
+        'tick_allow': round(absolute_tick_allowance, 4),
+        'pct_allow': round(percentage_allowance, 4),
+        'hour_utc': hour_utc,
+        'passed': passed,
+    }
+
+    return passed, metadata
+
+
 async def get_option_market_data(ib: IB, contract: Contract, underlying_future: Contract) -> dict | None:
     """
     Fetches live market data for a single option contract, including bid, ask,
@@ -408,40 +477,67 @@ async def create_combo_order_object(ib: IB, config: dict, strategy_def: dict) ->
 
     # 5. Add Liquidity Filter and Calculate Limit Price (Ceiling/Floor) and Initial Price (Start)
     tuning_params = config.get('strategy_tuning', {})
-    max_spread_pct = tuning_params.get('max_liquidity_spread_percentage', 0.25)
     fixed_slippage = tuning_params.get('fixed_slippage_cents', 0.5)
-    # NEW: Configurable ceiling aggression (0.0 = mid, 1.0 = full ask/bid)
     ceiling_aggression = tuning_params.get('ceiling_aggression_factor', 0.75)
 
-    # Inverted spread guard: BUY spread should be a debit (positive theoretical),
-    # SELL spread should be a credit (negative theoretical). When the sign is wrong,
-    # it typically means IV mismatch between legs (e.g., one leg used fallback IV).
-    # IB will reject these as "riskless combination orders."
-    if action == 'BUY' and net_theoretical_price < 0:
+    # --- Load hybrid liquidity filter parameters ---
+    # Priority: config.json override > commodity profile > hardcoded fallback
+    from config import get_active_profile
+    _liq_profile = get_active_profile(config)
+    _profile_spread_pct = getattr(_liq_profile, 'max_liquidity_spread_pct', 0.75)
+    _profile_spread_ticks = getattr(_liq_profile, 'max_liquidity_spread_ticks', 60)
+
+    max_spread_pct = tuning_params.get('max_liquidity_spread_percentage', _profile_spread_pct)
+    max_spread_ticks = tuning_params.get('max_liquidity_spread_ticks', _profile_spread_ticks)
+
+    # --- Symmetric Inverted Spread Guard ---
+    # BUY spread should be a debit (positive theoretical).
+    # SELL spread should be a credit (negative theoretical).
+    # When the sign contradicts the action, it means IV mismatch between legs
+    # (e.g., one leg used fallback IV). IB will reject these as "riskless
+    # combination orders."
+    if (action == 'BUY' and net_theoretical_price < 0) or \
+       (action == 'SELL' and net_theoretical_price > 0):
         logging.warning(
-            f"INVERTED SPREAD FILTER: BUY spread has negative net theoretical "
-            f"({net_theoretical_price:.2f}). Likely IV mismatch between legs. Skipping."
+            f"INVERTED SPREAD FILTER: Pricing mismatch (Action '{action}' contradicts "
+            f"net theoretical {net_theoretical_price:.2f}). Likely IV mismatch between "
+            f"legs. Skipping."
         )
         return None
 
     market_spread = combo_ask_price - combo_bid_price
 
-    # Liquidity Filter: Check if the market spread is too wide relative to the theoretical price
-    if net_theoretical_price > 0 and (market_spread / net_theoretical_price) > max_spread_pct:
-        from datetime import datetime, timezone
-        _spread_pct = market_spread / net_theoretical_price
-        _hour_utc = datetime.now(timezone.utc).hour
-        _contract_sym = chain.get('tradingClass', config.get('symbol', '?'))
+    # --- Hybrid Tick/Percentage Liquidity Filter ---
+    _contract_sym = chain.get('tradingClass', config.get('symbol', '?'))
+    liq_passed, liq_meta = _check_combo_liquidity(
+        market_spread=market_spread,
+        net_theoretical_price=net_theoretical_price,
+        tick_size=tick_size,
+        max_spread_pct=max_spread_pct,
+        max_spread_ticks=max_spread_ticks,
+        contract_sym=_contract_sym,
+        expiry=exp_details.get('exp_date', '?'),
+    )
+
+    # Structured log tag — grep-friendly for calibration script
+    _liq_tag = '[liquidity_metric: ' + ', '.join(
+        f"{k}={v}" for k, v in liq_meta.items() if k != 'passed'
+    ) + ']'
+
+    if not liq_passed:
         logging.warning(
-            f"LIQUIDITY FILTER FAILED: Market spread ({market_spread:.2f}) is "
-            f"{_spread_pct:.1%} of theoretical price ({net_theoretical_price:.2f}), "
-            f"which exceeds the max of {max_spread_pct:.1%}. Aborting order. "
-            f"[liquidity_metric: contract={_contract_sym}, expiry={exp_details.get('exp_date', '?')}, "
-            f"spread_pct={_spread_pct:.3f}, hour_utc={_hour_utc}]"
+            f"LIQUIDITY FILTER FAILED: Market spread ({market_spread:.2f}) exceeds "
+            f"allowed ({liq_meta['allowed']:.2f}, binding={liq_meta['binding']}). "
+            f"Aborting order. {_liq_tag}"
         )
         return None
+    else:
+        logging.info(
+            f"LIQUIDITY FILTER PASSED: Market spread ({market_spread:.2f}) within "
+            f"allowed ({liq_meta['allowed']:.2f}, binding={liq_meta['binding']}). "
+            f"{_liq_tag}"
+        )
 
-    tick_size = get_tick_size(config)  # Commodity-agnostic tick size
     market_mid = (combo_bid_price + combo_ask_price) / 2
 
     # ================================================================

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -1263,8 +1263,16 @@ async def _handle_and_log_fill(ib: IB, trade: Trade, fill: Fill, combo_id: int, 
         logger.exception(f"Error processing and logging fill for order {trade.order.orderId}: {e}")
 
 
-async def check_liquidity_conditions(ib: IB, contract, order_size: int) -> tuple[bool, str]:
-    """Check if liquidity conditions are safe for execution."""
+async def check_liquidity_conditions(ib: IB, contract, order_size: int, config: dict = None) -> tuple[bool, str]:
+    """Check if liquidity conditions are safe for execution.
+
+    Args:
+        ib: Connected IB instance
+        contract: Contract to check
+        order_size: Intended order quantity
+        config: Optional config dict for parameterized thresholds.
+            If None, uses hardcoded defaults (backward-compatible).
+    """
     try:
         # --- PATCH: Bypass Depth Check for Combos (BAG) ---
         # IBKR returns 0 depth for synthetic combos even when legs have liquidity.
@@ -1290,9 +1298,11 @@ async def check_liquidity_conditions(ib: IB, contract, order_size: int) -> tuple
 
         ib.cancelMktDepth(contract)
 
-        # Safety checks
-        min_depth = order_size * 3  # Want 3x our order size in book
-        max_spread_pct = 0.5  # Max 0.5% spread
+        # Safety checks (parameterized — commodity-agnostic)
+        _tuning = (config or {}).get('strategy_tuning', {})
+        min_depth_multiplier = _tuning.get('min_book_depth_multiplier', 3)
+        min_depth = order_size * min_depth_multiplier
+        max_spread_pct = _tuning.get('max_single_leg_spread_pct', 0.5)
 
         if total_depth < min_depth:
             return False, f"Insufficient depth: {total_depth} (need {min_depth})"


### PR DESCRIPTION
## Summary
- Replace pure-percentage liquidity filter (`market_spread / theoretical`) with hybrid model: `allowed = max(tick_floor, pct_ceiling)`
- Tick floor protects cheap OTM options from ratio inflation (was blocking nearly all CC/NG trades)
- Percentage ceiling using `abs(theo)` caps slippage on expensive ITM options and filters credit spreads (previously completely bypassed)
- Symmetric inverted spread guard now catches both BUY+negative and SELL+positive theo mismatches
- Parameterized `check_liquidity_conditions()` in order_manager.py (`config=None` default, zero breakage)
- Added `calibrate_liquidity_thresholds.py` script for data-driven threshold tuning from production logs

## Files changed
| File | Change |
|------|--------|
| `trading_bot/ib_interface.py` | `_check_combo_liquidity()` helper, symmetric guard, enriched PASS/FAIL logging, removed redundant `tick_size` reassignment |
| `config/commodity_profiles.py` | `max_liquidity_spread_pct` + `max_liquidity_spread_ticks` fields on CommodityProfile, KC (80 ticks), CC (30 ticks) |
| `config/profiles/ng.json` | NG profile: 80 ticks |
| `config.json` | Base defaults + per-commodity overrides updated |
| `trading_bot/order_manager.py` | `check_liquidity_conditions(config=None)` parameterized |
| `scripts/calibrate_liquidity_thresholds.py` | New calibration script (v1/v2 log parsing, percentile analysis) |
| `tests/test_ib_interface.py` | 8 new unit tests for `_check_combo_liquidity` |

## Parameters
| Commodity | Tick Size | Max Ticks | Tick Floor | Max Spread % |
|-----------|----------|-----------|------------|-------------|
| KC | 0.05 | 80 | 4.00 c/lb | 75% |
| CC | 1.0 | 30 | 30 $/ton | 75% |
| NG | 0.001 | 80 | 0.08 $/mmBtu | 75% |

## Test plan
- [x] 8 new `TestCheckComboLiquidity` unit tests (tick floor, pct ceiling, credit spreads, zero edge cases)
- [x] All 9 existing `TestIbInterface` tests pass (backward compatible)
- [x] Full suite: 798 passed, 0 failures
- [x] Profile field verification: all 3 commodities load correctly
- [x] Calibration script runs against existing FAIL logs (152 entries parsed)
- [ ] Post-deploy: monitor PASS/FAIL ratio and binding constraint distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)