### PR TITLE
Split test_drawdown_recovery.py, fix async antipatterns

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,111 @@
+"""Shared test helpers for drawdown / portfolio-risk guard tests."""
+
+import json
+import os
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+
+def mock_ib(net_liq):
+    """Create a mock IB returning the given NetLiquidation."""
+    ib = MagicMock()
+    summary_item = MagicMock()
+    summary_item.tag = 'NetLiquidation'
+    summary_item.currency = 'USD'
+    summary_item.value = str(net_liq)
+    ib.accountSummaryAsync = AsyncMock(return_value=[summary_item])
+    return ib
+
+
+def write_drawdown_state(data_dir, status, drawdown_pct, starting_equity):
+    """Write drawdown_state.json to disk."""
+    data_dir = str(data_dir)
+    state_file = os.path.join(data_dir, 'drawdown_state.json')
+    os.makedirs(data_dir, exist_ok=True)
+    state = {
+        "status": status,
+        "current_drawdown_pct": drawdown_pct,
+        "starting_equity": starting_equity,
+        "last_updated": datetime.now(timezone.utc).isoformat(),
+        "date": datetime.now(timezone.utc).date().isoformat(),
+    }
+    with open(state_file, 'w') as f:
+        json.dump(state, f)
+
+
+def write_equity_csv(data_dir, starting_equity):
+    """Write daily_equity.csv for load_prev_close()."""
+    data_dir = str(data_dir)
+    equity_file = os.path.join(data_dir, 'daily_equity.csv')
+    with open(equity_file, 'w') as f:
+        f.write(f"2026-01-01 17:00:00,{starting_equity}\n")
+
+
+def make_drawdown_guard(tmpdir, status="PANIC", starting_equity=100000, **config_overrides):
+    """Create a DrawdownGuard with pre-set persisted state."""
+    from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+
+    data_dir = str(tmpdir)
+    cb_config = {
+        'enabled': True,
+        'warning_pct': 1.5,
+        'halt_pct': 2.5,
+        'panic_pct': 4.0,
+        'recovery_pct': 3.0,
+        'recovery_hold_minutes': 30,
+    }
+    cb_config.update(config_overrides)
+    config = {
+        'drawdown_circuit_breaker': cb_config,
+        'notifications': {'enabled': False},
+        'data_dir': data_dir,
+    }
+
+    write_drawdown_state(data_dir, status, -4.5, starting_equity)
+    write_equity_csv(data_dir, starting_equity)
+
+    return DrawdownGuard(config)
+
+
+def make_portfolio_risk_guard(tmpdir, status="PANIC", starting_equity=100000, current_equity=95000, **config_overrides):
+    """Create a PortfolioRiskGuard with pre-set persisted state."""
+    from trading_bot.shared_context import PortfolioRiskGuard
+
+    data_dir = str(tmpdir)
+    cb_config = {
+        'enabled': True,
+        'warning_pct': 1.5,
+        'halt_pct': 2.5,
+        'panic_pct': 4.0,
+        'recovery_pct': 3.0,
+        'recovery_hold_minutes': 30,
+    }
+    cb_config.update(config_overrides)
+    config = {
+        'data_dir_root': data_dir,
+        'drawdown_circuit_breaker': cb_config,
+        'notifications': {'enabled': False},
+    }
+
+    state_file = os.path.join(data_dir, 'portfolio_risk_state.json')
+    os.makedirs(data_dir, exist_ok=True)
+    state = {
+        "status": status,
+        "peak_equity": starting_equity,
+        "current_equity": current_equity,
+        "starting_equity": starting_equity,
+        "daily_pnl": current_equity - starting_equity,
+        "positions": {},
+        "margin": {},
+        "date": datetime.now(timezone.utc).date().isoformat(),
+        "last_updated": datetime.now(timezone.utc).isoformat(),
+    }
+    with open(state_file, 'w') as f:
+        json.dump(state, f)
+
+    kc_dir = os.path.join(data_dir, 'KC')
+    os.makedirs(kc_dir, exist_ok=True)
+    with open(os.path.join(kc_dir, 'daily_equity.csv'), 'w') as f:
+        f.write(f"2026-01-01 17:00:00,{starting_equity}\n")
+
+    return PortfolioRiskGuard(config=config)

--- a/tests/test_drawdown_panic_gate.py
+++ b/tests/test_drawdown_panic_gate.py
@@ -1,0 +1,131 @@
+"""Tests for _panic_is_live flag gating in DrawdownGuard and PortfolioRiskGuard.
+
+Covers:
+- Loaded PANIC from disk does NOT trigger emergency close
+- Loaded PANIC still blocks new entries
+- Fresh PANIC evaluation triggers emergency close
+- _panic_is_live is False for non-PANIC statuses
+- Daily reset clears _panic_is_live
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from conftest import mock_ib, make_drawdown_guard, make_portfolio_risk_guard
+
+
+# ---------------------------------------------------------------------------
+# DrawdownGuard Panic Gate Tests
+# ---------------------------------------------------------------------------
+
+class TestDrawdownGuardPanicGate:
+    """Tests for C2: _panic_is_live gating on should_panic_close."""
+
+    def test_loaded_panic_does_not_trigger_close(self, tmp_path):
+        """C2: Loaded PANIC should NOT trigger emergency close (panic_is_live=False)."""
+        guard = make_drawdown_guard(tmp_path, status="PANIC")
+
+        assert guard._panic_is_live is False
+        assert guard.state['status'] == "PANIC"
+        assert guard.should_panic_close() is False
+
+    def test_loaded_panic_still_blocks_entries(self, tmp_path):
+        """C2: Loaded PANIC should still block new entries (conservative)."""
+        guard = make_drawdown_guard(tmp_path, status="PANIC")
+
+        assert guard.is_entry_allowed() is False
+
+    @pytest.mark.asyncio
+    async def test_fresh_panic_triggers_close(self, tmp_path):
+        """C2: Fresh PANIC evaluation should trigger emergency close."""
+        guard = make_drawdown_guard(tmp_path, status="NORMAL", starting_equity=100000)
+
+        # NLV = 95500 → drawdown = -4.5% → exceeds panic_pct=4.0%
+        ib = mock_ib(95500)
+
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+
+        assert guard.state['status'] == "PANIC"
+        assert guard._panic_is_live is True
+        assert guard.should_panic_close() is True
+
+    @pytest.mark.asyncio
+    async def test_panic_is_live_false_when_not_panic(self, tmp_path):
+        """C2: _panic_is_live should be False when status is not PANIC."""
+        guard = make_drawdown_guard(tmp_path, status="NORMAL", starting_equity=100000)
+
+        # NLV = 98000 → drawdown = -2.0% → WARNING
+        ib = mock_ib(98000)
+
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+
+        assert guard.state['status'] == "WARNING"
+        assert guard._panic_is_live is False
+
+    def test_daily_reset_clears_panic_is_live(self, tmp_path):
+        """C2: _reset_daily should clear _panic_is_live."""
+        guard = make_drawdown_guard(tmp_path, status="PANIC")
+        guard._panic_is_live = True
+
+        guard.state['date'] = '1999-01-01'
+        guard._reset_daily()
+
+        assert guard._panic_is_live is False
+
+
+# ---------------------------------------------------------------------------
+# PortfolioRiskGuard Panic Gate Tests
+# ---------------------------------------------------------------------------
+
+class TestPortfolioRiskGuardPanicGate:
+    """Tests for C1: _panic_is_live flag in PortfolioRiskGuard."""
+
+    def test_loaded_panic_does_not_trigger_close(self, tmp_path):
+        """C1: Loaded PANIC from disk should NOT trigger emergency close."""
+        guard = make_portfolio_risk_guard(tmp_path, status="PANIC")
+
+        assert guard._panic_is_live is False
+        assert guard._status == "PANIC"
+        assert guard.should_panic_close() is False
+
+    def test_loaded_panic_blocks_entries(self, tmp_path):
+        """C1: Loaded PANIC should block entries (conservative)."""
+        guard = make_portfolio_risk_guard(tmp_path, status="PANIC")
+
+        assert guard.is_entry_allowed() is False
+
+    @pytest.mark.asyncio
+    async def test_fresh_panic_triggers_close(self, tmp_path):
+        """C1: After update_equity freshly evaluates PANIC, should_panic_close is True."""
+        guard = make_portfolio_risk_guard(tmp_path, status="NORMAL", starting_equity=100000, current_equity=100000)
+
+        # equity=95500 → drawdown=4.5% → exceeds panic_pct=4.0%
+        await guard.update_equity(95500, -4500)
+
+        assert guard._status == "PANIC"
+        assert guard._panic_is_live is True
+        assert guard.should_panic_close() is True
+
+    @pytest.mark.asyncio
+    async def test_panic_is_live_false_for_non_panic(self, tmp_path):
+        """C1: _panic_is_live should be False when status is not PANIC."""
+        guard = make_portfolio_risk_guard(tmp_path, status="NORMAL", starting_equity=100000, current_equity=100000)
+
+        # equity=98500 → drawdown=1.5% → WARNING
+        await guard.update_equity(98500, -1500)
+
+        assert guard._status == "WARNING"
+        assert guard._panic_is_live is False
+
+    def test_daily_reset_clears_panic_is_live(self, tmp_path):
+        """C1: _reset_daily should clear _panic_is_live."""
+        guard = make_portfolio_risk_guard(tmp_path, status="PANIC")
+        guard._panic_is_live = True
+
+        guard._state_date = "1999-01-01"
+        guard._reset_daily()
+
+        assert guard._panic_is_live is False

--- a/tests/test_drawdown_recovery.py
+++ b/tests/test_drawdown_recovery.py
@@ -1,5 +1,4 @@
-"""
-Tests for PANIC/HALT recovery de-escalation in DrawdownGuard and PortfolioRiskGuard.
+"""Tests for PANIC/HALT recovery de-escalation in DrawdownGuard and PortfolioRiskGuard.
 
 Covers:
 1. Status sticks during active drawdown (no recovery)
@@ -10,81 +9,31 @@ Covers:
 6. Daily reset clears recovery timer
 7. Backward-compatible state loading (no recovery_start key)
 8. PortfolioRiskGuard mirrors DrawdownGuard recovery behavior
-9. Starting equity from previous close (daily_equity.csv)
+9. Recovery timer oscillation tolerance
 """
 
-import asyncio
 import json
 import os
-import tempfile
 from datetime import datetime, timezone, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch, call
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from conftest import mock_ib, make_drawdown_guard, make_portfolio_risk_guard
+
 
 # ---------------------------------------------------------------------------
-# DrawdownGuard Tests
+# DrawdownGuard Recovery Tests
 # ---------------------------------------------------------------------------
 
 class TestDrawdownGuardRecovery:
     """Tests for recovery logic in DrawdownGuard."""
 
-    def _make_guard(self, tmpdir, status="PANIC", drawdown=-4.5, starting_equity=100000):
-        """Create a DrawdownGuard with pre-set state."""
-        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
-
-        data_dir = str(tmpdir)
-        config = {
-            'drawdown_circuit_breaker': {
-                'enabled': True,
-                'warning_pct': 1.5,
-                'halt_pct': 2.5,
-                'panic_pct': 4.0,
-                'recovery_pct': 3.0,
-                'recovery_hold_minutes': 30,
-            },
-            'notifications': {'enabled': False},
-            'data_dir': data_dir,
-        }
-
-        # Pre-write state so constructor loads it
-        state_file = os.path.join(data_dir, 'drawdown_state.json')
-        os.makedirs(data_dir, exist_ok=True)
-        state = {
-            "status": status,
-            "current_drawdown_pct": drawdown,
-            "starting_equity": starting_equity,
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-            "date": datetime.now(timezone.utc).date().isoformat(),
-        }
-        with open(state_file, 'w') as f:
-            json.dump(state, f)
-
-        # Write daily_equity.csv so load_prev_close() returns starting_equity
-        # (starting_equity is reset to 0.0 on load, then re-derived from this file)
-        equity_file = os.path.join(data_dir, 'daily_equity.csv')
-        with open(equity_file, 'w') as f:
-            f.write(f"2026-01-01 17:00:00,{starting_equity}\n")
-
-        guard = DrawdownGuard(config)
-        return guard
-
-    def _mock_ib(self, net_liq):
-        """Create a mock IB that returns the given NetLiquidation."""
-        ib = MagicMock()
-        summary_item = MagicMock()
-        summary_item.tag = 'NetLiquidation'
-        summary_item.currency = 'USD'
-        summary_item.value = str(net_liq)
-        ib.accountSummaryAsync = AsyncMock(return_value=[summary_item])
-        return ib
-
     @pytest.mark.asyncio
     async def test_sticks_during_active_drawdown(self, tmp_path):
         """PANIC status should stick when drawdown is still severe."""
-        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
-        ib = self._mock_ib(95000)  # -5% drawdown, still bad
+        guard = make_drawdown_guard(tmp_path, status="PANIC", starting_equity=100000)
+        ib = mock_ib(95000)  # -5% drawdown, still bad
 
         result = await guard.update_pnl(ib)
 
@@ -94,8 +43,8 @@ class TestDrawdownGuardRecovery:
     @pytest.mark.asyncio
     async def test_halt_sticks_during_active_drawdown(self, tmp_path):
         """HALT status should stick when drawdown is still above recovery threshold."""
-        guard = self._make_guard(tmp_path, status="HALT", starting_equity=100000)
-        ib = self._mock_ib(96500)  # -3.5% drawdown, above recovery_pct=3% but below panic_pct=4%
+        guard = make_drawdown_guard(tmp_path, status="HALT", starting_equity=100000)
+        ib = mock_ib(96500)  # -3.5% drawdown, above recovery_pct=3% but below panic_pct=4%
 
         result = await guard.update_pnl(ib)
 
@@ -105,8 +54,8 @@ class TestDrawdownGuardRecovery:
     @pytest.mark.asyncio
     async def test_recovery_timer_starts(self, tmp_path):
         """Recovery timer should start when drawdown improves below recovery_pct."""
-        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
-        ib = self._mock_ib(98000)  # -2% drawdown, below recovery_pct=3%
+        guard = make_drawdown_guard(tmp_path, status="PANIC", starting_equity=100000)
+        ib = mock_ib(98000)  # -2% drawdown, below recovery_pct=3%
 
         result = await guard.update_pnl(ib)
 
@@ -116,11 +65,11 @@ class TestDrawdownGuardRecovery:
     @pytest.mark.asyncio
     async def test_recovery_timer_resets_on_worsening(self, tmp_path):
         """Recovery timer should reset if drawdown worsens again."""
-        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        guard = make_drawdown_guard(tmp_path, status="PANIC", starting_equity=100000)
         guard._recovery_start = datetime.now(timezone.utc).isoformat()
 
         # Drawdown worsens back to -4% (abs > recovery_pct=3%)
-        ib = self._mock_ib(96000)
+        ib = mock_ib(96000)
 
         result = await guard.update_pnl(ib)
 
@@ -130,13 +79,13 @@ class TestDrawdownGuardRecovery:
     @pytest.mark.asyncio
     async def test_recovery_completes_after_hold_period(self, tmp_path):
         """After sustained improvement for hold period, should de-escalate to WARNING."""
-        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        guard = make_drawdown_guard(tmp_path, status="PANIC", starting_equity=100000)
         # Set recovery_start to 31 minutes ago
         guard._recovery_start = (
             datetime.now(timezone.utc) - timedelta(minutes=31)
         ).isoformat()
 
-        ib = self._mock_ib(98000)  # -2% drawdown, below recovery_pct=3%
+        ib = mock_ib(98000)  # -2% drawdown, below recovery_pct=3%
 
         with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification') as mock_notify:
             result = await guard.update_pnl(ib)
@@ -151,12 +100,12 @@ class TestDrawdownGuardRecovery:
     @pytest.mark.asyncio
     async def test_recovery_notification_sent(self, tmp_path):
         """Pushover notification should be sent when recovery completes."""
-        guard = self._make_guard(tmp_path, status="HALT", starting_equity=100000)
+        guard = make_drawdown_guard(tmp_path, status="HALT", starting_equity=100000)
         guard._recovery_start = (
             datetime.now(timezone.utc) - timedelta(minutes=45)
         ).isoformat()
 
-        ib = self._mock_ib(98500)  # -1.5% drawdown
+        ib = mock_ib(98500)  # -1.5% drawdown
 
         with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification') as mock_notify:
             result = await guard.update_pnl(ib)
@@ -173,7 +122,7 @@ class TestDrawdownGuardRecovery:
 
     def test_daily_reset_clears_recovery_timer(self, tmp_path):
         """Daily reset should clear recovery timer."""
-        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        guard = make_drawdown_guard(tmp_path, status="PANIC", starting_equity=100000)
         guard._recovery_start = datetime.now(timezone.utc).isoformat()
 
         # Simulate new day by changing the state date
@@ -214,8 +163,8 @@ class TestDrawdownGuardRecovery:
     @pytest.mark.asyncio
     async def test_halt_to_panic_escalation_still_works(self, tmp_path):
         """HALT should still escalate to PANIC when drawdown worsens past panic threshold."""
-        guard = self._make_guard(tmp_path, status="HALT", starting_equity=100000)
-        ib = self._mock_ib(95500)  # -4.5% drawdown, past panic_pct=4%
+        guard = make_drawdown_guard(tmp_path, status="HALT", starting_equity=100000)
+        ib = mock_ib(95500)  # -4.5% drawdown, past panic_pct=4%
 
         result = await guard.update_pnl(ib)
 
@@ -225,8 +174,8 @@ class TestDrawdownGuardRecovery:
     @pytest.mark.asyncio
     async def test_recovery_state_persisted(self, tmp_path):
         """Recovery timer should be persisted to disk."""
-        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
-        ib = self._mock_ib(98000)  # Triggers recovery timer start
+        guard = make_drawdown_guard(tmp_path, status="PANIC", starting_equity=100000)
+        ib = mock_ib(98000)  # Triggers recovery timer start
 
         with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
             await guard.update_pnl(ib)
@@ -241,62 +190,16 @@ class TestDrawdownGuardRecovery:
 
 
 # ---------------------------------------------------------------------------
-# PortfolioRiskGuard Tests
+# PortfolioRiskGuard Recovery Tests
 # ---------------------------------------------------------------------------
 
 class TestPortfolioRiskGuardRecovery:
     """Tests for recovery logic in PortfolioRiskGuard."""
 
-    def _make_guard(self, tmpdir, status="PANIC", starting_equity=100000, current_equity=95000):
-        """Create a PortfolioRiskGuard with pre-set state."""
-        from trading_bot.shared_context import PortfolioRiskGuard
-
-        data_dir = str(tmpdir)
-        config = {
-            'data_dir_root': data_dir,
-            'drawdown_circuit_breaker': {
-                'enabled': True,
-                'warning_pct': 1.5,
-                'halt_pct': 2.5,
-                'panic_pct': 4.0,
-                'recovery_pct': 3.0,
-                'recovery_hold_minutes': 30,
-            },
-            'notifications': {'enabled': False},
-        }
-
-        # Pre-write state
-        state_file = os.path.join(data_dir, 'portfolio_risk_state.json')
-        os.makedirs(data_dir, exist_ok=True)
-        state = {
-            "status": status,
-            "peak_equity": starting_equity,
-            "current_equity": current_equity,
-            "starting_equity": starting_equity,
-            "daily_pnl": current_equity - starting_equity,
-            "positions": {},
-            "margin": {},
-            "date": datetime.now(timezone.utc).date().isoformat(),
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-        }
-        with open(state_file, 'w') as f:
-            json.dump(state, f)
-
-        # Write daily_equity.csv in a subdirectory so _load_prev_close() finds it
-        # (starting_equity is reset to 0.0 on load, then re-derived from this file)
-        subdir = os.path.join(data_dir, 'KC')
-        os.makedirs(subdir, exist_ok=True)
-        equity_file = os.path.join(subdir, 'daily_equity.csv')
-        with open(equity_file, 'w') as f:
-            f.write(f"2026-01-01 17:00:00,{starting_equity}\n")
-
-        guard = PortfolioRiskGuard(config=config)
-        return guard
-
     @pytest.mark.asyncio
     async def test_sticks_during_active_drawdown(self, tmp_path):
         """PANIC should stick when drawdown is still severe."""
-        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        guard = make_portfolio_risk_guard(tmp_path, status="PANIC", starting_equity=100000)
         # equity=95000 → drawdown_pct=5.0%, above recovery_pct=3.0%
         await guard.update_equity(95000, -5000)
 
@@ -306,7 +209,7 @@ class TestPortfolioRiskGuardRecovery:
     @pytest.mark.asyncio
     async def test_recovery_timer_starts(self, tmp_path):
         """Recovery timer should start when drawdown improves below recovery_pct."""
-        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        guard = make_portfolio_risk_guard(tmp_path, status="PANIC", starting_equity=100000)
         # equity=98000 → drawdown_pct=2.0%, below recovery_pct=3.0%
         await guard.update_equity(98000, -2000)
 
@@ -316,7 +219,7 @@ class TestPortfolioRiskGuardRecovery:
     @pytest.mark.asyncio
     async def test_recovery_timer_resets_on_worsening(self, tmp_path):
         """Recovery timer should reset if drawdown worsens."""
-        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        guard = make_portfolio_risk_guard(tmp_path, status="PANIC", starting_equity=100000)
         guard._recovery_start = datetime.now(timezone.utc).isoformat()
 
         # equity=96000 → drawdown_pct=4.0%, above recovery_pct=3.0%
@@ -328,7 +231,7 @@ class TestPortfolioRiskGuardRecovery:
     @pytest.mark.asyncio
     async def test_recovery_completes_after_hold_period(self, tmp_path):
         """After sustained improvement, should de-escalate to WARNING."""
-        guard = self._make_guard(tmp_path, status="HALT", starting_equity=100000)
+        guard = make_portfolio_risk_guard(tmp_path, status="HALT", starting_equity=100000)
         guard._recovery_start = (
             datetime.now(timezone.utc) - timedelta(minutes=35)
         ).isoformat()
@@ -344,7 +247,7 @@ class TestPortfolioRiskGuardRecovery:
     @pytest.mark.asyncio
     async def test_halt_to_panic_escalation(self, tmp_path):
         """HALT should escalate to PANIC when drawdown exceeds panic threshold."""
-        guard = self._make_guard(tmp_path, status="HALT", starting_equity=100000)
+        guard = make_portfolio_risk_guard(tmp_path, status="HALT", starting_equity=100000)
         # equity=95500 → drawdown_pct=4.5%, above panic_pct=4.0%
         await guard.update_equity(95500, -4500)
 
@@ -385,7 +288,7 @@ class TestPortfolioRiskGuardRecovery:
     @pytest.mark.asyncio
     async def test_recovery_state_persisted(self, tmp_path):
         """Recovery start time should be saved to disk."""
-        guard = self._make_guard(tmp_path, status="PANIC", starting_equity=100000)
+        guard = make_portfolio_risk_guard(tmp_path, status="PANIC", starting_equity=100000)
         # equity=98000 → drawdown_pct=2.0%, triggers recovery timer
         await guard.update_equity(98000, -2000)
 
@@ -401,7 +304,7 @@ class TestPortfolioRiskGuardRecovery:
     @pytest.mark.asyncio
     async def test_recovery_in_progress_holds_status(self, tmp_path):
         """During recovery observation (timer running, not yet elapsed), status should hold."""
-        guard = self._make_guard(tmp_path, status="HALT", starting_equity=100000)
+        guard = make_portfolio_risk_guard(tmp_path, status="HALT", starting_equity=100000)
         guard._recovery_start = (
             datetime.now(timezone.utc) - timedelta(minutes=10)
         ).isoformat()
@@ -463,667 +366,27 @@ class TestPortfolioRiskGuardRecovery:
 
 
 # ---------------------------------------------------------------------------
-# Previous Close (daily_equity.csv) Tests
+# Recovery Timer Oscillation Tests
 # ---------------------------------------------------------------------------
-
-class TestDrawdownGuardPrevClose:
-    """Tests for starting_equity initialization from daily_equity.csv."""
-
-    def _mock_ib(self, net_liq):
-        ib = MagicMock()
-        summary_item = MagicMock()
-        summary_item.tag = 'NetLiquidation'
-        summary_item.currency = 'USD'
-        summary_item.value = str(net_liq)
-        ib.accountSummaryAsync = AsyncMock(return_value=[summary_item])
-        return ib
-
-    def _write_equity_csv(self, data_dir, rows):
-        """Write daily_equity.csv with given rows [(timestamp, value), ...]."""
-        equity_file = os.path.join(data_dir, 'daily_equity.csv')
-        with open(equity_file, 'w') as f:
-            for ts, val in rows:
-                f.write(f"{ts},{val}\n")
-
-    def _make_guard(self, data_dir):
-        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
-        config = {
-            'drawdown_circuit_breaker': {
-                'enabled': True,
-                'warning_pct': 1.5,
-                'halt_pct': 2.5,
-                'panic_pct': 4.0,
-            },
-            'notifications': {'enabled': False},
-            'data_dir': str(data_dir),
-        }
-        return DrawdownGuard(config)
-
-    @pytest.mark.asyncio
-    async def test_starting_equity_from_prev_close(self, tmp_path):
-        """starting_equity should come from daily_equity.csv, not live NLV."""
-        self._write_equity_csv(tmp_path, [
-            ("2026-03-02 17:00:00", "35000.00"),
-            ("2026-03-03 17:00:00", "35145.06"),
-        ])
-        guard = self._make_guard(tmp_path)
-        ib = self._mock_ib(34000)  # Live NLV is lower
-
-        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
-            await guard.update_pnl(ib)
-
-        assert guard.state['starting_equity'] == 35145.06
-        # Should detect drawdown: (34000-35145)/35145 = -3.26% → HALT
-        assert guard.state['status'] == "HALT"
-
-    @pytest.mark.asyncio
-    async def test_falls_back_to_live_nlv_when_csv_missing(self, tmp_path):
-        """If daily_equity.csv doesn't exist, fall back to live NLV."""
-        guard = self._make_guard(tmp_path)
-        ib = self._mock_ib(35000)
-
-        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
-            await guard.update_pnl(ib)
-
-        assert guard.state['starting_equity'] == 35000
-
-    @pytest.mark.asyncio
-    async def test_falls_back_to_live_nlv_when_csv_empty(self, tmp_path):
-        """If daily_equity.csv is empty, fall back to live NLV."""
-        equity_file = os.path.join(tmp_path, 'daily_equity.csv')
-        with open(equity_file, 'w') as f:
-            f.write("")
-        guard = self._make_guard(tmp_path)
-        ib = self._mock_ib(35000)
-
-        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
-            await guard.update_pnl(ib)
-
-        assert guard.state['starting_equity'] == 35000
-
-    @pytest.mark.asyncio
-    async def test_handles_corrupt_csv(self, tmp_path):
-        """Corrupt CSV should fall back to live NLV gracefully."""
-        equity_file = os.path.join(tmp_path, 'daily_equity.csv')
-        with open(equity_file, 'w') as f:
-            f.write("not,a,valid\ncsv,file,here\n")
-        guard = self._make_guard(tmp_path)
-        ib = self._mock_ib(35000)
-
-        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
-            await guard.update_pnl(ib)
-
-        # Should fall back gracefully (corrupt value raises ValueError)
-        assert guard.state['starting_equity'] == 35000
-
-    @pytest.mark.asyncio
-    async def test_all_engines_get_same_starting_equity(self, tmp_path):
-        """Multiple guards with same daily_equity.csv get identical starting_equity."""
-        self._write_equity_csv(tmp_path, [
-            ("2026-03-03 17:00:00", "35145.06"),
-        ])
-
-        guard1 = self._make_guard(tmp_path)
-        guard2 = self._make_guard(tmp_path)
-        guard3 = self._make_guard(tmp_path)
-
-        # Different live NLVs (simulating staggered startup)
-        ib1 = self._mock_ib(35100)
-        ib2 = self._mock_ib(34800)
-        ib3 = self._mock_ib(34500)
-
-        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
-            await guard1.update_pnl(ib1)
-            await guard2.update_pnl(ib2)
-            await guard3.update_pnl(ib3)
-
-        # All should use the same prev close, not their respective live NLVs
-        assert guard1.state['starting_equity'] == 35145.06
-        assert guard2.state['starting_equity'] == 35145.06
-        assert guard3.state['starting_equity'] == 35145.06
-
-    @pytest.mark.asyncio
-    async def test_first_call_evaluates_thresholds(self, tmp_path):
-        """First update_pnl should evaluate thresholds (not just return NORMAL)."""
-        self._write_equity_csv(tmp_path, [
-            ("2026-03-03 17:00:00", "35000.00"),
-        ])
-        guard = self._make_guard(tmp_path)
-        ib = self._mock_ib(33000)  # -5.7% drawdown
-
-        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
-            result = await guard.update_pnl(ib)
-
-        # Should detect PANIC immediately, not return NORMAL
-        assert result == "PANIC"
-
-
-class TestPortfolioRiskGuardPrevClose:
-    """Tests for PortfolioRiskGuard starting_equity from daily_equity.csv."""
-
-    def _make_guard(self, data_dir):
-        from trading_bot.shared_context import PortfolioRiskGuard
-        config = {
-            'data_dir_root': str(data_dir),
-            'drawdown_circuit_breaker': {
-                'enabled': True,
-                'warning_pct': 1.5,
-                'halt_pct': 2.5,
-                'panic_pct': 4.0,
-                'recovery_pct': 3.0,
-                'recovery_hold_minutes': 30,
-            },
-            'notifications': {'enabled': False},
-        }
-        return PortfolioRiskGuard(config=config)
-
-    @pytest.mark.asyncio
-    async def test_starting_equity_from_prev_close(self, tmp_path):
-        """PortfolioRiskGuard should use prev close from daily_equity.csv."""
-        # Create a commodity subdir with daily_equity.csv
-        kc_dir = tmp_path / "KC"
-        kc_dir.mkdir()
-        equity_file = kc_dir / "daily_equity.csv"
-        equity_file.write_text("2026-03-03 17:00:00,35145.06\n")
-
-        guard = self._make_guard(tmp_path)
-        await guard.update_equity(34000, -1145)
-
-        assert guard._starting_equity == 35145.06
-
-    @pytest.mark.asyncio
-    async def test_falls_back_to_live_equity(self, tmp_path):
-        """Without daily_equity.csv, should fall back to live equity."""
-        guard = self._make_guard(tmp_path)
-        await guard.update_equity(35000, 0)
-
-        assert guard._starting_equity == 35000
-
-    @pytest.mark.asyncio
-    async def test_daily_reset_uses_prev_close(self, tmp_path):
-        """On date rollover, _reset_daily should prefer prev close."""
-        kc_dir = tmp_path / "KC"
-        kc_dir.mkdir()
-        equity_file = kc_dir / "daily_equity.csv"
-        equity_file.write_text("2026-03-03 17:00:00,35145.06\n")
-
-        guard = self._make_guard(tmp_path)
-        guard._starting_equity = 34000
-        guard._current_equity = 34500
-        guard._peak_equity = 35000
-        guard._state_date = "2026-03-03"  # Yesterday
-        guard._status = "HALT"
-
-        await guard.update_equity(34200, -945)
-
-        # Should have reset and used prev close
-        assert guard._starting_equity == 35145.06
-
-
-# ---------------------------------------------------------------------------
-# Workstream A/C/E: Starting Equity Reset, Panic Gate, Recovery Oscillation
-# ---------------------------------------------------------------------------
-
-class TestDrawdownGuardStartingEquityReset:
-    """Tests for A2: starting_equity forced to 0.0 on load, re-derived from prev close."""
-
-    def _mock_ib(self, net_liq):
-        ib = MagicMock()
-        summary_item = MagicMock()
-        summary_item.tag = 'NetLiquidation'
-        summary_item.currency = 'USD'
-        summary_item.value = str(net_liq)
-        ib.accountSummaryAsync = AsyncMock(return_value=[summary_item])
-        return ib
-
-    def test_load_state_resets_starting_equity_to_zero(self, tmp_path):
-        """A2: _load_state must reset starting_equity to 0.0 regardless of persisted value."""
-        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
-
-        data_dir = str(tmp_path)
-        state_file = os.path.join(data_dir, 'drawdown_state.json')
-        os.makedirs(data_dir, exist_ok=True)
-        state = {
-            "status": "HALT",
-            "current_drawdown_pct": -3.0,
-            "starting_equity": 35182.91,  # Stale value from mid-day restart
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-            "date": datetime.now(timezone.utc).date().isoformat(),
-        }
-        with open(state_file, 'w') as f:
-            json.dump(state, f)
-
-        config = {
-            'drawdown_circuit_breaker': {'enabled': True},
-            'notifications': {},
-            'data_dir': data_dir,
-        }
-        guard = DrawdownGuard(config)
-
-        # starting_equity should be 0.0 after load, not the persisted value
-        assert guard.state['starting_equity'] == 0.0
-        # But status should still be loaded
-        assert guard.state['status'] == "HALT"
-
-    @pytest.mark.asyncio
-    async def test_starting_equity_rederived_from_prev_close_after_reset(self, tmp_path):
-        """A2 + a897d2d: load→reset to 0→update_pnl→re-derives from daily_equity.csv."""
-        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
-
-        data_dir = str(tmp_path)
-        os.makedirs(data_dir, exist_ok=True)
-
-        # Write stale state with wrong starting_equity (from mid-day NLV)
-        state_file = os.path.join(data_dir, 'drawdown_state.json')
-        state = {
-            "status": "HALT",
-            "current_drawdown_pct": -3.0,
-            "starting_equity": 35182.91,  # Wrong: was set from live NLV
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-            "date": datetime.now(timezone.utc).date().isoformat(),
-        }
-        with open(state_file, 'w') as f:
-            json.dump(state, f)
-
-        # Write daily_equity.csv with the correct prev close
-        equity_file = os.path.join(data_dir, 'daily_equity.csv')
-        with open(equity_file, 'w') as f:
-            f.write("2026-03-03 17:00:00,35145.06\n")
-
-        config = {
-            'drawdown_circuit_breaker': {
-                'enabled': True,
-                'warning_pct': 2.0,
-                'halt_pct': 4.0,
-                'panic_pct': 6.0,
-            },
-            'notifications': {'enabled': False},
-            'data_dir': data_dir,
-        }
-        guard = DrawdownGuard(config)
-
-        # Verify starting_equity was reset to 0 on load
-        assert guard.state['starting_equity'] == 0.0
-
-        # Now call update_pnl — should re-derive from daily_equity.csv
-        ib = self._mock_ib(33000)  # NLV = $33,000
-
-        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
-            await guard.update_pnl(ib)
-
-        # Should use prev close, NOT the stale persisted value
-        assert guard.state['starting_equity'] == 35145.06
-        # Drawdown: (33000 - 35145.06) / 35145.06 = -6.10% → PANIC
-        assert guard.state['status'] == "PANIC"
-
-    @pytest.mark.asyncio
-    async def test_zero_guard_prevents_division_by_zero(self, tmp_path):
-        """A3: update_pnl returns current status when starting_equity is 0."""
-        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
-
-        data_dir = str(tmp_path)
-        os.makedirs(data_dir, exist_ok=True)
-
-        config = {
-            'drawdown_circuit_breaker': {'enabled': True},
-            'notifications': {},
-            'data_dir': data_dir,
-        }
-        guard = DrawdownGuard(config)
-        guard.state['starting_equity'] = 0.0
-        guard.state['status'] = "HALT"
-
-        # Mock IB that returns 0 NLV (load_prev_close also returns None → stays 0)
-        ib = MagicMock()
-        summary_item = MagicMock()
-        summary_item.tag = 'NetLiquidation'
-        summary_item.currency = 'USD'
-        summary_item.value = '0'
-        ib.accountSummaryAsync = AsyncMock(return_value=[summary_item])
-
-        result = await guard.update_pnl(ib)
-        assert result == "HALT"  # Returns current status without crash
-
-
-class TestDrawdownGuardPanicGate:
-    """Tests for C2: _panic_is_live gating on should_panic_close."""
-
-    def _make_guard(self, tmpdir, status="PANIC", starting_equity=100000):
-        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
-
-        data_dir = str(tmpdir)
-        config = {
-            'drawdown_circuit_breaker': {
-                'enabled': True,
-                'warning_pct': 1.5,
-                'halt_pct': 2.5,
-                'panic_pct': 4.0,
-            },
-            'notifications': {'enabled': False},
-            'data_dir': data_dir,
-        }
-
-        state_file = os.path.join(data_dir, 'drawdown_state.json')
-        os.makedirs(data_dir, exist_ok=True)
-        state = {
-            "status": status,
-            "current_drawdown_pct": -5.0,
-            "starting_equity": starting_equity,
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-            "date": datetime.now(timezone.utc).date().isoformat(),
-        }
-        with open(state_file, 'w') as f:
-            json.dump(state, f)
-
-        equity_file = os.path.join(data_dir, 'daily_equity.csv')
-        with open(equity_file, 'w') as f:
-            f.write(f"2026-01-01 17:00:00,{starting_equity}\n")
-
-        return DrawdownGuard(config)
-
-    def _mock_ib(self, net_liq):
-        ib = MagicMock()
-        summary_item = MagicMock()
-        summary_item.tag = 'NetLiquidation'
-        summary_item.currency = 'USD'
-        summary_item.value = str(net_liq)
-        ib.accountSummaryAsync = AsyncMock(return_value=[summary_item])
-        return ib
-
-    def test_loaded_panic_does_not_trigger_close(self, tmp_path):
-        """C2: Loaded PANIC should NOT trigger emergency close (panic_is_live=False)."""
-        guard = self._make_guard(tmp_path, status="PANIC")
-
-        # panic_is_live should be False after loading from disk
-        assert guard._panic_is_live is False
-        assert guard.state['status'] == "PANIC"
-        assert guard.should_panic_close() is False
-
-    def test_loaded_panic_still_blocks_entries(self, tmp_path):
-        """C2: Loaded PANIC should still block new entries (conservative)."""
-        guard = self._make_guard(tmp_path, status="PANIC")
-
-        assert guard.is_entry_allowed() is False
-
-    @pytest.mark.asyncio
-    async def test_fresh_panic_triggers_close(self, tmp_path):
-        """C2: Fresh PANIC evaluation should trigger emergency close."""
-        guard = self._make_guard(tmp_path, status="NORMAL", starting_equity=100000)
-
-        # NLV = 95500 → drawdown = -4.5% → exceeds panic_pct=4.0%
-        ib = self._mock_ib(95500)
-
-        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
-            await guard.update_pnl(ib)
-
-        assert guard.state['status'] == "PANIC"
-        assert guard._panic_is_live is True
-        assert guard.should_panic_close() is True
-
-    @pytest.mark.asyncio
-    async def test_panic_is_live_false_when_not_panic(self, tmp_path):
-        """C2: _panic_is_live should be False when status is not PANIC."""
-        guard = self._make_guard(tmp_path, status="NORMAL", starting_equity=100000)
-
-        # NLV = 98000 → drawdown = -2.0% → WARNING
-        ib = self._mock_ib(98000)
-
-        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
-            await guard.update_pnl(ib)
-
-        assert guard.state['status'] == "WARNING"
-        assert guard._panic_is_live is False
-
-    def test_daily_reset_clears_panic_is_live(self, tmp_path):
-        """C2: _reset_daily should clear _panic_is_live."""
-        guard = self._make_guard(tmp_path, status="PANIC")
-        guard._panic_is_live = True
-
-        guard.state['date'] = '1999-01-01'
-        guard._reset_daily()
-
-        assert guard._panic_is_live is False
-
-
-class TestPortfolioRiskGuardStartingEquityReset:
-    """Tests for A1: PortfolioRiskGuard starting_equity reset on load."""
-
-    def test_load_state_resets_starting_equity(self, tmp_path):
-        """A1: _load_state must reset starting_equity to 0.0."""
-        from trading_bot.shared_context import PortfolioRiskGuard
-
-        data_dir = str(tmp_path)
-        state_file = os.path.join(data_dir, 'portfolio_risk_state.json')
-        os.makedirs(data_dir, exist_ok=True)
-        state = {
-            "status": "HALT",
-            "peak_equity": 35200,
-            "current_equity": 33500,
-            "starting_equity": 35182.91,  # Stale
-            "daily_pnl": -1682.91,
-            "positions": {},
-            "margin": {},
-            "date": datetime.now(timezone.utc).date().isoformat(),
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-        }
-        with open(state_file, 'w') as f:
-            json.dump(state, f)
-
-        config = {
-            'data_dir_root': data_dir,
-            'drawdown_circuit_breaker': {'enabled': True},
-            'notifications': {},
-        }
-        guard = PortfolioRiskGuard(config=config)
-
-        # starting_equity reset, but status and peak preserved
-        assert guard._starting_equity == 0.0
-        assert guard._status == "HALT"
-        assert guard._peak_equity == 35200
-
-    @pytest.mark.asyncio
-    async def test_starting_equity_rederived_from_prev_close(self, tmp_path):
-        """A1 + a897d2d: load→reset→update_equity→re-derives from daily_equity.csv."""
-        from trading_bot.shared_context import PortfolioRiskGuard
-
-        data_dir = str(tmp_path)
-        os.makedirs(data_dir, exist_ok=True)
-
-        # Write stale state
-        state_file = os.path.join(data_dir, 'portfolio_risk_state.json')
-        state = {
-            "status": "HALT",
-            "peak_equity": 35200,
-            "current_equity": 33500,
-            "starting_equity": 35182.91,
-            "daily_pnl": -1682.91,
-            "positions": {},
-            "margin": {},
-            "date": datetime.now(timezone.utc).date().isoformat(),
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-        }
-        with open(state_file, 'w') as f:
-            json.dump(state, f)
-
-        # Write daily_equity.csv with correct prev close
-        kc_dir = os.path.join(data_dir, 'KC')
-        os.makedirs(kc_dir, exist_ok=True)
-        with open(os.path.join(kc_dir, 'daily_equity.csv'), 'w') as f:
-            f.write("2026-03-03 17:00:00,35145.06\n")
-
-        config = {
-            'data_dir_root': data_dir,
-            'drawdown_circuit_breaker': {
-                'enabled': True,
-                'warning_pct': 2.0,
-                'halt_pct': 4.0,
-                'panic_pct': 6.0,
-            },
-            'notifications': {'enabled': False},
-        }
-        guard = PortfolioRiskGuard(config=config)
-        assert guard._starting_equity == 0.0
-
-        # update_equity should re-derive from prev close
-        await guard.update_equity(33000, -2145)
-
-        assert guard._starting_equity == 35145.06
-        # Drawdown: (35145 - 33000) / 35145 = 6.10% → PANIC
-        assert guard._status == "PANIC"
-
-
-class TestPortfolioRiskGuardPanicGate:
-    """Tests for C1: _panic_is_live flag in PortfolioRiskGuard."""
-
-    def _make_guard(self, tmpdir, status="PANIC", starting_equity=100000, current_equity=95000):
-        from trading_bot.shared_context import PortfolioRiskGuard
-
-        data_dir = str(tmpdir)
-        config = {
-            'data_dir_root': data_dir,
-            'drawdown_circuit_breaker': {
-                'enabled': True,
-                'warning_pct': 1.5,
-                'halt_pct': 2.5,
-                'panic_pct': 4.0,
-            },
-            'notifications': {'enabled': False},
-        }
-
-        state_file = os.path.join(data_dir, 'portfolio_risk_state.json')
-        os.makedirs(data_dir, exist_ok=True)
-        state = {
-            "status": status,
-            "peak_equity": starting_equity,
-            "current_equity": current_equity,
-            "starting_equity": starting_equity,
-            "daily_pnl": current_equity - starting_equity,
-            "positions": {},
-            "margin": {},
-            "date": datetime.now(timezone.utc).date().isoformat(),
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-        }
-        with open(state_file, 'w') as f:
-            json.dump(state, f)
-
-        kc_dir = os.path.join(data_dir, 'KC')
-        os.makedirs(kc_dir, exist_ok=True)
-        with open(os.path.join(kc_dir, 'daily_equity.csv'), 'w') as f:
-            f.write(f"2026-01-01 17:00:00,{starting_equity}\n")
-
-        return PortfolioRiskGuard(config=config)
-
-    def test_loaded_panic_does_not_trigger_close(self, tmp_path):
-        """C1: Loaded PANIC from disk should NOT trigger emergency close."""
-        guard = self._make_guard(tmp_path, status="PANIC")
-
-        assert guard._panic_is_live is False
-        assert guard._status == "PANIC"
-        assert guard.should_panic_close() is False
-
-    def test_loaded_panic_blocks_entries(self, tmp_path):
-        """C1: Loaded PANIC should block entries (conservative)."""
-        guard = self._make_guard(tmp_path, status="PANIC")
-
-        assert guard.is_entry_allowed() is False
-
-    @pytest.mark.asyncio
-    async def test_fresh_panic_triggers_close(self, tmp_path):
-        """C1: After update_equity freshly evaluates PANIC, should_panic_close is True."""
-        guard = self._make_guard(tmp_path, status="NORMAL", starting_equity=100000, current_equity=100000)
-
-        # equity=95500 → drawdown=4.5% → exceeds panic_pct=4.0%
-        await guard.update_equity(95500, -4500)
-
-        assert guard._status == "PANIC"
-        assert guard._panic_is_live is True
-        assert guard.should_panic_close() is True
-
-    @pytest.mark.asyncio
-    async def test_panic_is_live_false_for_non_panic(self, tmp_path):
-        """C1: _panic_is_live should be False when status is not PANIC."""
-        guard = self._make_guard(tmp_path, status="NORMAL", starting_equity=100000, current_equity=100000)
-
-        # equity=98500 → drawdown=1.5% → WARNING
-        await guard.update_equity(98500, -1500)
-
-        assert guard._status == "WARNING"
-        assert guard._panic_is_live is False
-
-    def test_daily_reset_clears_panic_is_live(self, tmp_path):
-        """C1: _reset_daily should clear _panic_is_live."""
-        guard = self._make_guard(tmp_path, status="PANIC")
-        guard._panic_is_live = True
-
-        guard._state_date = "1999-01-01"
-        guard._reset_daily()
-
-        assert guard._panic_is_live is False
-
 
 class TestRecoveryTimerOscillation:
     """Tests for Workstream E: Recovery timer not reset on noise between recovery_pct and halt_pct."""
 
-    def _make_dg(self, tmpdir, status="HALT", starting_equity=100000):
-        """Create a DrawdownGuard for oscillation testing."""
-        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
-
-        data_dir = str(tmpdir)
-        config = {
-            'drawdown_circuit_breaker': {
-                'enabled': True,
-                'warning_pct': 1.5,
-                'halt_pct': 2.5,
-                'panic_pct': 4.0,
-                'recovery_pct': 2.0,
-                'recovery_hold_minutes': 30,
-            },
-            'notifications': {'enabled': False},
-            'data_dir': data_dir,
-        }
-
-        state_file = os.path.join(data_dir, 'drawdown_state.json')
-        os.makedirs(data_dir, exist_ok=True)
-        state = {
-            "status": status,
-            "current_drawdown_pct": -3.0,
-            "starting_equity": starting_equity,
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-            "date": datetime.now(timezone.utc).date().isoformat(),
-        }
-        with open(state_file, 'w') as f:
-            json.dump(state, f)
-
-        equity_file = os.path.join(data_dir, 'daily_equity.csv')
-        with open(equity_file, 'w') as f:
-            f.write(f"2026-01-01 17:00:00,{starting_equity}\n")
-
-        return DrawdownGuard(config)
-
-    def _mock_ib(self, net_liq):
-        ib = MagicMock()
-        summary_item = MagicMock()
-        summary_item.tag = 'NetLiquidation'
-        summary_item.currency = 'USD'
-        summary_item.value = str(net_liq)
-        ib.accountSummaryAsync = AsyncMock(return_value=[summary_item])
-        return ib
-
     @pytest.mark.asyncio
     async def test_timer_not_reset_between_recovery_and_halt(self, tmp_path):
         """E: Timer should NOT reset when drawdown bounces between recovery_pct and halt_pct."""
-        guard = self._make_dg(tmp_path, status="HALT", starting_equity=100000)
+        guard = make_drawdown_guard(tmp_path, status="HALT", starting_equity=100000, recovery_pct=2.0)
         # recovery_pct=2.0, halt_pct=2.5
 
         # Step 1: drawdown -1.5% → below recovery_pct → timer starts
-        ib = self._mock_ib(98500)
+        ib = mock_ib(98500)
         with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
             await guard.update_pnl(ib)
         assert guard._recovery_start is not None
         saved_timer = guard._recovery_start
 
         # Step 2: drawdown -2.3% → between recovery_pct and halt_pct → timer should be preserved
-        ib = self._mock_ib(97700)
+        ib = mock_ib(97700)
         with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
             await guard.update_pnl(ib)
         assert guard._recovery_start == saved_timer  # Timer NOT reset
@@ -1132,14 +395,14 @@ class TestRecoveryTimerOscillation:
     @pytest.mark.asyncio
     async def test_timer_reset_above_halt_pct(self, tmp_path):
         """E: Timer SHOULD reset when drawdown crosses back above halt_pct."""
-        guard = self._make_dg(tmp_path, status="HALT", starting_equity=100000)
+        guard = make_drawdown_guard(tmp_path, status="HALT", starting_equity=100000, recovery_pct=2.0)
         # recovery_pct=2.0, halt_pct=2.5
 
         # Step 1: Start recovery timer
         guard._recovery_start = datetime.now(timezone.utc).isoformat()
 
         # Step 2: drawdown worsens to -3.0% → above halt_pct=2.5% → reset timer
-        ib = self._mock_ib(97000)
+        ib = mock_ib(97000)
         with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
             await guard.update_pnl(ib)
 
@@ -1149,16 +412,16 @@ class TestRecoveryTimerOscillation:
     @pytest.mark.asyncio
     async def test_oscillation_scenario_timer_survives(self, tmp_path):
         """E: Full oscillation scenario: start→bounce→return→complete."""
-        guard = self._make_dg(tmp_path, status="HALT", starting_equity=100000)
+        guard = make_drawdown_guard(tmp_path, status="HALT", starting_equity=100000, recovery_pct=2.0)
 
         # Step 1: Drawdown improves to -1.8% (below recovery_pct=2.0%) → timer starts
-        ib = self._mock_ib(98200)
+        ib = mock_ib(98200)
         with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
             await guard.update_pnl(ib)
         assert guard._recovery_start is not None
 
         # Step 2: Bounces to -2.2% (between recovery=2.0% and halt=2.5%) → timer preserved
-        ib = self._mock_ib(97800)
+        ib = mock_ib(97800)
         with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
             await guard.update_pnl(ib)
         assert guard._recovery_start is not None
@@ -1167,104 +430,9 @@ class TestRecoveryTimerOscillation:
         guard._recovery_start = (
             datetime.now(timezone.utc) - timedelta(minutes=31)
         ).isoformat()
-        ib = self._mock_ib(98500)
+        ib = mock_ib(98500)
         with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
             result = await guard.update_pnl(ib)
 
         assert result == "WARNING"
-        assert guard._recovery_start is None
-
-
-class TestStaleRecoveryStartValidation:
-    """Tests for A4: Stale recovery_start discarded on load."""
-
-    def test_drawdown_guard_discards_stale_recovery_start(self, tmp_path):
-        """A4: DrawdownGuard discards recovery_start from a previous day."""
-        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
-
-        data_dir = str(tmp_path)
-        os.makedirs(data_dir, exist_ok=True)
-
-        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
-        state_file = os.path.join(data_dir, 'drawdown_state.json')
-        state = {
-            "status": "HALT",
-            "current_drawdown_pct": -3.0,
-            "starting_equity": 100000,
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-            "date": datetime.now(timezone.utc).date().isoformat(),
-            "recovery_start": yesterday,  # From previous day
-        }
-        with open(state_file, 'w') as f:
-            json.dump(state, f)
-
-        config = {
-            'drawdown_circuit_breaker': {'enabled': True},
-            'notifications': {},
-            'data_dir': data_dir,
-        }
-        guard = DrawdownGuard(config)
-
-        assert guard._recovery_start is None
-
-    def test_drawdown_guard_keeps_today_recovery_start(self, tmp_path):
-        """A4: DrawdownGuard preserves recovery_start from today."""
-        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
-
-        data_dir = str(tmp_path)
-        os.makedirs(data_dir, exist_ok=True)
-
-        today_ts = datetime.now(timezone.utc).isoformat()
-        state_file = os.path.join(data_dir, 'drawdown_state.json')
-        state = {
-            "status": "HALT",
-            "current_drawdown_pct": -2.0,
-            "starting_equity": 100000,
-            "last_updated": today_ts,
-            "date": datetime.now(timezone.utc).date().isoformat(),
-            "recovery_start": today_ts,
-        }
-        with open(state_file, 'w') as f:
-            json.dump(state, f)
-
-        config = {
-            'drawdown_circuit_breaker': {'enabled': True},
-            'notifications': {},
-            'data_dir': data_dir,
-        }
-        guard = DrawdownGuard(config)
-
-        assert guard._recovery_start == today_ts
-
-    def test_portfolio_guard_discards_stale_recovery_start(self, tmp_path):
-        """A4: PortfolioRiskGuard discards recovery_start from a previous day."""
-        from trading_bot.shared_context import PortfolioRiskGuard
-
-        data_dir = str(tmp_path)
-        os.makedirs(data_dir, exist_ok=True)
-
-        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
-        state_file = os.path.join(data_dir, 'portfolio_risk_state.json')
-        state = {
-            "status": "HALT",
-            "peak_equity": 100000,
-            "current_equity": 97000,
-            "starting_equity": 100000,
-            "daily_pnl": -3000,
-            "positions": {},
-            "margin": {},
-            "date": datetime.now(timezone.utc).date().isoformat(),
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-            "recovery_start": yesterday,
-        }
-        with open(state_file, 'w') as f:
-            json.dump(state, f)
-
-        config = {
-            'data_dir_root': data_dir,
-            'drawdown_circuit_breaker': {'enabled': True},
-            'notifications': {},
-        }
-        guard = PortfolioRiskGuard(config=config)
-
         assert guard._recovery_start is None

--- a/tests/test_drawdown_starting_equity.py
+++ b/tests/test_drawdown_starting_equity.py
@@ -1,0 +1,524 @@
+"""Tests for starting equity initialization, previous close, and stale state handling.
+
+Covers:
+- DrawdownGuard starting_equity from daily_equity.csv (previous close)
+- PortfolioRiskGuard starting_equity from daily_equity.csv
+- Starting equity forced to 0.0 on load, re-derived from prev close
+- Stale recovery_start discarded on load
+"""
+
+import json
+import os
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from conftest import mock_ib
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers for tests that need fresh guards (no pre-set state)
+# ---------------------------------------------------------------------------
+
+def _make_fresh_drawdown_guard(data_dir):
+    """Create a DrawdownGuard without pre-written state."""
+    from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+    config = {
+        'drawdown_circuit_breaker': {
+            'enabled': True,
+            'warning_pct': 1.5,
+            'halt_pct': 2.5,
+            'panic_pct': 4.0,
+        },
+        'notifications': {'enabled': False},
+        'data_dir': str(data_dir),
+    }
+    return DrawdownGuard(config)
+
+
+def _make_fresh_portfolio_guard(data_dir):
+    """Create a PortfolioRiskGuard without pre-written state."""
+    from trading_bot.shared_context import PortfolioRiskGuard
+    config = {
+        'data_dir_root': str(data_dir),
+        'drawdown_circuit_breaker': {
+            'enabled': True,
+            'warning_pct': 1.5,
+            'halt_pct': 2.5,
+            'panic_pct': 4.0,
+            'recovery_pct': 3.0,
+            'recovery_hold_minutes': 30,
+        },
+        'notifications': {'enabled': False},
+    }
+    return PortfolioRiskGuard(config=config)
+
+
+def _write_equity_csv_rows(data_dir, rows):
+    """Write daily_equity.csv with given rows [(timestamp, value), ...]."""
+    equity_file = os.path.join(str(data_dir), 'daily_equity.csv')
+    with open(equity_file, 'w') as f:
+        for ts, val in rows:
+            f.write(f"{ts},{val}\n")
+
+
+# ---------------------------------------------------------------------------
+# DrawdownGuard Previous Close Tests
+# ---------------------------------------------------------------------------
+
+class TestDrawdownGuardPrevClose:
+    """Tests for starting_equity initialization from daily_equity.csv."""
+
+    @pytest.mark.asyncio
+    async def test_starting_equity_from_prev_close(self, tmp_path):
+        """starting_equity should come from daily_equity.csv, not live NLV."""
+        _write_equity_csv_rows(tmp_path, [
+            ("2026-03-02 17:00:00", "35000.00"),
+            ("2026-03-03 17:00:00", "35145.06"),
+        ])
+        guard = _make_fresh_drawdown_guard(tmp_path)
+        ib = mock_ib(34000)
+
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+
+        assert guard.state['starting_equity'] == 35145.06
+        # Should detect drawdown: (34000-35145)/35145 = -3.26% → HALT
+        assert guard.state['status'] == "HALT"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_live_nlv_when_csv_missing(self, tmp_path):
+        """If daily_equity.csv doesn't exist, fall back to live NLV."""
+        guard = _make_fresh_drawdown_guard(tmp_path)
+        ib = mock_ib(35000)
+
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+
+        assert guard.state['starting_equity'] == 35000
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_live_nlv_when_csv_empty(self, tmp_path):
+        """If daily_equity.csv is empty, fall back to live NLV."""
+        equity_file = os.path.join(tmp_path, 'daily_equity.csv')
+        with open(equity_file, 'w') as f:
+            f.write("")
+        guard = _make_fresh_drawdown_guard(tmp_path)
+        ib = mock_ib(35000)
+
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+
+        assert guard.state['starting_equity'] == 35000
+
+    @pytest.mark.asyncio
+    async def test_handles_corrupt_csv(self, tmp_path):
+        """Corrupt CSV should fall back to live NLV gracefully."""
+        equity_file = os.path.join(tmp_path, 'daily_equity.csv')
+        with open(equity_file, 'w') as f:
+            f.write("not,a,valid\ncsv,file,here\n")
+        guard = _make_fresh_drawdown_guard(tmp_path)
+        ib = mock_ib(35000)
+
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+
+        # Should fall back gracefully (corrupt value raises ValueError)
+        assert guard.state['starting_equity'] == 35000
+
+    @pytest.mark.asyncio
+    async def test_all_engines_get_same_starting_equity(self, tmp_path):
+        """Multiple guards with same daily_equity.csv get identical starting_equity."""
+        _write_equity_csv_rows(tmp_path, [
+            ("2026-03-03 17:00:00", "35145.06"),
+        ])
+
+        guard1 = _make_fresh_drawdown_guard(tmp_path)
+        guard2 = _make_fresh_drawdown_guard(tmp_path)
+        guard3 = _make_fresh_drawdown_guard(tmp_path)
+
+        # Different live NLVs (simulating staggered startup)
+        ib1 = mock_ib(35100)
+        ib2 = mock_ib(34800)
+        ib3 = mock_ib(34500)
+
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard1.update_pnl(ib1)
+            await guard2.update_pnl(ib2)
+            await guard3.update_pnl(ib3)
+
+        # All should use the same prev close, not their respective live NLVs
+        assert guard1.state['starting_equity'] == 35145.06
+        assert guard2.state['starting_equity'] == 35145.06
+        assert guard3.state['starting_equity'] == 35145.06
+
+    @pytest.mark.asyncio
+    async def test_first_call_evaluates_thresholds(self, tmp_path):
+        """First update_pnl should evaluate thresholds (not just return NORMAL)."""
+        _write_equity_csv_rows(tmp_path, [
+            ("2026-03-03 17:00:00", "35000.00"),
+        ])
+        guard = _make_fresh_drawdown_guard(tmp_path)
+        ib = mock_ib(33000)  # -5.7% drawdown
+
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            result = await guard.update_pnl(ib)
+
+        # Should detect PANIC immediately, not return NORMAL
+        assert result == "PANIC"
+
+
+# ---------------------------------------------------------------------------
+# PortfolioRiskGuard Previous Close Tests
+# ---------------------------------------------------------------------------
+
+class TestPortfolioRiskGuardPrevClose:
+    """Tests for PortfolioRiskGuard starting_equity from daily_equity.csv."""
+
+    @pytest.mark.asyncio
+    async def test_starting_equity_from_prev_close(self, tmp_path):
+        """PortfolioRiskGuard should use prev close from daily_equity.csv."""
+        kc_dir = tmp_path / "KC"
+        kc_dir.mkdir()
+        equity_file = kc_dir / "daily_equity.csv"
+        equity_file.write_text("2026-03-03 17:00:00,35145.06\n")
+
+        guard = _make_fresh_portfolio_guard(tmp_path)
+        await guard.update_equity(34000, -1145)
+
+        assert guard._starting_equity == 35145.06
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_live_equity(self, tmp_path):
+        """Without daily_equity.csv, should fall back to live equity."""
+        guard = _make_fresh_portfolio_guard(tmp_path)
+        await guard.update_equity(35000, 0)
+
+        assert guard._starting_equity == 35000
+
+    @pytest.mark.asyncio
+    async def test_daily_reset_uses_prev_close(self, tmp_path):
+        """On date rollover, _reset_daily should prefer prev close."""
+        kc_dir = tmp_path / "KC"
+        kc_dir.mkdir()
+        equity_file = kc_dir / "daily_equity.csv"
+        equity_file.write_text("2026-03-03 17:00:00,35145.06\n")
+
+        guard = _make_fresh_portfolio_guard(tmp_path)
+        guard._starting_equity = 34000
+        guard._current_equity = 34500
+        guard._peak_equity = 35000
+        guard._state_date = "2026-03-03"  # Yesterday
+        guard._status = "HALT"
+
+        await guard.update_equity(34200, -945)
+
+        # Should have reset and used prev close
+        assert guard._starting_equity == 35145.06
+
+
+# ---------------------------------------------------------------------------
+# DrawdownGuard Starting Equity Reset Tests
+# ---------------------------------------------------------------------------
+
+class TestDrawdownGuardStartingEquityReset:
+    """Tests for A2: starting_equity forced to 0.0 on load, re-derived from prev close."""
+
+    def test_load_state_resets_starting_equity_to_zero(self, tmp_path):
+        """A2: _load_state must reset starting_equity to 0.0 regardless of persisted value."""
+        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+
+        data_dir = str(tmp_path)
+        state_file = os.path.join(data_dir, 'drawdown_state.json')
+        os.makedirs(data_dir, exist_ok=True)
+        state = {
+            "status": "HALT",
+            "current_drawdown_pct": -3.0,
+            "starting_equity": 35182.91,  # Stale value from mid-day restart
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "date": datetime.now(timezone.utc).date().isoformat(),
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        config = {
+            'drawdown_circuit_breaker': {'enabled': True},
+            'notifications': {},
+            'data_dir': data_dir,
+        }
+        guard = DrawdownGuard(config)
+
+        # starting_equity should be 0.0 after load, not the persisted value
+        assert guard.state['starting_equity'] == 0.0
+        # But status should still be loaded
+        assert guard.state['status'] == "HALT"
+
+    @pytest.mark.asyncio
+    async def test_starting_equity_rederived_from_prev_close_after_reset(self, tmp_path):
+        """A2 + a897d2d: load→reset to 0→update_pnl→re-derives from daily_equity.csv."""
+        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+
+        data_dir = str(tmp_path)
+        os.makedirs(data_dir, exist_ok=True)
+
+        # Write stale state with wrong starting_equity (from mid-day NLV)
+        state_file = os.path.join(data_dir, 'drawdown_state.json')
+        state = {
+            "status": "HALT",
+            "current_drawdown_pct": -3.0,
+            "starting_equity": 35182.91,  # Wrong: was set from live NLV
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "date": datetime.now(timezone.utc).date().isoformat(),
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        # Write daily_equity.csv with the correct prev close
+        equity_file = os.path.join(data_dir, 'daily_equity.csv')
+        with open(equity_file, 'w') as f:
+            f.write("2026-03-03 17:00:00,35145.06\n")
+
+        config = {
+            'drawdown_circuit_breaker': {
+                'enabled': True,
+                'warning_pct': 2.0,
+                'halt_pct': 4.0,
+                'panic_pct': 6.0,
+            },
+            'notifications': {'enabled': False},
+            'data_dir': data_dir,
+        }
+        guard = DrawdownGuard(config)
+
+        # Verify starting_equity was reset to 0 on load
+        assert guard.state['starting_equity'] == 0.0
+
+        # Now call update_pnl — should re-derive from daily_equity.csv
+        ib = mock_ib(33000)  # NLV = $33,000
+
+        with patch('trading_bot.drawdown_circuit_breaker.send_pushover_notification'):
+            await guard.update_pnl(ib)
+
+        # Should use prev close, NOT the stale persisted value
+        assert guard.state['starting_equity'] == 35145.06
+        # Drawdown: (33000 - 35145.06) / 35145.06 = -6.10% → PANIC
+        assert guard.state['status'] == "PANIC"
+
+    @pytest.mark.asyncio
+    async def test_zero_guard_prevents_division_by_zero(self, tmp_path):
+        """A3: update_pnl returns current status when starting_equity is 0."""
+        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+
+        data_dir = str(tmp_path)
+        os.makedirs(data_dir, exist_ok=True)
+
+        config = {
+            'drawdown_circuit_breaker': {'enabled': True},
+            'notifications': {},
+            'data_dir': data_dir,
+        }
+        guard = DrawdownGuard(config)
+        guard.state['starting_equity'] = 0.0
+        guard.state['status'] = "HALT"
+
+        # Mock IB that returns 0 NLV (load_prev_close also returns None → stays 0)
+        ib = MagicMock()
+        summary_item = MagicMock()
+        summary_item.tag = 'NetLiquidation'
+        summary_item.currency = 'USD'
+        summary_item.value = '0'
+        ib.accountSummaryAsync = AsyncMock(return_value=[summary_item])
+
+        result = await guard.update_pnl(ib)
+        assert result == "HALT"  # Returns current status without crash
+
+
+# ---------------------------------------------------------------------------
+# PortfolioRiskGuard Starting Equity Reset Tests
+# ---------------------------------------------------------------------------
+
+class TestPortfolioRiskGuardStartingEquityReset:
+    """Tests for A1: PortfolioRiskGuard starting_equity reset on load."""
+
+    def test_load_state_resets_starting_equity(self, tmp_path):
+        """A1: _load_state must reset starting_equity to 0.0."""
+        from trading_bot.shared_context import PortfolioRiskGuard
+
+        data_dir = str(tmp_path)
+        state_file = os.path.join(data_dir, 'portfolio_risk_state.json')
+        os.makedirs(data_dir, exist_ok=True)
+        state = {
+            "status": "HALT",
+            "peak_equity": 35200,
+            "current_equity": 33500,
+            "starting_equity": 35182.91,  # Stale
+            "daily_pnl": -1682.91,
+            "positions": {},
+            "margin": {},
+            "date": datetime.now(timezone.utc).date().isoformat(),
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        config = {
+            'data_dir_root': data_dir,
+            'drawdown_circuit_breaker': {'enabled': True},
+            'notifications': {},
+        }
+        guard = PortfolioRiskGuard(config=config)
+
+        # starting_equity reset, but status and peak preserved
+        assert guard._starting_equity == 0.0
+        assert guard._status == "HALT"
+        assert guard._peak_equity == 35200
+
+    @pytest.mark.asyncio
+    async def test_starting_equity_rederived_from_prev_close(self, tmp_path):
+        """A1 + a897d2d: load→reset→update_equity→re-derives from daily_equity.csv."""
+        from trading_bot.shared_context import PortfolioRiskGuard
+
+        data_dir = str(tmp_path)
+        os.makedirs(data_dir, exist_ok=True)
+
+        # Write stale state
+        state_file = os.path.join(data_dir, 'portfolio_risk_state.json')
+        state = {
+            "status": "HALT",
+            "peak_equity": 35200,
+            "current_equity": 33500,
+            "starting_equity": 35182.91,
+            "daily_pnl": -1682.91,
+            "positions": {},
+            "margin": {},
+            "date": datetime.now(timezone.utc).date().isoformat(),
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        # Write daily_equity.csv with correct prev close
+        kc_dir = os.path.join(data_dir, 'KC')
+        os.makedirs(kc_dir, exist_ok=True)
+        with open(os.path.join(kc_dir, 'daily_equity.csv'), 'w') as f:
+            f.write("2026-03-03 17:00:00,35145.06\n")
+
+        config = {
+            'data_dir_root': data_dir,
+            'drawdown_circuit_breaker': {
+                'enabled': True,
+                'warning_pct': 2.0,
+                'halt_pct': 4.0,
+                'panic_pct': 6.0,
+            },
+            'notifications': {'enabled': False},
+        }
+        guard = PortfolioRiskGuard(config=config)
+        assert guard._starting_equity == 0.0
+
+        # update_equity should re-derive from prev close
+        await guard.update_equity(33000, -2145)
+
+        assert guard._starting_equity == 35145.06
+        # Drawdown: (35145 - 33000) / 35145 = 6.10% → PANIC
+        assert guard._status == "PANIC"
+
+
+# ---------------------------------------------------------------------------
+# Stale Recovery Start Validation Tests
+# ---------------------------------------------------------------------------
+
+class TestStaleRecoveryStartValidation:
+    """Tests for A4: Stale recovery_start discarded on load."""
+
+    def test_drawdown_guard_discards_stale_recovery_start(self, tmp_path):
+        """A4: DrawdownGuard discards recovery_start from a previous day."""
+        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+
+        data_dir = str(tmp_path)
+        os.makedirs(data_dir, exist_ok=True)
+
+        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        state_file = os.path.join(data_dir, 'drawdown_state.json')
+        state = {
+            "status": "HALT",
+            "current_drawdown_pct": -3.0,
+            "starting_equity": 100000,
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "date": datetime.now(timezone.utc).date().isoformat(),
+            "recovery_start": yesterday,  # From previous day
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        config = {
+            'drawdown_circuit_breaker': {'enabled': True},
+            'notifications': {},
+            'data_dir': data_dir,
+        }
+        guard = DrawdownGuard(config)
+
+        assert guard._recovery_start is None
+
+    def test_drawdown_guard_keeps_today_recovery_start(self, tmp_path):
+        """A4: DrawdownGuard preserves recovery_start from today."""
+        from trading_bot.drawdown_circuit_breaker import DrawdownGuard
+
+        data_dir = str(tmp_path)
+        os.makedirs(data_dir, exist_ok=True)
+
+        today_ts = datetime.now(timezone.utc).isoformat()
+        state_file = os.path.join(data_dir, 'drawdown_state.json')
+        state = {
+            "status": "HALT",
+            "current_drawdown_pct": -2.0,
+            "starting_equity": 100000,
+            "last_updated": today_ts,
+            "date": datetime.now(timezone.utc).date().isoformat(),
+            "recovery_start": today_ts,
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        config = {
+            'drawdown_circuit_breaker': {'enabled': True},
+            'notifications': {},
+            'data_dir': data_dir,
+        }
+        guard = DrawdownGuard(config)
+
+        assert guard._recovery_start == today_ts
+
+    def test_portfolio_guard_discards_stale_recovery_start(self, tmp_path):
+        """A4: PortfolioRiskGuard discards recovery_start from a previous day."""
+        from trading_bot.shared_context import PortfolioRiskGuard
+
+        data_dir = str(tmp_path)
+        os.makedirs(data_dir, exist_ok=True)
+
+        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        state_file = os.path.join(data_dir, 'portfolio_risk_state.json')
+        state = {
+            "status": "HALT",
+            "peak_equity": 100000,
+            "current_equity": 97000,
+            "starting_equity": 100000,
+            "daily_pnl": -3000,
+            "positions": {},
+            "margin": {},
+            "date": datetime.now(timezone.utc).date().isoformat(),
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "recovery_start": yesterday,
+        }
+        with open(state_file, 'w') as f:
+            json.dump(state, f)
+
+        config = {
+            'data_dir_root': data_dir,
+            'drawdown_circuit_breaker': {'enabled': True},
+            'notifications': {},
+        }
+        guard = PortfolioRiskGuard(config=config)
+
+        assert guard._recovery_start is None

--- a/tests/test_order_manager.py
+++ b/tests/test_order_manager.py
@@ -1,4 +1,3 @@
-import asyncio
 import unittest
 from unittest.mock import patch, MagicMock, AsyncMock
 from ib_insync import Bag, ComboLeg, Contract, Order, Trade, Position
@@ -9,25 +8,22 @@ import os
 from trading_bot.order_manager import generate_and_queue_orders, place_queued_orders, close_stale_positions, ORDER_QUEUE
 from ib_insync import util
 
-class TestOrderManager(unittest.TestCase):
+class TestOrderManager(unittest.IsolatedAsyncioTestCase):
 
     @patch('trading_bot.order_manager.generate_signals')
     @patch('trading_bot.order_manager.IBConnectionPool')
-    def test_generate_and_queue_orders_calls_signal_generator(self, mock_pool, mock_generate_signals):
-        async def run_test():
-            mock_ib_instance = AsyncMock()
-            mock_pool.get_connection = AsyncMock(return_value=mock_ib_instance)
-            mock_generate_signals.return_value = [] # Return empty list to stop early
+    async def test_generate_and_queue_orders_calls_signal_generator(self, mock_pool, mock_generate_signals):
+        mock_ib_instance = AsyncMock()
+        mock_pool.get_connection = AsyncMock(return_value=mock_ib_instance)
+        mock_generate_signals.return_value = [] # Return empty list to stop early
 
-            config = {'strategy': {'signal_threshold': 0.5}}
-            await generate_and_queue_orders(config)
+        config = {'strategy': {'signal_threshold': 0.5}}
+        await generate_and_queue_orders(config)
 
-            mock_generate_signals.assert_called_once()
-            mock_pool.get_connection.assert_called_once()
+        mock_generate_signals.assert_called_once()
+        mock_pool.get_connection.assert_called_once()
 
-        asyncio.run(run_test())
-
-class TestPositionClosing(unittest.TestCase):
+class TestPositionClosing(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):
         # Use a temporary ledger path for tests to avoid messing with real data
@@ -93,146 +89,143 @@ class TestPositionClosing(unittest.TestCase):
     @patch('trading_bot.order_manager.place_order', new_callable=MagicMock)
     @patch('trading_bot.order_manager.log_trade_to_ledger', new_callable=AsyncMock)
     @patch('trading_bot.order_manager.IBConnectionPool')
-    def test_closes_only_old_positions_and_correct_symbols(self, mock_pool, mock_log_trade, mock_place_order):
-        async def run_test():
-            mock_ib_instance = AsyncMock()
-            mock_pool.get_connection = AsyncMock(return_value=mock_ib_instance)
-            mock_ib_instance.connectAsync = AsyncMock()
-            mock_ib_instance.reqPositionsAsync = AsyncMock()
-            mock_ib_instance.isConnected = MagicMock(return_value=True)
+    async def test_closes_only_old_positions_and_correct_symbols(self, mock_pool, mock_log_trade, mock_place_order):
+        mock_ib_instance = AsyncMock()
+        mock_pool.get_connection = AsyncMock(return_value=mock_ib_instance)
+        mock_ib_instance.connectAsync = AsyncMock()
+        mock_ib_instance.reqPositionsAsync = AsyncMock()
+        mock_ib_instance.isConnected = MagicMock(return_value=True)
 
-            # Mock Market Data for Limit Order logic
-            # reqMktData returns a Ticker
-            mock_ticker = MagicMock()
-            mock_ticker.bid = 5.0
-            mock_ticker.ask = 5.5
-            mock_ticker.last = 5.25
-            mock_ticker.close = 5.25
+        # Mock Market Data for Limit Order logic
+        # reqMktData returns a Ticker
+        mock_ticker = MagicMock()
+        mock_ticker.bid = 5.0
+        mock_ticker.ask = 5.5
+        mock_ticker.last = 5.25
+        mock_ticker.close = 5.25
 
-            # Since reqMktData is synchronous in ib_insync (it returns the ticker object immediately, which updates later),
-            # we just return the mock ticker.
-            # We must explicitly set it as a MagicMock to avoid AsyncMock treating it as a coroutine
-            mock_ib_instance.reqMktData = MagicMock(return_value=mock_ticker)
-            mock_ib_instance.cancelMktData = MagicMock()
+        # Since reqMktData is synchronous in ib_insync (it returns the ticker object immediately, which updates later),
+        # we just return the mock ticker.
+        # We must explicitly set it as a MagicMock to avoid AsyncMock treating it as a coroutine
+        mock_ib_instance.reqMktData = MagicMock(return_value=mock_ticker)
+        mock_ib_instance.cancelMktData = MagicMock()
 
-            # Mock Positions
-            mock_positions = [
-                Position(account='test_account', contract=Contract(localSymbol='KC 26JUL24 250 C', symbol='KC', conId=1, exchange='NYBOT', secType='FOP'), position=1, avgCost=1.0),
-                Position(account='test_account', contract=Contract(localSymbol='KC 26JUL24 260 C', symbol='KC', conId=2, exchange='NYBOT', secType='FOP'), position=1, avgCost=1.0),
-                Position(account='test_account', contract=Contract(localSymbol='KC 26JUL24 300 P', symbol='KC', conId=3, exchange='NYBOT', secType='FOP'), position=1, avgCost=1.0),
-                Position(account='test_account', contract=Contract(localSymbol='KC 26JUL24 310 P', symbol='KC', conId=4, exchange='NYBOT', secType='FOP'), position=-1, avgCost=1.0),
-                Position(account='test_account', contract=Contract(localSymbol='KC 26JUL24 200 C', symbol='KC', conId=5, exchange='NYBOT', secType='FOP'), position=1, avgCost=1.0),
-            ]
-            mock_ib_instance.reqPositionsAsync.return_value = mock_positions
+        # Mock Positions
+        mock_positions = [
+            Position(account='test_account', contract=Contract(localSymbol='KC 26JUL24 250 C', symbol='KC', conId=1, exchange='NYBOT', secType='FOP'), position=1, avgCost=1.0),
+            Position(account='test_account', contract=Contract(localSymbol='KC 26JUL24 260 C', symbol='KC', conId=2, exchange='NYBOT', secType='FOP'), position=1, avgCost=1.0),
+            Position(account='test_account', contract=Contract(localSymbol='KC 26JUL24 300 P', symbol='KC', conId=3, exchange='NYBOT', secType='FOP'), position=1, avgCost=1.0),
+            Position(account='test_account', contract=Contract(localSymbol='KC 26JUL24 310 P', symbol='KC', conId=4, exchange='NYBOT', secType='FOP'), position=-1, avgCost=1.0),
+            Position(account='test_account', contract=Contract(localSymbol='KC 26JUL24 200 C', symbol='KC', conId=5, exchange='NYBOT', secType='FOP'), position=1, avgCost=1.0),
+        ]
+        mock_ib_instance.reqPositionsAsync.return_value = mock_positions
 
-            # Mock qualifyContractsAsync to return populated contracts based on conId
-            populated_contracts = {
-                1: Contract(localSymbol='KC 26JUL24 250 C', symbol='KC', conId=1, exchange='NYBOT', secType='FOP'),
-                2: Contract(localSymbol='KC 26JUL24 260 C', symbol='KC', conId=2, exchange='NYBOT', secType='FOP'),
-                3: Contract(localSymbol='KC 26JUL24 300 P', symbol='KC', conId=3, exchange='NYBOT', secType='FOP'),
-                4: Contract(localSymbol='KC 26JUL24 310 P', symbol='KC', conId=4, exchange='NYBOT', secType='FOP'),
-                5: Contract(localSymbol='KC 26JUL24 200 C', symbol='KC', conId=5, exchange='NYBOT', secType='FOP'),
-            }
+        # Mock qualifyContractsAsync to return populated contracts based on conId
+        populated_contracts = {
+            1: Contract(localSymbol='KC 26JUL24 250 C', symbol='KC', conId=1, exchange='NYBOT', secType='FOP'),
+            2: Contract(localSymbol='KC 26JUL24 260 C', symbol='KC', conId=2, exchange='NYBOT', secType='FOP'),
+            3: Contract(localSymbol='KC 26JUL24 300 P', symbol='KC', conId=3, exchange='NYBOT', secType='FOP'),
+            4: Contract(localSymbol='KC 26JUL24 310 P', symbol='KC', conId=4, exchange='NYBOT', secType='FOP'),
+            5: Contract(localSymbol='KC 26JUL24 200 C', symbol='KC', conId=5, exchange='NYBOT', secType='FOP'),
+        }
 
-            async def mock_qualify(*contracts):
-                result = []
-                for c in contracts:
-                    if c.conId in populated_contracts:
-                        result.append(populated_contracts[c.conId])
-                    else:
-                        result.append(c)
-                return result
-
-            mock_ib_instance.qualifyContractsAsync = AsyncMock(side_effect=mock_qualify)
-
-            mock_trade = MagicMock()
-            mock_trade.orderStatus.status = 'Filled'
-            mock_fill = MagicMock()
-            mock_fill.commissionReport.realizedPNL = 50.0
-            mock_trade.fills = [mock_fill]
-            mock_trade.orderStatus.avgFillPrice = 1.0
-
-            mock_place_order.return_value = mock_trade
-
-            config = {'symbol': 'KC', 'exchange': 'NYBOT'}
-
-            # Patch datetime to avoid Weekly Close logic triggering
-            with patch('trading_bot.order_manager.datetime') as mock_datetime:
-                mock_datetime.now.return_value = self.mock_now
-                mock_datetime.date.return_value = self.mock_now.date()
-
-                await close_stale_positions(config)
-
-            # We expect 3 calls to place_order: 1 for OLD_POSITION, 1 for COMBO_POSITION, 1 for RECON_POSITION
-            self.assertEqual(mock_place_order.call_count, 3)
-
-            single_order_calls = []
-            bag_order_call = None
-
-            for call in mock_place_order.call_args_list:
-                args, kwargs = call
-                contract = args[1]
-                if contract.secType == 'BAG':
-                    bag_order_call = call
+        async def mock_qualify(*contracts):
+            result = []
+            for c in contracts:
+                if c.conId in populated_contracts:
+                    result.append(populated_contracts[c.conId])
                 else:
-                    single_order_calls.append(call)
+                    result.append(c)
+            return result
 
-            # VERIFY SINGLE ORDERS
-            self.assertEqual(len(single_order_calls), 2)
+        mock_ib_instance.qualifyContractsAsync = AsyncMock(side_effect=mock_qualify)
 
-            # Sort calls by conId to make assertions deterministic
-            single_order_calls.sort(key=lambda call: call[0][1].conId)
+        mock_trade = MagicMock()
+        mock_trade.orderStatus.status = 'Filled'
+        mock_fill = MagicMock()
+        mock_fill.commissionReport.realizedPNL = 50.0
+        mock_trade.fills = [mock_fill]
+        mock_trade.orderStatus.avgFillPrice = 1.0
 
-            # 1. OLD_POSITION (conId 1)
-            args, _ = single_order_calls[0]
-            single_contract_1 = args[1]
-            single_order_1 = args[2]
+        mock_place_order.return_value = mock_trade
 
-            self.assertEqual(single_contract_1.conId, 1)
-            self.assertEqual(single_contract_1.symbol, 'KC')
-            self.assertEqual(single_contract_1.secType, 'FOP')
-            self.assertEqual(single_order_1.orderType, 'LMT')
-            self.assertEqual(single_order_1.lmtPrice, 5.0)
-            self.assertEqual(single_order_1.action, 'SELL')
+        config = {'symbol': 'KC', 'exchange': 'NYBOT'}
 
-            # 2. RECON_POSITION (conId 5)
-            args, _ = single_order_calls[1]
-            single_contract_2 = args[1]
-            single_order_2 = args[2]
+        # Patch datetime to avoid Weekly Close logic triggering
+        with patch('trading_bot.order_manager.datetime') as mock_datetime:
+            mock_datetime.now.return_value = self.mock_now
+            mock_datetime.date.return_value = self.mock_now.date()
 
-            self.assertEqual(single_contract_2.conId, 5)
-            self.assertEqual(single_contract_2.symbol, 'KC')
-            self.assertEqual(single_contract_2.secType, 'FOP')
-            self.assertEqual(single_order_2.orderType, 'LMT')
-            self.assertEqual(single_order_2.lmtPrice, 5.0)
-            self.assertEqual(single_order_2.action, 'SELL')
+            await close_stale_positions(config)
 
-            # VERIFY BAG ORDER
-            self.assertIsNotNone(bag_order_call)
-            args, _ = bag_order_call
-            bag_contract = args[1]
-            bag_order = args[2]
+        # We expect 3 calls to place_order: 1 for OLD_POSITION, 1 for COMBO_POSITION, 1 for RECON_POSITION
+        self.assertEqual(mock_place_order.call_count, 3)
 
-            self.assertEqual(bag_contract.symbol, 'KC')
-            self.assertEqual(bag_contract.secType, 'BAG')
+        single_order_calls = []
+        bag_order_call = None
 
-            # Verify Limit Order Logic
-            # Combo Position: ... -> Close Action: BUY (bag_action defaults to BUY as per code, unless we changed it logic?)
-            # Wait, the code sets bag_action based on final_legs_list[0]['action'] if size is 1?
-            # Or if multiple legs, bag_action = 'BUY' and we rely on leg actions?
-            # My code:
-            # bag_action = 'BUY'
-            # if len(final_legs_list) == 1:
-            #    bag_action = final_legs_list[0]['action']
+        for call in mock_place_order.call_args_list:
+            args, kwargs = call
+            contract = args[1]
+            if contract.secType == 'BAG':
+                bag_order_call = call
+            else:
+                single_order_calls.append(call)
 
-            # So for Bag it is BUY.
-            # Limit price for BUY is ASK (5.5).
-            # UPDATED: Code now calculates price from legs (5.25 - 5.25 = 0) + slippage (0.05).
-            self.assertEqual(bag_order.orderType, 'LMT')
-            self.assertEqual(bag_order.lmtPrice, 0.05)
-            self.assertEqual(bag_order.action, 'BUY')
+        # VERIFY SINGLE ORDERS
+        self.assertEqual(len(single_order_calls), 2)
 
-        asyncio.run(run_test())
+        # Sort calls by conId to make assertions deterministic
+        single_order_calls.sort(key=lambda call: call[0][1].conId)
+
+        # 1. OLD_POSITION (conId 1)
+        args, _ = single_order_calls[0]
+        single_contract_1 = args[1]
+        single_order_1 = args[2]
+
+        self.assertEqual(single_contract_1.conId, 1)
+        self.assertEqual(single_contract_1.symbol, 'KC')
+        self.assertEqual(single_contract_1.secType, 'FOP')
+        self.assertEqual(single_order_1.orderType, 'LMT')
+        self.assertEqual(single_order_1.lmtPrice, 5.0)
+        self.assertEqual(single_order_1.action, 'SELL')
+
+        # 2. RECON_POSITION (conId 5)
+        args, _ = single_order_calls[1]
+        single_contract_2 = args[1]
+        single_order_2 = args[2]
+
+        self.assertEqual(single_contract_2.conId, 5)
+        self.assertEqual(single_contract_2.symbol, 'KC')
+        self.assertEqual(single_contract_2.secType, 'FOP')
+        self.assertEqual(single_order_2.orderType, 'LMT')
+        self.assertEqual(single_order_2.lmtPrice, 5.0)
+        self.assertEqual(single_order_2.action, 'SELL')
+
+        # VERIFY BAG ORDER
+        self.assertIsNotNone(bag_order_call)
+        args, _ = bag_order_call
+        bag_contract = args[1]
+        bag_order = args[2]
+
+        self.assertEqual(bag_contract.symbol, 'KC')
+        self.assertEqual(bag_contract.secType, 'BAG')
+
+        # Verify Limit Order Logic
+        # Combo Position: ... -> Close Action: BUY (bag_action defaults to BUY as per code, unless we changed it logic?)
+        # Wait, the code sets bag_action based on final_legs_list[0]['action'] if size is 1?
+        # Or if multiple legs, bag_action = 'BUY' and we rely on leg actions?
+        # My code:
+        # bag_action = 'BUY'
+        # if len(final_legs_list) == 1:
+        #    bag_action = final_legs_list[0]['action']
+
+        # So for Bag it is BUY.
+        # Limit price for BUY is ASK (5.5).
+        # UPDATED: Code now calculates price from legs (5.25 - 5.25 = 0) + slippage (0.05).
+        self.assertEqual(bag_order.orderType, 'LMT')
+        self.assertEqual(bag_order.lmtPrice, 0.05)
+        self.assertEqual(bag_order.action, 'BUY')
 
 import pytest
 

--- a/tests/test_thesis_coherence.py
+++ b/tests/test_thesis_coherence.py
@@ -312,7 +312,7 @@ class TestCheckThesisCoherence(unittest.TestCase):
 # 3. Auto-close tests
 # ---------------------------------------------------------------------------
 
-class TestDeferredInvalidation(unittest.TestCase):
+class TestDeferredInvalidation(unittest.IsolatedAsyncioTestCase):
     """Tests for deferred invalidation + auto-close in fill handler."""
 
     @patch('trading_bot.order_manager.record_entry_thesis_for_trade', new_callable=AsyncMock)
@@ -500,7 +500,7 @@ class TestDeferredInvalidation(unittest.TestCase):
         # But no auto-close attempt
 
 
-class TestAutoCloseSuperseded(unittest.TestCase):
+class TestAutoCloseSuperseded(unittest.IsolatedAsyncioTestCase):
     """Tests for _auto_close_superseded()."""
 
     @patch('trading_bot.order_manager.get_trade_ledger_df')
@@ -574,7 +574,7 @@ class TestAutoCloseSuperseded(unittest.TestCase):
         ib.reqPositionsAsync.assert_not_called()
 
 
-class TestDedupPreventsSecondAutoClose(unittest.TestCase):
+class TestDedupPreventsSecondAutoClose(unittest.IsolatedAsyncioTestCase):
     """Verify _processed_supersedes prevents duplicate deferred invalidation."""
 
     @patch('trading_bot.order_manager.record_entry_thesis_for_trade', new_callable=AsyncMock)
@@ -648,7 +648,7 @@ class TestDedupPreventsSecondAutoClose(unittest.TestCase):
                          "_auto_close_superseded called more than once — dedup failed")
 
 
-class TestCloseSpreadPositionUsesPosContract(unittest.TestCase):
+class TestCloseSpreadPositionUsesPosContract(unittest.IsolatedAsyncioTestCase):
     """Verify _close_spread_position uses pos.contract directly, not re-qualification."""
 
     async def test_no_requalification(self):
@@ -663,6 +663,7 @@ class TestCloseSpreadPositionUsesPosContract(unittest.TestCase):
         ib.qualifyContractsAsync = AsyncMock(
             side_effect=AssertionError("qualifyContractsAsync should NOT be called"))
         ib.isConnected.return_value = True
+        ib.reqAllOpenOrdersAsync = AsyncMock(return_value=[])
 
         # Build fake position legs with correct contracts
         leg1 = MagicMock()
@@ -693,6 +694,9 @@ class TestCloseSpreadPositionUsesPosContract(unittest.TestCase):
             mock_trade = MagicMock()
             mock_trade.orderStatus.status = 'Filled'
             mock_trade.orderStatus.remaining = 0
+            mock_trade.orderStatus.avgFillPrice = 1.50
+            mock_trade.fills = []
+            mock_trade.log = []
             mock_place.return_value = mock_trade
 
             result = await _close_spread_position(
@@ -707,6 +711,7 @@ class TestCloseSpreadPositionUsesPosContract(unittest.TestCase):
 
         ib = MagicMock()
         ib.isConnected.return_value = True
+        ib.reqAllOpenOrdersAsync = AsyncMock(return_value=[])
 
         leg = MagicMock()
         leg.contract = MagicMock()
@@ -724,6 +729,9 @@ class TestCloseSpreadPositionUsesPosContract(unittest.TestCase):
             mock_trade = MagicMock()
             mock_trade.orderStatus.status = 'Filled'
             mock_trade.orderStatus.remaining = 0
+            mock_trade.orderStatus.avgFillPrice = 0.80
+            mock_trade.fills = []
+            mock_trade.log = []
             mock_place.return_value = mock_trade
 
             await _close_spread_position(


### PR DESCRIPTION
## Summary

- **Split** `test_drawdown_recovery.py` (1,270 lines, 6 concerns) into 3 focused files + shared `conftest.py` helpers
- **Fixed** `test_thesis_coherence.py` async antipattern: 4 classes inherited `unittest.TestCase` with `async def` methods — 28 tests silently passed without executing assertions. Changed to `IsolatedAsyncioTestCase`, fixed 2 exposed mock gaps (`avgFillPrice`, `reqAllOpenOrdersAsync`)
- **Fixed** `test_order_manager.py` manual `asyncio.run()` wrappers by switching to `IsolatedAsyncioTestCase`

### Files

| File | Action |
|------|--------|
| `tests/conftest.py` | **New** — 5 shared helpers (~105 lines) |
| `tests/test_drawdown_recovery.py` | Kept recovery + oscillation tests only (22 tests) |
| `tests/test_drawdown_starting_equity.py` | **New** — starting equity + stale state (17 tests) |
| `tests/test_drawdown_panic_gate.py` | **New** — panic gate tests (10 tests) |
| `tests/test_thesis_coherence.py` | 4× `TestCase` → `IsolatedAsyncioTestCase` + mock fixes |
| `tests/test_order_manager.py` | 2× `TestCase` → `IsolatedAsyncioTestCase`, unwrap `asyncio.run()` |

Net: -65 lines (965 added, 1030 removed). All 865 tests pass.

## Test plan

- [x] `pytest tests/test_drawdown_recovery.py tests/test_drawdown_starting_equity.py tests/test_drawdown_panic_gate.py -v` — 49 tests pass across 3 files
- [x] `pytest tests/test_thesis_coherence.py -v` — 35 passed (28 async tests now actually execute)
- [x] `pytest tests/test_order_manager.py -v` — 7 passed
- [x] `pytest tests/` — full suite 865 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)