### PR TITLE
fix: auto-close Error 478 + duplicate deferred invalidation

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1693,46 +1693,23 @@ async def _close_spread_position(
         f"({len(legs)} legs): {reason}"
     )
 
-    # --- Step 1: Re-qualify ALL contracts by conId ---
-    # CRITICAL FIX (2026-02-03): IBKR returns KC option positions with strikes
-    # in cents (307.5), but the order API expects dollars (3.075). We MUST
-    # re-qualify every contract using ONLY the conId so IB populates the
-    # correct strike format. Previous code skipped this for contracts that
-    # already had an exchange set, which was always the case for positions.
+    # --- Step 1: Use pos.contract directly (no re-qualification) ---
+    # CRITICAL FIX (2026-03-04): qualifyContractsAsync(Contract(conId=...))
+    # can return strike=285.0 for KC coffee, while the exchange expects 2.85.
+    # pos.contract from reqPositionsAsync() already has the correct conId,
+    # strike format, and exchange details. This matches the pattern used in
+    # emergency_hard_close() (L4548-4567).
     qualified_legs = []
     for leg in legs:
-        original_contract = leg.contract
-        try:
-            # Build a minimal contract with ONLY the conId.
-            # This forces IB to populate all fields from its database,
-            # including the correctly-formatted strike price.
-            minimal = Contract(conId=original_contract.conId)
-            qualified = await asyncio.wait_for(ib.qualifyContractsAsync(minimal), timeout=15)
-            if qualified and qualified[0].conId != 0:
-                qualified_legs.append(type(leg)(
-                    account=leg.account,
-                    contract=qualified[0],
-                    position=leg.position,
-                    avgCost=leg.avgCost
-                ))
-                logger.debug(
-                    f"Re-qualified {original_contract.localSymbol}: "
-                    f"strike {original_contract.strike} -> {qualified[0].strike}, "
-                    f"exchange={qualified[0].exchange}"
-                )
-            else:
-                logger.error(
-                    f"Contract re-qualification returned invalid result for "
-                    f"{original_contract.localSymbol} (conId={original_contract.conId}) "
-                    f"— using original (may fail with Error 478)"
-                )
-                qualified_legs.append(leg)
-        except Exception as e:
-            logger.error(
-                f"Contract re-qualification failed for "
-                f"{original_contract.localSymbol}: {e} — using original"
-            )
-            qualified_legs.append(leg)
+        contract = leg.contract
+        # reqPositionsAsync may return contracts without exchange — fill from config
+        if not contract.exchange:
+            contract.exchange = config.get('exchange', 'SMART')
+        qualified_legs.append(leg)
+        logger.debug(
+            f"Using pos.contract for {contract.localSymbol}: "
+            f"strike={contract.strike}, exchange={contract.exchange}"
+        )
 
     # --- Step 2: Close each leg individually ---
     # (BAG orders require additional combo definition logic; individual

--- a/tests/test_thesis_coherence.py
+++ b/tests/test_thesis_coherence.py
@@ -574,5 +574,164 @@ class TestAutoCloseSuperseded(unittest.TestCase):
         ib.reqPositionsAsync.assert_not_called()
 
 
+class TestDedupPreventsSecondAutoClose(unittest.TestCase):
+    """Verify _processed_supersedes prevents duplicate deferred invalidation."""
+
+    @patch('trading_bot.order_manager.record_entry_thesis_for_trade', new_callable=AsyncMock)
+    @patch('trading_bot.order_manager.log_trade_to_ledger', new_callable=AsyncMock)
+    @patch('trading_bot.order_manager._auto_close_superseded', new_callable=AsyncMock)
+    @patch('trading_bot.tms.TransactiveMemory')
+    async def test_second_fill_skips_invalidation(
+        self, mock_tms_cls, mock_auto_close, mock_log, mock_record
+    ):
+        """Two leg fills with same supersedes_trade_ids → only one invalidation + auto-close."""
+        from trading_bot.order_manager import (
+            _handle_and_log_fill, _recorded_thesis_positions, _processed_supersedes
+        )
+
+        mock_tms = MagicMock()
+        mock_tms.collection = True
+        mock_tms_cls.return_value = mock_tms
+
+        ib = MagicMock()
+        ib.isConnected.return_value = True
+        ib.qualifyContractsAsync = AsyncMock(return_value=[MagicMock()])
+
+        decision_data = {
+            'prediction_type': 'DIRECTIONAL',
+            'direction': 'BULLISH',
+            'contract_month': '202607',
+            'supersedes_trade_ids': ['old-bear-dedup'],
+            'supersedes_reason': 'CONTRADICT',
+        }
+
+        config = {'symbol': 'KC', 'exchange': 'NYBOT', 'notifications': {}}
+
+        # --- First leg fill ---
+        trade1 = MagicMock()
+        trade1.order.orderId = 200
+        trade1.order.orderRef = 'dedup-uuid'
+        trade1.contract = MagicMock(spec=['comboLegs', 'localSymbol'])
+        trade1.contract.localSymbol = 'COMBO'
+
+        fill1 = MagicMock()
+        fill1.contract = MagicMock()
+        fill1.contract.conId = 1001
+        fill1.execution.avgPrice = 2.00
+
+        _recorded_thesis_positions.discard('dedup-uuid')
+        _processed_supersedes.discard('old-bear-dedup')
+
+        await _handle_and_log_fill(ib, trade1, fill1, 500, 'dedup-uuid', decision_data, config)
+
+        self.assertEqual(mock_tms.invalidate_thesis.call_count, 1)
+        self.assertEqual(mock_auto_close.call_count, 1)
+
+        # --- Second leg fill (same decision_data ref) ---
+        trade2 = MagicMock()
+        trade2.order.orderId = 201
+        trade2.order.orderRef = 'dedup-uuid'
+        trade2.contract = MagicMock(spec=['comboLegs', 'localSymbol'])
+        trade2.contract.localSymbol = 'COMBO'
+
+        fill2 = MagicMock()
+        fill2.contract = MagicMock()
+        fill2.contract.conId = 1002
+        fill2.execution.avgPrice = 1.80
+
+        await _handle_and_log_fill(ib, trade2, fill2, 501, 'dedup-uuid', decision_data, config)
+
+        # Invalidation + auto-close should NOT have been called a second time
+        self.assertEqual(mock_tms.invalidate_thesis.call_count, 1,
+                         "invalidate_thesis called more than once — dedup failed")
+        self.assertEqual(mock_auto_close.call_count, 1,
+                         "_auto_close_superseded called more than once — dedup failed")
+
+
+class TestCloseSpreadPositionUsesPosContract(unittest.TestCase):
+    """Verify _close_spread_position uses pos.contract directly, not re-qualification."""
+
+    async def test_no_requalification(self):
+        """qualifyContractsAsync should never be called during spread close."""
+        import sys
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        # Lazy import to get the function from orchestrator
+        from orchestrator import _close_spread_position
+
+        ib = MagicMock()
+        ib.qualifyContractsAsync = AsyncMock(
+            side_effect=AssertionError("qualifyContractsAsync should NOT be called"))
+        ib.isConnected.return_value = True
+
+        # Build fake position legs with correct contracts
+        leg1 = MagicMock()
+        leg1.contract = MagicMock()
+        leg1.contract.localSymbol = 'KCN6 C310'
+        leg1.contract.strike = 3.10
+        leg1.contract.exchange = 'NYBOT'
+        leg1.contract.conId = 12345
+        leg1.position = 1
+        leg1.account = 'DU12345'
+        leg1.avgCost = 100.0
+
+        leg2 = MagicMock()
+        leg2.contract = MagicMock()
+        leg2.contract.localSymbol = 'KCN6 C320'
+        leg2.contract.strike = 3.20
+        leg2.contract.exchange = 'NYBOT'
+        leg2.contract.conId = 12346
+        leg2.position = -1
+        leg2.account = 'DU12345'
+        leg2.avgCost = 50.0
+
+        legs = [leg1, leg2]
+        config = {'exchange': 'NYBOT', 'notifications': {}}
+
+        # Mock place_order to return a filled trade
+        with patch('orchestrator.place_order') as mock_place:
+            mock_trade = MagicMock()
+            mock_trade.orderStatus.status = 'Filled'
+            mock_trade.orderStatus.remaining = 0
+            mock_place.return_value = mock_trade
+
+            result = await _close_spread_position(
+                ib, legs, 'test-pos-123', 'unit test close', config)
+
+        # qualifyContractsAsync was NOT called (would raise AssertionError if it was)
+        ib.qualifyContractsAsync.assert_not_called()
+
+    async def test_fills_missing_exchange_from_config(self):
+        """If pos.contract has no exchange, fill from config."""
+        from orchestrator import _close_spread_position
+
+        ib = MagicMock()
+        ib.isConnected.return_value = True
+
+        leg = MagicMock()
+        leg.contract = MagicMock()
+        leg.contract.localSymbol = 'KCN6 P270'
+        leg.contract.strike = 2.70
+        leg.contract.exchange = ''  # Missing exchange
+        leg.contract.conId = 54321
+        leg.position = -1
+        leg.account = 'DU12345'
+        leg.avgCost = 80.0
+
+        config = {'exchange': 'NYBOT', 'notifications': {}}
+
+        with patch('orchestrator.place_order') as mock_place:
+            mock_trade = MagicMock()
+            mock_trade.orderStatus.status = 'Filled'
+            mock_trade.orderStatus.remaining = 0
+            mock_place.return_value = mock_trade
+
+            await _close_spread_position(
+                ib, [leg], 'test-pos-456', 'unit test close', config)
+
+        # Exchange should have been filled from config
+        self.assertEqual(leg.contract.exchange, 'NYBOT')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -594,6 +594,11 @@ async def _log_catastrophe_fill_to_ledger(detected_fill: dict, position_id: str,
 # Module-level set for TMS thesis deduplication
 _recorded_thesis_positions = set()
 
+# Module-level set to prevent duplicate deferred invalidation + auto-close
+# when multiple leg fills trigger _handle_and_log_fill with the same
+# supersedes_trade_ids (same dict ref from decision_data).
+_processed_supersedes = set()
+
 # --- Logging Setup ---
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger("OrderManager")
@@ -1456,6 +1461,15 @@ async def _handle_and_log_fill(ib: IB, trade: Trade, fill: Fill, combo_id: int, 
                         "Deferred invalidation skipped; audit cycle will catch it.")
                 else:
                     for old_tid in superseded_ids:
+                        # Dedup: each leg fill triggers this block independently.
+                        # Only process each superseded trade ID once.
+                        if old_tid in _processed_supersedes:
+                            logger.debug(
+                                f"TMS: Deferred invalidation of {old_tid} already "
+                                f"processed, skipping duplicate.")
+                            continue
+                        _processed_supersedes.add(old_tid)
+
                         # 1. Invalidate thesis in TMS
                         tms_inv.invalidate_thesis(
                             old_tid,
@@ -1641,6 +1655,7 @@ async def place_queued_orders(config: dict, orders_list: list = None, connection
     # Clear thesis tracking at START of run (not in finally) to avoid racing
     # with fire-and-forget _handle_and_log_fill tasks still inflight
     _recorded_thesis_positions.clear()
+    _processed_supersedes.clear()
 
     # === D3 FIX: Explicit sequential processing ===
     # Use pop_all to atomically get and clear, preventing any race


### PR DESCRIPTION
## Summary

- **Error 478 (P0):** `_close_spread_position()` re-qualified contracts via `qualifyContractsAsync(Contract(conId=...))`, which returned `strike=285.0` for KC coffee while the exchange expects `2.85`. Replaced with direct `pos.contract` usage from `reqPositionsAsync()`, matching the proven `emergency_hard_close()` pattern.
- **Duplicate deferred invalidation (P1):** Both leg fills independently triggered the supersedes block in `_handle_and_log_fill`, causing double invalidation and a `TimeoutError` on the second auto-close. Added `_processed_supersedes` dedup set (following the `_recorded_thesis_positions` pattern).

## Test plan

- [x] `pytest tests/test_thesis_coherence.py -v` — 35 passed (32 existing + 3 new)
- [x] `pytest tests/ -x -q` — 833 passed, 0 failed
- [ ] After deploy: KC log shows `"Using pos.contract for..."` instead of `"Re-qualified..."`
- [ ] After deploy with contradiction: only one `"Deferred invalidation of {old_tid}"` log line per superseded trade

🤖 Generated with [Claude Code](https://claude.com/claude-code)