### PR TITLE
fix: harden drawdown guards, emergency close, and reconciliation

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1353,6 +1353,20 @@ async def _reconcile_orphaned_theses(
                     )
                     live_position_ids.add(tid)
 
+        # D3: Alert on IB positions with no matching thesis after FIFO matching
+        unmatched_ib = {sym: qty for sym, qty in remaining_ib.items() if qty != 0}
+        if unmatched_ib:
+            logger.warning(f"Orphan IB positions with no thesis match: {unmatched_ib}")
+            try:
+                send_pushover_notification(
+                    config.get('notifications', {}),
+                    "Orphan IB Positions Detected",
+                    f"{len(unmatched_ib)} positions in IB with no TMS thesis:\n"
+                    + "\n".join(f"  {sym}: {qty}" for sym, qty in unmatched_ib.items())
+                )
+            except Exception:
+                pass
+
         # 3. Identify orphans: active in TMS but not in IB
         orphaned_ids = [
             tid for tid in active_thesis_ids
@@ -4522,64 +4536,118 @@ async def emergency_hard_close(config: dict):
             f"Closing with MARKET orders. Slippage expected."
         )
 
-        # --- Submit all MARKET orders concurrently ---
-        # Use pos.contract directly from reqPositionsAsync — it has the correct
-        # conId and strike format. Re-qualifying via qualifyContractsAsync can
-        # return strike=285.0 vs exchange's 2.85, causing Error 478 rejections.
-        trades_pending = []  # (contract, trade, pos)
-        failed = 0
+        # --- B3: Register Error 201 handler for margin rejections ---
+        error_201_symbols = []
+        def on_emergency_error(reqId, errorCode, errorString, contract):
+            if errorCode == 201:
+                sym = getattr(contract, 'localSymbol', 'unknown') if contract else 'unknown'
+                error_201_symbols.append(sym)
+                logger.error(f"Emergency close Error 201 (margin): {sym}: {errorString}")
 
-        for pos in open_positions:
-            contract = pos.contract
-            # reqPositionsAsync may return contracts without exchange — fill from config
-            if not contract.exchange:
-                contract.exchange = config.get('exchange', 'SMART')
-            close_action = 'SELL' if pos.position > 0 else 'BUY'
-            qty = abs(pos.position)
+        # Safe: ib is per-commodity from IBConnectionPool, no cross-engine handler bleed
+        ib.errorEvent += on_emergency_error
 
-            order = MarketOrder(close_action, qty)
-            order.tif = 'GTC'
-            trade = ib.placeOrder(contract, order)
-            logger.info(f"Emergency close: {close_action} {qty} {contract.localSymbol} (MARKET)")
-            trades_pending.append((contract, trade, pos))
+        try:
+            # --- Submit all MARKET orders ---
+            # Use pos.contract directly from reqPositionsAsync — it has the correct
+            # conId and strike format. Re-qualifying via qualifyContractsAsync can
+            # return strike=285.0 vs exchange's 2.85, causing Error 478 rejections.
+            trades_pending = []  # (contract, trade, pos)
+            failed = 0
+            failed_symbols = []  # (localSymbol, status, error_detail)
 
-        # --- Phase 3: Wait for all fills concurrently ---
-        closed = 0
-        if trades_pending:
-            fill_timeout = 30  # seconds total for all fills
-            deadline = asyncio.get_event_loop().time() + fill_timeout
-            while trades_pending and asyncio.get_event_loop().time() < deadline:
-                await asyncio.sleep(0.5)
-                still_pending = []
-                for contract, trade, pos in trades_pending:
-                    if trade.isDone():
-                        if trade.orderStatus.status == 'Filled':
-                            closed += 1
-                            logger.info(
-                                f"Emergency fill: {contract.localSymbol} "
-                                f"@ {trade.orderStatus.avgFillPrice}"
-                            )
+            for pos in open_positions:
+                contract = pos.contract
+                # reqPositionsAsync may return contracts without exchange — fill from config
+                if not contract.exchange:
+                    contract.exchange = config.get('exchange', 'SMART')
+                close_action = 'SELL' if pos.position > 0 else 'BUY'
+                qty = abs(pos.position)
+
+                order = MarketOrder(close_action, qty)
+                order.tif = 'GTC'
+                trade = ib.placeOrder(contract, order)
+                logger.info(f"Emergency close: {close_action} {qty} {contract.localSymbol} (MARKET)")
+                trades_pending.append((contract, trade, pos))
+
+            # --- Phase 3: Wait for all fills ---
+            closed = 0
+            if trades_pending:
+                fill_timeout = 30  # seconds total for all fills
+                deadline = asyncio.get_event_loop().time() + fill_timeout
+                while trades_pending and asyncio.get_event_loop().time() < deadline:
+                    await asyncio.sleep(0.5)
+                    still_pending = []
+                    for contract, trade, pos in trades_pending:
+                        if trade.isDone():
+                            if trade.orderStatus.status == 'Filled':
+                                closed += 1
+                                logger.info(
+                                    f"Emergency fill: {contract.localSymbol} "
+                                    f"qty={trade.orderStatus.filled} "
+                                    f"@ {trade.orderStatus.avgFillPrice}"
+                                )
+                                # B1: Log to trade ledger
+                                try:
+                                    from trading_bot.utils import log_trade_to_ledger
+                                    import time as _time
+                                    await log_trade_to_ledger(
+                                        ib, trade,
+                                        reason="EMERGENCY_HARD_CLOSE",
+                                        position_id=f"EMERGENCY_{contract.localSymbol}_{today_date}_{int(_time.time())}"
+                                    )
+                                except Exception as ledger_err:
+                                    logger.error(f"Failed to log emergency fill to ledger: {ledger_err}")
+                            else:
+                                failed += 1
+                                # B2: Capture error details
+                                err_detail = "unknown"
+                                try:
+                                    if trade.log:
+                                        err_detail = trade.log[-1].message
+                                except Exception:
+                                    pass
+                                failed_symbols.append(
+                                    (contract.localSymbol, trade.orderStatus.status, err_detail)
+                                )
+                                logger.error(
+                                    f"Emergency close rejected/cancelled: "
+                                    f"{contract.localSymbol} status={trade.orderStatus.status} "
+                                    f"detail={err_detail}"
+                                )
                         else:
-                            failed += 1
-                            logger.error(
-                                f"Emergency close rejected/cancelled: "
-                                f"{contract.localSymbol} status={trade.orderStatus.status}"
-                            )
-                    else:
-                        still_pending.append((contract, trade, pos))
-                trades_pending = still_pending
+                            still_pending.append((contract, trade, pos))
+                    trades_pending = still_pending
 
-            # Anything still pending after timeout
-            for contract, trade, pos in trades_pending:
-                failed += 1
-                logger.error(
-                    f"Emergency close timed out ({fill_timeout}s): "
-                    f"{contract.localSymbol} status={trade.orderStatus.status}"
-                )
+                # Anything still pending after timeout
+                for contract, trade, pos in trades_pending:
+                    failed += 1
+                    err_detail = "timeout"
+                    try:
+                        if trade.log:
+                            err_detail = trade.log[-1].message
+                    except Exception:
+                        pass
+                    failed_symbols.append(
+                        (contract.localSymbol, trade.orderStatus.status, err_detail)
+                    )
+                    logger.error(
+                        f"Emergency close timed out ({fill_timeout}s): "
+                        f"{contract.localSymbol} status={trade.orderStatus.status}"
+                    )
 
-        summary = f"Emergency hard close: {closed} closed, {failed} failed"
-        logger.info(summary)
-        send_pushover_notification(config.get('notifications', {}), "Emergency Close Result", summary)
+            # B2: Include failed symbol details in notification
+            summary = f"Emergency hard close: {closed} closed, {failed} failed"
+            if failed_symbols:
+                detail = "\n".join(f"  {sym}: {status} — {err}" for sym, status, err in failed_symbols)
+                summary += f"\n{detail}"
+            if error_201_symbols:
+                summary += f"\nMargin rejections (Error 201): {', '.join(error_201_symbols)}"
+            logger.info(summary)
+            send_pushover_notification(config.get('notifications', {}), "Emergency Close Result", summary)
+
+        finally:
+            ib.errorEvent -= on_emergency_error
 
         # Sweep-invalidate active theses for positions we just closed.
         # Without this, ghost theses remain active until the 5AM cleanup job.

--- a/reconcile_trades.py
+++ b/reconcile_trades.py
@@ -150,6 +150,14 @@ async def reconcile_active_positions(config: dict):
         cutoff_time = now_utc - pd.Timedelta(hours=24)
 
         recent_trades = full_ledger[full_ledger['timestamp'] >= cutoff_time]
+        # Don't skip emergency/catastrophe symbols — these must be reconciled
+        # immediately since failed closes are exactly what we want to detect.
+        if 'reason' in recent_trades.columns:
+            recent_trades = recent_trades[
+                ~recent_trades['reason'].str.contains(
+                    'EMERGENCY_HARD_CLOSE|CATASTROPHE', na=False
+                )
+            ]
         skipped_symbols = set(recent_trades['local_symbol'].unique())
 
         if skipped_symbols:

--- a/tests/test_drawdown_recovery.py
+++ b/tests/test_drawdown_recovery.py
@@ -61,6 +61,12 @@ class TestDrawdownGuardRecovery:
         with open(state_file, 'w') as f:
             json.dump(state, f)
 
+        # Write daily_equity.csv so load_prev_close() returns starting_equity
+        # (starting_equity is reset to 0.0 on load, then re-derived from this file)
+        equity_file = os.path.join(data_dir, 'daily_equity.csv')
+        with open(equity_file, 'w') as f:
+            f.write(f"2026-01-01 17:00:00,{starting_equity}\n")
+
         guard = DrawdownGuard(config)
         return guard
 
@@ -275,6 +281,14 @@ class TestPortfolioRiskGuardRecovery:
         }
         with open(state_file, 'w') as f:
             json.dump(state, f)
+
+        # Write daily_equity.csv in a subdirectory so _load_prev_close() finds it
+        # (starting_equity is reset to 0.0 on load, then re-derived from this file)
+        subdir = os.path.join(data_dir, 'KC')
+        os.makedirs(subdir, exist_ok=True)
+        equity_file = os.path.join(subdir, 'daily_equity.csv')
+        with open(equity_file, 'w') as f:
+            f.write(f"2026-01-01 17:00:00,{starting_equity}\n")
 
         guard = PortfolioRiskGuard(config=config)
         return guard
@@ -644,3 +658,613 @@ class TestPortfolioRiskGuardPrevClose:
 
         # Should have reset and used prev close
         assert guard._starting_equity == 35145.06
+
+
+# ---------------------------------------------------------------------------
+# Workstream A/C/E: Starting Equity Reset, Panic Gate, Recovery Oscillation
+# ---------------------------------------------------------------------------
+
+class TestDrawdownGuardStartingEquityReset:
+    """Tests for A2: starting_equity forced to 0.0 on load, re-derived from prev close."""
+
+    def _mock_ib(self, net_liq):
+        ib = MagicMock()
+        summary_item = MagicMock()
+        summary_item.tag = 'NetLiquidation'
+        summary_item.currency = 'USD'
+        summary_item.value = str(net_liq)
+        ib.accountSummaryAsync = AsyncMock(return_value=[summary_item])
+        return ib
+
+    def test_load_state_resets_starting_equity_to_zero(self, tmp_path):
+        """A2: _load_state must reset starting_equity to 0.0 regardless of persisted value."""
+        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+
+        data_dir = str(tmp_path)
+        state_file = os.path.join(data_dir, 'drawdown_state.json')
+        os.makedirs(data_dir, exist_ok=True)
+        state = {
+            "status": "HALT",
+            "current_drawdown_pct": -3.0,
+            "starting_equity": 35182.91,  # Stale value from mid-day restart
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "date": datetime.now(timezone.utc).date().isoformat(),
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        config = {
+            'drawdown_circuit_breaker': {'enabled': True},
+            'notifications': {},
+            'data_dir': data_dir,
+        }
+        guard = DrawdownGuard(config)
+
+        # starting_equity should be 0.0 after load, not the persisted value
+        assert guard.state['starting_equity'] == 0.0
+        # But status should still be loaded
+        assert guard.state['status'] == "HALT"
+
+    @pytest.mark.asyncio
+    async def test_starting_equity_rederived_from_prev_close_after_reset(self, tmp_path):
+        """A2 + a897d2d: load→reset to 0→update_pnl→re-derives from daily_equity.csv."""
+        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+
+        data_dir = str(tmp_path)
+        os.makedirs(data_dir, exist_ok=True)
+
+        # Write stale state with wrong starting_equity (from mid-day NLV)
+        state_file = os.path.join(data_dir, 'drawdown_state.json')
+        state = {
+            "status": "HALT",
+            "current_drawdown_pct": -3.0,
+            "starting_equity": 35182.91,  # Wrong: was set from live NLV
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "date": datetime.now(timezone.utc).date().isoformat(),
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        # Write daily_equity.csv with the correct prev close
+        equity_file = os.path.join(data_dir, 'daily_equity.csv')
+        with open(equity_file, 'w') as f:
+            f.write("2026-03-03 17:00:00,35145.06\n")
+
+        config = {
+            'drawdown_circuit_breaker': {
+                'enabled': True,
+                'warning_pct': 2.0,
+                'halt_pct': 4.0,
+                'panic_pct': 6.0,
+            },
+            'notifications': {'enabled': False},
+            'data_dir': data_dir,
+        }
+        guard = DrawdownGuard(config)
+
+        # Verify starting_equity was reset to 0 on load
+        assert guard.state['starting_equity'] == 0.0
+
+        # Now call update_pnl — should re-derive from daily_equity.csv
+        ib = self._mock_ib(33000)  # NLV = $33,000
+
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+
+        # Should use prev close, NOT the stale persisted value
+        assert guard.state['starting_equity'] == 35145.06
+        # Drawdown: (33000 - 35145.06) / 35145.06 = -6.10% → PANIC
+        assert guard.state['status'] == "PANIC"
+
+    @pytest.mark.asyncio
+    async def test_zero_guard_prevents_division_by_zero(self, tmp_path):
+        """A3: update_pnl returns current status when starting_equity is 0."""
+        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+
+        data_dir = str(tmp_path)
+        os.makedirs(data_dir, exist_ok=True)
+
+        config = {
+            'drawdown_circuit_breaker': {'enabled': True},
+            'notifications': {},
+            'data_dir': data_dir,
+        }
+        guard = DrawdownGuard(config)
+        guard.state['starting_equity'] = 0.0
+        guard.state['status'] = "HALT"
+
+        # Mock IB that returns 0 NLV (load_prev_close also returns None → stays 0)
+        ib = MagicMock()
+        summary_item = MagicMock()
+        summary_item.tag = 'NetLiquidation'
+        summary_item.currency = 'USD'
+        summary_item.value = '0'
+        ib.accountSummaryAsync = AsyncMock(return_value=[summary_item])
+
+        result = await guard.update_pnl(ib)
+        assert result == "HALT"  # Returns current status without crash
+
+
+class TestDrawdownGuardPanicGate:
+    """Tests for C2: _panic_is_live gating on should_panic_close."""
+
+    def _make_guard(self, tmpdir, status="PANIC", starting_equity=100000):
+        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+
+        data_dir = str(tmpdir)
+        config = {
+            'drawdown_circuit_breaker': {
+                'enabled': True,
+                'warning_pct': 1.5,
+                'halt_pct': 2.5,
+                'panic_pct': 4.0,
+            },
+            'notifications': {'enabled': False},
+            'data_dir': data_dir,
+        }
+
+        state_file = os.path.join(data_dir, 'drawdown_state.json')
+        os.makedirs(data_dir, exist_ok=True)
+        state = {
+            "status": status,
+            "current_drawdown_pct": -5.0,
+            "starting_equity": starting_equity,
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "date": datetime.now(timezone.utc).date().isoformat(),
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        equity_file = os.path.join(data_dir, 'daily_equity.csv')
+        with open(equity_file, 'w') as f:
+            f.write(f"2026-01-01 17:00:00,{starting_equity}\n")
+
+        return DrawdownGuard(config)
+
+    def _mock_ib(self, net_liq):
+        ib = MagicMock()
+        summary_item = MagicMock()
+        summary_item.tag = 'NetLiquidation'
+        summary_item.currency = 'USD'
+        summary_item.value = str(net_liq)
+        ib.accountSummaryAsync = AsyncMock(return_value=[summary_item])
+        return ib
+
+    def test_loaded_panic_does_not_trigger_close(self, tmp_path):
+        """C2: Loaded PANIC should NOT trigger emergency close (panic_is_live=False)."""
+        guard = self._make_guard(tmp_path, status="PANIC")
+
+        # panic_is_live should be False after loading from disk
+        assert guard._panic_is_live is False
+        assert guard.state['status'] == "PANIC"
+        assert guard.should_panic_close() is False
+
+    def test_loaded_panic_still_blocks_entries(self, tmp_path):
+        """C2: Loaded PANIC should still block new entries (conservative)."""
+        guard = self._make_guard(tmp_path, status="PANIC")
+
+        assert guard.is_entry_allowed() is False
+
+    @pytest.mark.asyncio
+    async def test_fresh_panic_triggers_close(self, tmp_path):
+        """C2: Fresh PANIC evaluation should trigger emergency close."""
+        guard = self._make_guard(tmp_path, status="NORMAL", starting_equity=100000)
+
+        # NLV = 95500 → drawdown = -4.5% → exceeds panic_pct=4.0%
+        ib = self._mock_ib(95500)
+
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+
+        assert guard.state['status'] == "PANIC"
+        assert guard._panic_is_live is True
+        assert guard.should_panic_close() is True
+
+    @pytest.mark.asyncio
+    async def test_panic_is_live_false_when_not_panic(self, tmp_path):
+        """C2: _panic_is_live should be False when status is not PANIC."""
+        guard = self._make_guard(tmp_path, status="NORMAL", starting_equity=100000)
+
+        # NLV = 98000 → drawdown = -2.0% → WARNING
+        ib = self._mock_ib(98000)
+
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+
+        assert guard.state['status'] == "WARNING"
+        assert guard._panic_is_live is False
+
+    def test_daily_reset_clears_panic_is_live(self, tmp_path):
+        """C2: _reset_daily should clear _panic_is_live."""
+        guard = self._make_guard(tmp_path, status="PANIC")
+        guard._panic_is_live = True
+
+        guard.state['date'] = '1999-01-01'
+        guard._reset_daily()
+
+        assert guard._panic_is_live is False
+
+
+class TestPortfolioRiskGuardStartingEquityReset:
+    """Tests for A1: PortfolioRiskGuard starting_equity reset on load."""
+
+    def test_load_state_resets_starting_equity(self, tmp_path):
+        """A1: _load_state must reset starting_equity to 0.0."""
+        from trading_bot.shared_context import PortfolioRiskGuard
+
+        data_dir = str(tmp_path)
+        state_file = os.path.join(data_dir, 'portfolio_risk_state.json')
+        os.makedirs(data_dir, exist_ok=True)
+        state = {
+            "status": "HALT",
+            "peak_equity": 35200,
+            "current_equity": 33500,
+            "starting_equity": 35182.91,  # Stale
+            "daily_pnl": -1682.91,
+            "positions": {},
+            "margin": {},
+            "date": datetime.now(timezone.utc).date().isoformat(),
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        config = {
+            'data_dir_root': data_dir,
+            'drawdown_circuit_breaker': {'enabled': True},
+            'notifications': {},
+        }
+        guard = PortfolioRiskGuard(config=config)
+
+        # starting_equity reset, but status and peak preserved
+        assert guard._starting_equity == 0.0
+        assert guard._status == "HALT"
+        assert guard._peak_equity == 35200
+
+    @pytest.mark.asyncio
+    async def test_starting_equity_rederived_from_prev_close(self, tmp_path):
+        """A1 + a897d2d: load→reset→update_equity→re-derives from daily_equity.csv."""
+        from trading_bot.shared_context import PortfolioRiskGuard
+
+        data_dir = str(tmp_path)
+        os.makedirs(data_dir, exist_ok=True)
+
+        # Write stale state
+        state_file = os.path.join(data_dir, 'portfolio_risk_state.json')
+        state = {
+            "status": "HALT",
+            "peak_equity": 35200,
+            "current_equity": 33500,
+            "starting_equity": 35182.91,
+            "daily_pnl": -1682.91,
+            "positions": {},
+            "margin": {},
+            "date": datetime.now(timezone.utc).date().isoformat(),
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        # Write daily_equity.csv with correct prev close
+        kc_dir = os.path.join(data_dir, 'KC')
+        os.makedirs(kc_dir, exist_ok=True)
+        with open(os.path.join(kc_dir, 'daily_equity.csv'), 'w') as f:
+            f.write("2026-03-03 17:00:00,35145.06\n")
+
+        config = {
+            'data_dir_root': data_dir,
+            'drawdown_circuit_breaker': {
+                'enabled': True,
+                'warning_pct': 2.0,
+                'halt_pct': 4.0,
+                'panic_pct': 6.0,
+            },
+            'notifications': {'enabled': False},
+        }
+        guard = PortfolioRiskGuard(config=config)
+        assert guard._starting_equity == 0.0
+
+        # update_equity should re-derive from prev close
+        await guard.update_equity(33000, -2145)
+
+        assert guard._starting_equity == 35145.06
+        # Drawdown: (35145 - 33000) / 35145 = 6.10% → PANIC
+        assert guard._status == "PANIC"
+
+
+class TestPortfolioRiskGuardPanicGate:
+    """Tests for C1: _panic_is_live flag in PortfolioRiskGuard."""
+
+    def _make_guard(self, tmpdir, status="PANIC", starting_equity=100000, current_equity=95000):
+        from trading_bot.shared_context import PortfolioRiskGuard
+
+        data_dir = str(tmpdir)
+        config = {
+            'data_dir_root': data_dir,
+            'drawdown_circuit_breaker': {
+                'enabled': True,
+                'warning_pct': 1.5,
+                'halt_pct': 2.5,
+                'panic_pct': 4.0,
+            },
+            'notifications': {'enabled': False},
+        }
+
+        state_file = os.path.join(data_dir, 'portfolio_risk_state.json')
+        os.makedirs(data_dir, exist_ok=True)
+        state = {
+            "status": status,
+            "peak_equity": starting_equity,
+            "current_equity": current_equity,
+            "starting_equity": starting_equity,
+            "daily_pnl": current_equity - starting_equity,
+            "positions": {},
+            "margin": {},
+            "date": datetime.now(timezone.utc).date().isoformat(),
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        kc_dir = os.path.join(data_dir, 'KC')
+        os.makedirs(kc_dir, exist_ok=True)
+        with open(os.path.join(kc_dir, 'daily_equity.csv'), 'w') as f:
+            f.write(f"2026-01-01 17:00:00,{starting_equity}\n")
+
+        return PortfolioRiskGuard(config=config)
+
+    def test_loaded_panic_does_not_trigger_close(self, tmp_path):
+        """C1: Loaded PANIC from disk should NOT trigger emergency close."""
+        guard = self._make_guard(tmp_path, status="PANIC")
+
+        assert guard._panic_is_live is False
+        assert guard._status == "PANIC"
+        assert guard.should_panic_close() is False
+
+    def test_loaded_panic_blocks_entries(self, tmp_path):
+        """C1: Loaded PANIC should block entries (conservative)."""
+        guard = self._make_guard(tmp_path, status="PANIC")
+
+        assert guard.is_entry_allowed() is False
+
+    @pytest.mark.asyncio
+    async def test_fresh_panic_triggers_close(self, tmp_path):
+        """C1: After update_equity freshly evaluates PANIC, should_panic_close is True."""
+        guard = self._make_guard(tmp_path, status="NORMAL", starting_equity=100000, current_equity=100000)
+
+        # equity=95500 → drawdown=4.5% → exceeds panic_pct=4.0%
+        await guard.update_equity(95500, -4500)
+
+        assert guard._status == "PANIC"
+        assert guard._panic_is_live is True
+        assert guard.should_panic_close() is True
+
+    @pytest.mark.asyncio
+    async def test_panic_is_live_false_for_non_panic(self, tmp_path):
+        """C1: _panic_is_live should be False when status is not PANIC."""
+        guard = self._make_guard(tmp_path, status="NORMAL", starting_equity=100000, current_equity=100000)
+
+        # equity=98500 → drawdown=1.5% → WARNING
+        await guard.update_equity(98500, -1500)
+
+        assert guard._status == "WARNING"
+        assert guard._panic_is_live is False
+
+    def test_daily_reset_clears_panic_is_live(self, tmp_path):
+        """C1: _reset_daily should clear _panic_is_live."""
+        guard = self._make_guard(tmp_path, status="PANIC")
+        guard._panic_is_live = True
+
+        guard._state_date = "1999-01-01"
+        guard._reset_daily()
+
+        assert guard._panic_is_live is False
+
+
+class TestRecoveryTimerOscillation:
+    """Tests for Workstream E: Recovery timer not reset on noise between recovery_pct and halt_pct."""
+
+    def _make_dg(self, tmpdir, status="HALT", starting_equity=100000):
+        """Create a DrawdownGuard for oscillation testing."""
+        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+
+        data_dir = str(tmpdir)
+        config = {
+            'drawdown_circuit_breaker': {
+                'enabled': True,
+                'warning_pct': 1.5,
+                'halt_pct': 2.5,
+                'panic_pct': 4.0,
+                'recovery_pct': 2.0,
+                'recovery_hold_minutes': 30,
+            },
+            'notifications': {'enabled': False},
+            'data_dir': data_dir,
+        }
+
+        state_file = os.path.join(data_dir, 'drawdown_state.json')
+        os.makedirs(data_dir, exist_ok=True)
+        state = {
+            "status": status,
+            "current_drawdown_pct": -3.0,
+            "starting_equity": starting_equity,
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "date": datetime.now(timezone.utc).date().isoformat(),
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        equity_file = os.path.join(data_dir, 'daily_equity.csv')
+        with open(equity_file, 'w') as f:
+            f.write(f"2026-01-01 17:00:00,{starting_equity}\n")
+
+        return DrawdownGuard(config)
+
+    def _mock_ib(self, net_liq):
+        ib = MagicMock()
+        summary_item = MagicMock()
+        summary_item.tag = 'NetLiquidation'
+        summary_item.currency = 'USD'
+        summary_item.value = str(net_liq)
+        ib.accountSummaryAsync = AsyncMock(return_value=[summary_item])
+        return ib
+
+    @pytest.mark.asyncio
+    async def test_timer_not_reset_between_recovery_and_halt(self, tmp_path):
+        """E: Timer should NOT reset when drawdown bounces between recovery_pct and halt_pct."""
+        guard = self._make_dg(tmp_path, status="HALT", starting_equity=100000)
+        # recovery_pct=2.0, halt_pct=2.5
+
+        # Step 1: drawdown -1.5% → below recovery_pct → timer starts
+        ib = self._mock_ib(98500)
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+        assert guard._recovery_start is not None
+        saved_timer = guard._recovery_start
+
+        # Step 2: drawdown -2.3% → between recovery_pct and halt_pct → timer should be preserved
+        ib = self._mock_ib(97700)
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+        assert guard._recovery_start == saved_timer  # Timer NOT reset
+        assert guard.state['status'] == "HALT"  # Status held
+
+    @pytest.mark.asyncio
+    async def test_timer_reset_above_halt_pct(self, tmp_path):
+        """E: Timer SHOULD reset when drawdown crosses back above halt_pct."""
+        guard = self._make_dg(tmp_path, status="HALT", starting_equity=100000)
+        # recovery_pct=2.0, halt_pct=2.5
+
+        # Step 1: Start recovery timer
+        guard._recovery_start = datetime.now(timezone.utc).isoformat()
+
+        # Step 2: drawdown worsens to -3.0% → above halt_pct=2.5% → reset timer
+        ib = self._mock_ib(97000)
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+
+        assert guard._recovery_start is None  # Timer reset
+        assert guard.state['status'] == "HALT"  # Status held
+
+    @pytest.mark.asyncio
+    async def test_oscillation_scenario_timer_survives(self, tmp_path):
+        """E: Full oscillation scenario: start→bounce→return→complete."""
+        guard = self._make_dg(tmp_path, status="HALT", starting_equity=100000)
+
+        # Step 1: Drawdown improves to -1.8% (below recovery_pct=2.0%) → timer starts
+        ib = self._mock_ib(98200)
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+        assert guard._recovery_start is not None
+
+        # Step 2: Bounces to -2.2% (between recovery=2.0% and halt=2.5%) → timer preserved
+        ib = self._mock_ib(97800)
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+        assert guard._recovery_start is not None
+
+        # Step 3: Back to -1.5% and timer expired (simulate 31 min ago)
+        guard._recovery_start = (
+            datetime.now(timezone.utc) - timedelta(minutes=31)
+        ).isoformat()
+        ib = self._mock_ib(98500)
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            result = await guard.update_pnl(ib)
+
+        assert result == "WARNING"
+        assert guard._recovery_start is None
+
+
+class TestStaleRecoveryStartValidation:
+    """Tests for A4: Stale recovery_start discarded on load."""
+
+    def test_drawdown_guard_discards_stale_recovery_start(self, tmp_path):
+        """A4: DrawdownGuard discards recovery_start from a previous day."""
+        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+
+        data_dir = str(tmp_path)
+        os.makedirs(data_dir, exist_ok=True)
+
+        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        state_file = os.path.join(data_dir, 'drawdown_state.json')
+        state = {
+            "status": "HALT",
+            "current_drawdown_pct": -3.0,
+            "starting_equity": 100000,
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "date": datetime.now(timezone.utc).date().isoformat(),
+            "recovery_start": yesterday,  # From previous day
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        config = {
+            'drawdown_circuit_breaker': {'enabled': True},
+            'notifications': {},
+            'data_dir': data_dir,
+        }
+        guard = DrawdownGuard(config)
+
+        assert guard._recovery_start is None
+
+    def test_drawdown_guard_keeps_today_recovery_start(self, tmp_path):
+        """A4: DrawdownGuard preserves recovery_start from today."""
+        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+
+        data_dir = str(tmp_path)
+        os.makedirs(data_dir, exist_ok=True)
+
+        today_ts = datetime.now(timezone.utc).isoformat()
+        state_file = os.path.join(data_dir, 'drawdown_state.json')
+        state = {
+            "status": "HALT",
+            "current_drawdown_pct": -2.0,
+            "starting_equity": 100000,
+            "last_updated": today_ts,
+            "date": datetime.now(timezone.utc).date().isoformat(),
+            "recovery_start": today_ts,
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        config = {
+            'drawdown_circuit_breaker': {'enabled': True},
+            'notifications': {},
+            'data_dir': data_dir,
+        }
+        guard = DrawdownGuard(config)
+
+        assert guard._recovery_start == today_ts
+
+    def test_portfolio_guard_discards_stale_recovery_start(self, tmp_path):
+        """A4: PortfolioRiskGuard discards recovery_start from a previous day."""
+        from trading_bot.shared_context import PortfolioRiskGuard
+
+        data_dir = str(tmp_path)
+        os.makedirs(data_dir, exist_ok=True)
+
+        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        state_file = os.path.join(data_dir, 'portfolio_risk_state.json')
+        state = {
+            "status": "HALT",
+            "peak_equity": 100000,
+            "current_equity": 97000,
+            "starting_equity": 100000,
+            "daily_pnl": -3000,
+            "positions": {},
+            "margin": {},
+            "date": datetime.now(timezone.utc).date().isoformat(),
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "recovery_start": yesterday,
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        config = {
+            'data_dir_root': data_dir,
+            'drawdown_circuit_breaker': {'enabled': True},
+            'notifications': {},
+        }
+        guard = PortfolioRiskGuard(config=config)
+
+        assert guard._recovery_start is None

--- a/trading_bot/drawdown_circuit_breaker.py
+++ b/trading_bot/drawdown_circuit_breaker.py
@@ -62,6 +62,7 @@ class DrawdownGuard:
         self.recovery_pct = self.config.get('recovery_pct', 3.0)
         self.recovery_hold_minutes = self.config.get('recovery_hold_minutes', 30)
         self._recovery_start = None
+        self._panic_is_live = False  # Only True after update_pnl() freshly evaluates PANIC
         self._data_dir = config.get('data_dir', 'data')
         # Always use per-commodity data_dir; ignore any legacy state_file in sub-config
         self.state_file = os.path.join(self._data_dir, 'drawdown_state.json')
@@ -87,8 +88,25 @@ class DrawdownGuard:
                     current_date = datetime.now(timezone.utc).date().isoformat()
                     if saved_date == current_date:
                         self.state = saved
+                        # Force starting_equity to 0.0 so update_pnl() re-derives
+                        # from prev close (daily_equity.csv). Persisted value may
+                        # have been set from live NLV during an earlier startup.
+                        self.state['starting_equity'] = 0.0
                         self._recovery_start = saved.get('recovery_start')
-                        logger.info(f"Loaded drawdown state: {self.state['status']} ({self.state['current_drawdown_pct']:.2f}%)")
+                        # Discard stale recovery_start from previous day
+                        if self._recovery_start:
+                            try:
+                                rs_date = datetime.fromisoformat(self._recovery_start).date()
+                                if rs_date != datetime.now(timezone.utc).date():
+                                    logger.info("Discarded stale recovery_start from previous day")
+                                    self._recovery_start = None
+                            except (ValueError, TypeError):
+                                self._recovery_start = None
+                        logger.info(
+                            f"Loaded drawdown state: {self.state['status']} "
+                            f"({self.state['current_drawdown_pct']:.2f}%), "
+                            f"starting_equity=0 (will re-derive from prev close)"
+                        )
                     else:
                         logger.info("Saved drawdown state is old. Starting fresh.")
             except Exception as e:
@@ -116,6 +134,7 @@ class DrawdownGuard:
         if self.state['date'] != current_date:
             logger.info("Resetting DrawdownGuard for new day.")
             self._recovery_start = None
+            self._panic_is_live = False
             self.state = {
                 "status": "NORMAL",
                 "current_drawdown_pct": 0.0,
@@ -168,6 +187,8 @@ class DrawdownGuard:
 
             # 3. Calculate Drawdown
             start_eq = self.state['starting_equity']
+            if start_eq <= 0:
+                return self.state['status']  # Can't calculate drawdown yet
             pnl = net_liq - start_eq
             drawdown_pct = (pnl / start_eq) * 100
 
@@ -203,7 +224,10 @@ class DrawdownGuard:
                         if elapsed_minutes >= self.recovery_hold_minutes:
                             new_status = "WARNING"
                             self._recovery_start = None
-                            logger.warning(f"Recovery complete: {prev_status} -> WARNING after {elapsed_minutes:.0f}min sustained improvement")
+                            logger.warning(
+                                f"Recovery complete: {prev_status} -> WARNING after "
+                                f"{elapsed_minutes:.0f}min (drawdown at completion: {drawdown_pct:.2f}%)"
+                            )
                             send_pushover_notification(
                                 self.notification_config,
                                 f"📈 Recovery: {prev_status} → WARNING",
@@ -213,12 +237,20 @@ class DrawdownGuard:
                         else:
                             logger.info(f"Recovery in progress: {elapsed_minutes:.0f}/{self.recovery_hold_minutes}min")
                             new_status = prev_status  # Hold during observation
+                elif abs(drawdown_pct) <= self.halt_pct:
+                    # Between recovery_pct and halt_pct — hold status, keep timer intact.
+                    # Timer continues running (wall-clock) — elapsed time includes
+                    # danger-zone excursions. Recovery completion is only evaluated
+                    # when drawdown is actually below recovery_pct at the moment of
+                    # the check. Acceptable tradeoff vs. oscillation problem where
+                    # any noise restarted the 30-min countdown indefinitely.
+                    new_status = prev_status
                 else:
-                    # Still in drawdown territory - reset recovery timer
+                    # Back above halt_pct — genuine re-escalation, reset timer
                     if self._recovery_start is not None:
-                        logger.info(f"Recovery timer reset (drawdown worsened to {drawdown_pct:.2f}%)")
+                        logger.info(f"Recovery timer reset (drawdown worsened past halt to {drawdown_pct:.2f}%)")
                         self._recovery_start = None
-                    new_status = prev_status  # Stick at current level
+                    new_status = prev_status
 
             if new_status != prev_status:
                 logger.warning(f"Drawdown Status Changed: {prev_status} -> {new_status} (PNL: {drawdown_pct:.2f}%)")
@@ -247,6 +279,9 @@ class DrawdownGuard:
                         ticker="ALL"
                     )
 
+            # Track whether PANIC was freshly evaluated (not loaded from disk)
+            self._panic_is_live = (new_status == "PANIC")
+
             self._save_state()
             return new_status
 
@@ -260,4 +295,4 @@ class DrawdownGuard:
 
     def should_panic_close(self) -> bool:
         """Check if we need to emergency close everything."""
-        return self.state['status'] == "PANIC"
+        return self.state['status'] == "PANIC" and self._panic_is_live

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -1370,9 +1370,30 @@ async def _handle_and_log_fill(ib: IB, trade: Trade, fill: Fill, combo_id: int, 
             else:
                 logger.warning(f"Could not match fill conId {fill.contract.conId} to any leg in {trade.contract.localSymbol}.")
 
-        # This now calls the async version of the function, passing the unique position ID
-        await log_trade_to_ledger(ib, trade, "Strategy Execution", specific_fill=corrected_fill, combo_id=combo_id, position_id=position_uuid)
-        logger.info(f"Successfully logged fill for {detailed_contract.localSymbol} (Order ID: {trade.order.orderId}, Position ID: {position_uuid})")
+        # Log fill to ledger with retry — a single failure here silently drops the record
+        _ledger_logged = False
+        for _attempt in range(3):
+            try:
+                await log_trade_to_ledger(ib, trade, "Strategy Execution", specific_fill=corrected_fill, combo_id=combo_id, position_id=position_uuid)
+                _ledger_logged = True
+                break
+            except Exception as _ledger_err:
+                if _attempt < 2:
+                    logger.warning(f"Ledger write attempt {_attempt + 1}/3 failed: {_ledger_err}, retrying in 2s...")
+                    await asyncio.sleep(2)
+                else:
+                    logger.error(f"LEDGER WRITE FAILED after 3 attempts for order {trade.order.orderId}: {_ledger_err}")
+                    try:
+                        send_pushover_notification(
+                            (config or {}).get('notifications', {}),
+                            "LEDGER WRITE FAILED",
+                            f"Fill for {detailed_contract.localSymbol} qty={corrected_fill.execution.shares if corrected_fill else 'N/A'} "
+                            f"NOT recorded after 3 attempts. Manual reconciliation required."
+                        )
+                    except Exception:
+                        pass
+        if _ledger_logged:
+            logger.info(f"Successfully logged fill for {detailed_contract.localSymbol} (Order ID: {trade.order.orderId}, Position ID: {position_uuid})")
 
         # --- NEW: Record Trade Thesis to TMS (DEDUPLICATED) ---
         if decision_data and position_uuid:

--- a/trading_bot/shared_context.py
+++ b/trading_bot/shared_context.py
@@ -110,6 +110,7 @@ class PortfolioRiskGuard:
         )
         self._recovery_start = None
         self._recovery_active = False
+        self._panic_is_live = False  # Only True after update_equity() freshly evaluates PANIC
         self._load_state()
 
     # --- Persistence ---
@@ -123,20 +124,35 @@ class PortfolioRiskGuard:
                 from datetime import datetime, timezone
                 current_date = datetime.now(timezone.utc).date().isoformat()
                 if saved.get('date') == current_date:
+                    # peak_equity preserved: tracks intraday high-water mark,
+                    # valid across same-day restarts.
                     self._peak_equity = saved.get('peak_equity', 0.0)
                     self._current_equity = saved.get('current_equity', 0.0)
-                    self._starting_equity = saved.get('starting_equity', 0.0)
+                    # Force starting_equity to 0.0 so update_equity() re-derives
+                    # from prev close (daily_equity.csv). Persisted value may have
+                    # been set from live NLV during an earlier startup.
+                    self._starting_equity = 0.0
                     self._daily_pnl = saved.get('daily_pnl', 0.0)
                     self._positions_by_commodity = saved.get('positions', {})
                     self._margin_by_commodity = saved.get('margin', {})
                     self._status = saved.get('status', 'NORMAL')
                     self._state_date = current_date
                     self._recovery_start = saved.get('recovery_start')
+                    # Discard stale recovery_start from previous day
                     if self._recovery_start:
-                        self._recovery_active = True
+                        try:
+                            rs_date = datetime.fromisoformat(self._recovery_start).date()
+                            if rs_date != datetime.now(timezone.utc).date():
+                                logger.info("Discarded stale recovery_start from previous day")
+                                self._recovery_start = None
+                            else:
+                                self._recovery_active = True
+                        except (ValueError, TypeError):
+                            self._recovery_start = None
                     logger.info(
                         f"PortfolioRiskGuard loaded: {self._status}, "
                         f"equity=${self._current_equity:,.0f}, "
+                        f"starting_equity=0 (will re-derive from prev close), "
                         f"positions={self._positions_by_commodity}"
                     )
                     return
@@ -315,6 +331,7 @@ class PortfolioRiskGuard:
             self._daily_pnl = 0.0
             self._recovery_start = None
             self._recovery_active = False
+            self._panic_is_live = False
             prev_close = self._load_prev_close()
             if prev_close is not None:
                 self._starting_equity = prev_close
@@ -391,7 +408,10 @@ class PortfolioRiskGuard:
                                 self._status = "WARNING"
                                 self._recovery_start = None
                                 self._recovery_active = True  # Allow de-escalation this cycle
-                                logger.warning(f"PortfolioRiskGuard recovery: {prev} -> WARNING after {elapsed:.0f}min")
+                                logger.warning(
+                                    f"PortfolioRiskGuard recovery: {prev} -> WARNING after "
+                                    f"{elapsed:.0f}min (drawdown at completion: {drawdown_pct:.2f}%)"
+                                )
                                 try:
                                     from notifications import send_pushover_notification
                                     send_pushover_notification(
@@ -404,12 +424,19 @@ class PortfolioRiskGuard:
                                     pass
                         if not self._recovery_active:
                             self._status = prev  # Hold during observation
+                    elif drawdown_pct <= dd_cfg.get('halt_pct', 2.5):
+                        # Between recovery_pct and halt_pct — hold status, keep timer.
+                        # Timer continues running (wall-clock) — elapsed time includes
+                        # danger-zone excursions. Recovery completion is only evaluated
+                        # when drawdown is actually below recovery_pct. Acceptable
+                        # tradeoff vs. oscillation (where noise restarted the countdown).
+                        self._status = prev
                     else:
-                        # Still in drawdown territory - reset recovery timer
+                        # Back above halt_pct — genuine re-escalation, reset timer
                         if self._recovery_start is not None:
                             self._recovery_start = None
                             self._recovery_active = False
-                            logger.info("PortfolioRiskGuard recovery timer reset (drawdown worsened)")
+                            logger.info(f"PortfolioRiskGuard recovery timer reset (drawdown worsened past halt to {drawdown_pct:.2f}%)")
                         self._status = prev
                 elif status_priority.get(self._status, 0) < status_priority.get(prev, 0):
                     if not self._recovery_active:
@@ -418,6 +445,9 @@ class PortfolioRiskGuard:
                 # Reset recovery_active flag after use
                 if self._recovery_active and self._status == "WARNING":
                     self._recovery_active = False
+
+                # Track whether PANIC was freshly evaluated (not loaded from disk)
+                self._panic_is_live = (self._status == "PANIC")
 
             self._persist()
 
@@ -431,7 +461,7 @@ class PortfolioRiskGuard:
         return self._status in ("NORMAL", "WARNING")
 
     def should_panic_close(self) -> bool:
-        return self._status == "PANIC"
+        return self._status == "PANIC" and self._panic_is_live
 
     async def get_snapshot(self) -> dict:
         async with self._lock:


### PR DESCRIPTION
## Summary

- **Fix false PANIC on restart**: Force `starting_equity` re-derivation from `daily_equity.csv` on every load instead of trusting persisted value (both DrawdownGuard and PortfolioRiskGuard)
- **Prevent stale PANIC liquidation**: Add `_panic_is_live` flag to gate `should_panic_close()` — loaded PANIC blocks entries but won't trigger emergency close until fresh equity evaluation confirms it
- **Harden emergency_hard_close**: Write fills to trade ledger, track failed symbols with error details, handle IB Error 201 (margin) with scoped handler and cleanup
- **Improve reconciliation reliability**: Add 3-attempt retry to fire-and-forget fill handler, exclude `EMERGENCY_HARD_CLOSE`/`CATASTROPHE` entries from recently-traded filter, alert on orphan IB positions after FIFO matching
- **Fix recovery timer oscillation**: Timer preserved when drawdown bounces between `recovery_pct` and `halt_pct`, only reset on genuine re-escalation past `halt_pct`
- **Validate stale recovery_start**: Discard `recovery_start` from previous trading day on load

## Test plan

- [x] 21 new test cases covering all workstreams (A through E)
- [x] Starting equity reset on load → verify 0.0, re-derived from prev close on next update
- [x] A1/A2 + a897d2d interaction: load → reset → re-derive → correct drawdown calculation
- [x] Zero-guard: `start_eq == 0` → returns current status without division error
- [x] `should_panic_close()` returns False when `_panic_is_live` is False (loaded PANIC)
- [x] `should_panic_close()` returns True after fresh PANIC evaluation
- [x] `is_entry_allowed()` returns False when loaded PANIC (conservative blocking preserved)
- [x] Recovery timer NOT reset between `recovery_pct` and `halt_pct`
- [x] Recovery timer IS reset above `halt_pct`
- [x] Full oscillation scenario: start → bounce → return → complete
- [x] Stale `recovery_start` from previous day discarded on load
- [x] Full test suite: 863 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)