### PR TITLE
fix: cockpit data inconsistency — TMS path not updated on commodity switch

### DIFF
--- a/_commodity_selector.py
+++ b/_commodity_selector.py
@@ -83,6 +83,9 @@ def _reinit_data_dirs(ticker: str):
     from trading_bot.task_tracker import set_data_dir as set_tracker_dir
     set_tracker_dir(data_dir)
 
+    from trading_bot.tms import set_data_dir as set_tms_dir
+    set_tms_dir(data_dir)
+
 
 def selected_commodity() -> str:
     """Render commodity selector in sidebar and return the active ticker.

--- a/dashboard_utils.py
+++ b/dashboard_utils.py
@@ -2035,16 +2035,27 @@ def build_thesis_display_name(thesis: dict) -> str:
 
 # === THESIS STATUS FUNCTIONS ===
 
-def get_active_theses() -> list[dict]:
+def get_active_theses(ticker: str = None) -> list[dict]:
     """
     Retrieves all active trade theses from TMS.
     Returns a list of thesis dictionaries with computed fields.
+
+    Args:
+        ticker: Optional commodity ticker to resolve TMS path explicitly.
+                Falls back to COMMODITY_TICKER env var or module default.
     """
     try:
         from trading_bot.tms import TransactiveMemory
-        tms = TransactiveMemory()
+
+        # Use explicit path when ticker is provided to avoid stale module globals
+        if ticker:
+            persist_path = os.path.join("data", ticker, "tms")
+            tms = TransactiveMemory(persist_path=persist_path)
+        else:
+            tms = TransactiveMemory()
 
         if not tms.collection:
+            logger.warning("TMS collection not available — cannot load active theses")
             return []
 
         # Query all active theses

--- a/pages/1_Cockpit.py
+++ b/pages/1_Cockpit.py
@@ -218,7 +218,7 @@ def render_thesis_card_enhanced(thesis: dict, live_data: dict, config: dict = No
                 st.write(str(triggers) if triggers else "None defined")
 
 
-def render_portfolio_risk_summary(live_data: dict):
+def render_portfolio_risk_summary(live_data: dict, active_theses: list = None):
     """Portfolio risk using margin/P&L proxies (not live Greeks)."""
     st.subheader("📊 Portfolio Risk")
 
@@ -265,12 +265,22 @@ def render_portfolio_risk_summary(live_data: dict):
         positions = [p for p in live_data.get('open_positions', []) if p.position != 0]
         leg_count = len(positions)
 
-        # Count positions (spreads), not individual legs
-        active_theses = get_active_theses()
-        pos_count = len(active_theses) if active_theses else leg_count
+        # Count positions (spreads) from TMS theses
+        if active_theses:
+            pos_count = len(active_theses)
+            pos_label = "Open Positions"
+            pos_help = (
+                f"{pos_count} spread positions (from TMS theses), "
+                f"{leg_count} individual legs visible in IB."
+            )
+        else:
+            pos_count = leg_count
+            pos_label = "Open Legs"
+            pos_help = (
+                f"{leg_count} individual option legs in IB. "
+                "TMS theses unavailable — showing raw leg count."
+            )
 
-        # Build tooltip with breakdown
-        pos_help = f"Positions (spreads), not individual legs. {leg_count} legs across {pos_count} positions."
         if positions:
             sorted_pos = sorted(
                 positions,
@@ -282,14 +292,14 @@ def render_portfolio_risk_summary(live_data: dict):
                 contract = p.contract
                 symbol = getattr(contract, 'localSymbol', getattr(contract, 'symbol', 'Unknown'))
                 qty = p.position
-                details.append(f"• {symbol}: {qty:g}")
+                details.append(f"\u2022 {symbol}: {qty:g}")
 
             if len(positions) > 10:
                 details.append(f"...and {len(positions) - 10} more")
 
             pos_help += "\n\n" + "\n".join(details)
 
-        st.metric("Open Positions", pos_count, help=pos_help)
+        st.metric(pos_label, pos_count, help=pos_help)
 
 
 def render_prediction_markets():
@@ -891,13 +901,16 @@ else:
 st.markdown("---")
 
 # === SECTION 2: Financial HUD ===
+# Load active theses once for all sections (Portfolio Risk + Active Theses)
+_active_theses = get_active_theses(ticker=ticker)
+
 if config:
     live_data = fetch_all_live_data(config)
     _all_commodities = tuple(discover_active_commodities())
     benchmarks = fetch_todays_benchmark_data(commodity_tickers=_all_commodities)
 
     # Render Portfolio Risk
-    render_portfolio_risk_summary(live_data)
+    render_portfolio_risk_summary(live_data, _active_theses)
 
     # === E.1: Portfolio VaR Display ===
     try:
@@ -951,7 +964,7 @@ if config:
             with var_cols[2]:
                 st.metric("Utilization", f":{util_color}[{util:.0%}]", help="Percentage of the VaR limit currently being used.")
             with var_cols[3]:
-                st.metric("Positions", f"{pos_count} ({', '.join(commodities)})", help="Total number of open positions and active commodities.")
+                st.metric("Legs", f"{pos_count} ({', '.join(commodities)})", help="Individual option contract legs held in IB across all active commodities.")
 
             # Failure indicator
             if status == "FAILED":
@@ -1128,8 +1141,8 @@ st.write(f"{icon} Current Market Regime: **{label}**")
 
 st.markdown("")
 
-# Active Theses Table
-active_theses = get_active_theses()
+# Active Theses Table (reuse precomputed from Financial HUD section)
+active_theses = _active_theses
 
 if active_theses:
     # Summary metrics

--- a/tests/test_ui_ux.py
+++ b/tests/test_ui_ux.py
@@ -113,7 +113,7 @@ class TestCockpitUX(unittest.TestCase):
 
         target_metrics = [
             "Unrealized P&L", "Margin Util", "VaR(95%)", "VaR(99%)",
-            "Utilization", "Positions", "Since Reset"
+            "Utilization", "Legs", "Since Reset"
         ]
         found_metrics = {m: False for m in target_metrics}
 


### PR DESCRIPTION
## Summary
- **Root cause**: `_commodity_selector._reinit_data_dirs()` updated 9 modules on commodity switch but omitted TMS. The TMS path stayed on the first-imported commodity (e.g., NG), causing KC's Cockpit to query NG's empty TMS
- **Fix**: Add `trading_bot.tms.set_data_dir` to `_reinit_data_dirs()` and pass explicit ticker to `get_active_theses()`
- Rename VaR "Positions" to "Legs" to eliminate confusion with thesis-level position count
- Compute `get_active_theses()` once per page render instead of twice

## Affected metrics
| Before | After |
|--------|-------|
| "Open Positions: 4" (IB netted legs fallback) | "Open Positions: 5" (TMS theses) |
| "Positions: 6 (KC)" in VaR | "Legs: 6 (KC)" in VaR |
| "No active position theses" | Shows all 5 active theses |

## Test plan
- [x] 798 tests pass
- [ ] Verify Cockpit shows correct thesis count after deploy
- [ ] Switch commodity selector KC → CC → KC and verify theses reload correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)