### PR TITLE
Fix Cockpit P&L matching, show untracked positions, remove dead stop columns

### DIFF
--- a/dashboard_utils.py
+++ b/dashboard_utils.py
@@ -317,6 +317,93 @@ def load_trade_data(ticker: str = None):
         return pd.DataFrame()
 
 
+def build_position_pnl_map(live_data: dict, ticker: str = None) -> dict:
+    """Map position_id → aggregate unrealizedPNL using the trade ledger as a bridge.
+
+    IBKR portfolio items are keyed by localSymbol (e.g. "KCH6 C3.5").
+    The trade ledger maps local_symbol → position_id.
+    This function joins the two to produce {position_id: total_unrealized_pnl}.
+    """
+    portfolio_items = live_data.get('portfolio_items', [])
+    if not portfolio_items:
+        return {}
+
+    trade_df = load_trade_data(ticker)
+    if trade_df.empty or 'local_symbol' not in trade_df.columns or 'position_id' not in trade_df.columns:
+        return {}
+
+    # Build local_symbol → position_id lookup (last-write-wins)
+    symbol_to_pid = {}
+    for _, row in trade_df.iterrows():
+        sym = row.get('local_symbol')
+        pid = row.get('position_id')
+        if pd.notna(sym) and pd.notna(pid):
+            symbol_to_pid[sym] = pid
+
+    # Aggregate unrealizedPNL per position_id
+    pnl_map: dict[str, float] = {}
+    for item in portfolio_items:
+        if not hasattr(item, 'contract'):
+            continue
+        local_sym = getattr(item.contract, 'localSymbol', None)
+        if not local_sym:
+            continue
+        pid = symbol_to_pid.get(local_sym)
+        if pid is None:
+            continue
+        pnl = getattr(item, 'unrealizedPNL', 0) or 0
+        pnl_map[pid] = pnl_map.get(pid, 0) + pnl
+
+    return pnl_map
+
+
+def find_untracked_ibkr_positions(live_data: dict, active_theses: list, ticker: str = None) -> list:
+    """Find IBKR portfolio positions that have no matching active thesis.
+
+    Returns list of dicts with keys: local_symbol, quantity, unrealized_pnl,
+    market_value, avg_cost.
+    """
+    portfolio_items = live_data.get('portfolio_items', [])
+    if not portfolio_items:
+        return []
+
+    # Collect position_ids from active theses
+    thesis_pids = {t.get('position_id') for t in (active_theses or [])}
+
+    trade_df = load_trade_data(ticker)
+    # Build local_symbol → position_id lookup
+    symbol_to_pid = {}
+    if not trade_df.empty and 'local_symbol' in trade_df.columns and 'position_id' in trade_df.columns:
+        for _, row in trade_df.iterrows():
+            sym = row.get('local_symbol')
+            pid = row.get('position_id')
+            if pd.notna(sym) and pd.notna(pid):
+                symbol_to_pid[sym] = pid
+
+    untracked = []
+    for item in portfolio_items:
+        if not hasattr(item, 'contract'):
+            continue
+        qty = getattr(item, 'position', 0)
+        if qty == 0:
+            continue
+        local_sym = getattr(item.contract, 'localSymbol', None)
+        if not local_sym:
+            continue
+        pid = symbol_to_pid.get(local_sym)
+        if pid and pid in thesis_pids:
+            continue  # tracked
+        untracked.append({
+            'local_symbol': local_sym,
+            'quantity': qty,
+            'unrealized_pnl': getattr(item, 'unrealizedPNL', None),
+            'market_value': getattr(item, 'marketValue', None),
+            'avg_cost': getattr(item, 'averageCost', None),
+        })
+
+    return untracked
+
+
 @st.cache_data(ttl=3600)
 def _load_legacy_council_history(data_dir: str) -> pd.DataFrame:
     """Loads and caches legacy council history files (long TTL)."""

--- a/pages/1_Cockpit.py
+++ b/pages/1_Cockpit.py
@@ -13,7 +13,6 @@ import pytz
 import sys
 import os
 import asyncio
-import re
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from dashboard_utils import (
@@ -34,103 +33,24 @@ from dashboard_utils import (
     load_task_schedule_status,
     load_deduplicator_metrics,
     _resolve_data_path,
-    _relative_time
+    _relative_time,
+    build_position_pnl_map,
+    find_untracked_ibkr_positions,
 )
 from trading_bot.calendars import is_trading_day
 from config.commodity_profiles import get_commodity_profile as get_profile_dataclass, parse_trading_hours
 
 
-def _parse_price_from_text(text: str, entry_price: float, min_price: float, max_price: float) -> float | None:
-    """Helper to extract price from trigger text."""
-    text_upper = text.upper()
-
-    # Look for price keywords
-    if any(kw in text_upper for kw in ['STOP', 'CLOSE', 'EXIT', 'PRICE <', 'PRICE >', 'BELOW', 'ABOVE', 'BREACH']):
-        match = re.search(r'\$?(\d+(?:\.\d{1,2})?)', text)
-        if match:
-            price = float(match.group(1))
-            if min_price <= price <= max_price:
-                return price
-
-    # Check for percentage-based stops
-    pct_match = re.search(r'(\d+(?:\.\d+)?)\s*%', text)
-    if pct_match and entry_price and entry_price > 0:
-        pct = float(pct_match.group(1)) / 100
-        calculated_stop = entry_price * (1 - pct)
-        if min_price <= calculated_stop <= max_price:
-            return calculated_stop
-
-    return None
-
-
-def extract_stop_price_from_triggers(
-    triggers: any,
-    entry_price: float,
-    config: dict = None
-) -> float | None:
-    """
-    Extracts stop/invalidation price from various trigger formats.
-
-    Handles:
-    - Dict: {'stop_loss_price': 320.0}
-    - List: ['Close if price < 320', 'Monitor frost']
-    - String: 'Stop at 5% loss'
-
-    Uses config-driven price bounds to filter false positives.
-    """
-    if triggers is None:
-        return None
-
-    # Get commodity-specific bounds (permissive fallback for any commodity)
-    profile = get_commodity_profile(config)
-    min_price, max_price = profile.get('stop_parse_range', [0, 100000])
-
-    # === Dict format ===
-    if isinstance(triggers, dict):
-        for key in ['stop_loss_price', 'stop_price', 'invalidation_price', 'exit_price']:
-            if key in triggers:
-                price = float(triggers[key])
-                if min_price <= price <= max_price:
-                    return price
-        return None
-
-    # === List format ===
-    if isinstance(triggers, list):
-        for trigger in triggers:
-            if isinstance(trigger, str):
-                price = _parse_price_from_text(trigger, entry_price, min_price, max_price)
-                if price is not None:
-                    return price
-        return None
-
-    # === String format ===
-    if isinstance(triggers, str):
-        return _parse_price_from_text(triggers, entry_price, min_price, max_price)
-
-    return None
-
-
-def render_thesis_card_enhanced(thesis: dict, live_data: dict, config: dict = None):
-    """Renders thesis card with live P&L and distance to invalidation."""
+def render_thesis_card_enhanced(thesis: dict, live_data: dict, config: dict = None, pnl_map: dict = None):
+    """Renders thesis card with live P&L and invalidation triggers inline."""
     position_id = thesis.get('position_id', 'UNKNOWN')
     strategy = thesis.get('strategy_type', 'DIRECTIONAL')
     entry_price = thesis.get('entry_price', 0) or thesis.get('supporting_data', {}).get('entry_price', 0)
 
-    # Find matching position in portfolio
-    unrealized_pnl = None
-    for item in live_data.get('portfolio_items', []):
-        if hasattr(item, 'contract') and position_id in str(item.contract.localSymbol):
-            unrealized_pnl = getattr(item, 'unrealizedPNL', None)
-            break
+    # P&L lookup via pre-built map (bridges localSymbol → position_id via ledger)
+    unrealized_pnl = pnl_map.get(position_id) if pnl_map else None
 
-    # Extract stop price from triggers
     triggers = thesis.get('invalidation_triggers', [])
-    stop_price = extract_stop_price_from_triggers(triggers, entry_price, config)
-
-    # Calculate distance to stop
-    distance_pct = None
-    if stop_price and entry_price and entry_price != 0:
-        distance_pct = abs(entry_price - stop_price) / entry_price
 
     # Render
     with st.container():
@@ -142,7 +62,6 @@ def render_thesis_card_enhanced(thesis: dict, live_data: dict, config: dict = No
                 f"Guardian: {thesis.get('guardian_agent', 'Master')}"
             )
         with head_cols[1]:
-            # UX Improvement: Copy ID Button
             label = f"🆔 {position_id[:8]}"
             if hasattr(st, "popover"):
                 with st.popover(label, width="stretch"):
@@ -152,10 +71,9 @@ def render_thesis_card_enhanced(thesis: dict, live_data: dict, config: dict = No
                 with st.expander(label):
                     st.code(position_id, language=None)
 
-        cols = st.columns(4)
+        cols = st.columns(3)
 
         with cols[0]:
-            # Format entry timestamp for tooltip
             entry_ts = thesis.get('entry_timestamp', 'Unknown')
             if isinstance(entry_ts, datetime):
                 entry_ts_str = entry_ts.strftime('%Y-%m-%d %H:%M:%S UTC')
@@ -181,41 +99,17 @@ def render_thesis_card_enhanced(thesis: dict, live_data: dict, config: dict = No
                 st.metric("Unrealized P&L", "N/A", help="Current open profit/loss on active positions")
 
         with cols[2]:
-            stop_help = "Calculated from invalidation triggers"
-            if isinstance(triggers, list) and triggers:
-                stop_help += ":\n\n" + "\n".join([f"• {t}" for t in triggers])
-            elif isinstance(triggers, str):
-                stop_help += f":\n\n• {triggers}"
-
             st.metric(
-                "Stop Price",
-                f"${stop_price:.2f}" if stop_price else "N/A",
-                help=stop_help
+                "Strategy",
+                strategy.replace('_', ' ').title(),
+                help="Trading strategy used for this position"
             )
 
-        with cols[3]:
-            dist_help = "Distance between current entry price and stop price"
-            if distance_pct is not None:
-                if distance_pct < 0.05:
-                    st.error(f"⚠️ {distance_pct:.1%} to stop", help=dist_help)
-                elif distance_pct < 0.10:
-                    st.warning(f"🔶 {distance_pct:.1%} to stop", help=dist_help)
-                else:
-                    st.success(f"✅ {distance_pct:.1%} to stop", help=dist_help)
-            else:
-                # Issue 6 Fix: Strategy-aware stop display
-                MULTI_LEG_STRATEGIES = {'IRON_CONDOR', 'LONG_STRADDLE', 'IRON_BUTTERFLY', 'STRANGLE'}
-                if strategy.upper() in MULTI_LEG_STRATEGIES:
-                    st.info("📑 Uses invalidation triggers")
-                else:
-                    st.error("No stop defined")
-
-        with st.expander("📜 Invalidation Triggers"):
-            if isinstance(triggers, list):
-                for t in triggers:
-                    st.write(f"• {t}")
-            else:
-                st.write(str(triggers) if triggers else "None defined")
+        # Show invalidation triggers inline
+        if isinstance(triggers, list) and triggers:
+            st.caption("Triggers: " + "  \u2022  ".join(str(t) for t in triggers))
+        elif isinstance(triggers, str) and triggers:
+            st.caption(f"Triggers: {triggers}")
 
 
 def render_portfolio_risk_summary(live_data: dict, active_theses: list = None):
@@ -1191,8 +1085,16 @@ if active_theses:
     st.markdown("")
 
     # Detailed thesis cards
+    pnl_map = build_position_pnl_map(live_data, ticker=ticker)
     for thesis in active_theses:
-        render_thesis_card_enhanced(thesis, live_data, config)
+        render_thesis_card_enhanced(thesis, live_data, config, pnl_map=pnl_map)
+
+    # Untracked IBKR positions warning
+    _untracked = find_untracked_ibkr_positions(live_data, active_theses, ticker=ticker)
+    if _untracked:
+        st.warning(f"⚠️ {len(_untracked)} IBKR position(s) with no active thesis")
+        with st.expander(f"View {len(_untracked)} untracked position(s)"):
+            st.dataframe(pd.DataFrame(_untracked), use_container_width=True)
 
 else:
     st.info("No active position theses. The system has no open positions or theses haven't been recorded yet.")

--- a/tests/test_ui_ux.py
+++ b/tests/test_ui_ux.py
@@ -575,5 +575,251 @@ class TestScorecardUX(unittest.TestCase):
             )
 
 
+class TestBuildPositionPnlMap(unittest.TestCase):
+    """Tests for dashboard_utils.build_position_pnl_map()."""
+
+    def _make_item(self, local_symbol, unrealized_pnl, position=1):
+        """Create a mock portfolio item."""
+        class MockContract:
+            pass
+        class MockItem:
+            pass
+        contract = MockContract()
+        contract.localSymbol = local_symbol
+        item = MockItem()
+        item.contract = contract
+        item.unrealizedPNL = unrealized_pnl
+        item.position = position
+        return item
+
+    def test_single_leg_match(self):
+        """Single leg maps correctly via ledger."""
+        import pandas as pd
+        from unittest.mock import patch
+
+        ledger = pd.DataFrame({
+            'local_symbol': ['KCH6 C3.5'],
+            'position_id': ['pid-001'],
+        })
+        live_data = {'portfolio_items': [self._make_item('KCH6 C3.5', 150.0)]}
+
+        with patch('dashboard_utils.load_trade_data', return_value=ledger):
+            from dashboard_utils import build_position_pnl_map
+            result = build_position_pnl_map(live_data, ticker='KC')
+
+        self.assertEqual(result, {'pid-001': 150.0})
+
+    def test_multi_leg_spread_aggregation(self):
+        """Multiple legs with same position_id aggregate P&L."""
+        import pandas as pd
+        from unittest.mock import patch
+
+        ledger = pd.DataFrame({
+            'local_symbol': ['KCH6 C3.5', 'KCH6 C3.75'],
+            'position_id': ['pid-001', 'pid-001'],
+        })
+        live_data = {'portfolio_items': [
+            self._make_item('KCH6 C3.5', 100.0),
+            self._make_item('KCH6 C3.75', -30.0),
+        ]}
+
+        with patch('dashboard_utils.load_trade_data', return_value=ledger):
+            from dashboard_utils import build_position_pnl_map
+            result = build_position_pnl_map(live_data, ticker='KC')
+
+        self.assertAlmostEqual(result['pid-001'], 70.0)
+
+    def test_empty_portfolio(self):
+        """Empty portfolio returns empty dict."""
+        from dashboard_utils import build_position_pnl_map
+        result = build_position_pnl_map({'portfolio_items': []}, ticker='KC')
+        self.assertEqual(result, {})
+
+    def test_empty_ledger(self):
+        """Empty ledger returns empty dict."""
+        import pandas as pd
+        from unittest.mock import patch
+
+        live_data = {'portfolio_items': [self._make_item('KCH6 C3.5', 100.0)]}
+
+        with patch('dashboard_utils.load_trade_data', return_value=pd.DataFrame()):
+            from dashboard_utils import build_position_pnl_map
+            result = build_position_pnl_map(live_data, ticker='KC')
+
+        self.assertEqual(result, {})
+
+    def test_missing_position_id_column(self):
+        """Ledger without position_id column returns empty dict."""
+        import pandas as pd
+        from unittest.mock import patch
+
+        ledger = pd.DataFrame({'local_symbol': ['KCH6 C3.5']})
+        live_data = {'portfolio_items': [self._make_item('KCH6 C3.5', 100.0)]}
+
+        with patch('dashboard_utils.load_trade_data', return_value=ledger):
+            from dashboard_utils import build_position_pnl_map
+            result = build_position_pnl_map(live_data, ticker='KC')
+
+        self.assertEqual(result, {})
+
+    def test_no_match_excluded(self):
+        """Portfolio items not in ledger are excluded from map."""
+        import pandas as pd
+        from unittest.mock import patch
+
+        ledger = pd.DataFrame({
+            'local_symbol': ['KCH6 C3.5'],
+            'position_id': ['pid-001'],
+        })
+        live_data = {'portfolio_items': [self._make_item('KCH6 P3.0', 50.0)]}
+
+        with patch('dashboard_utils.load_trade_data', return_value=ledger):
+            from dashboard_utils import build_position_pnl_map
+            result = build_position_pnl_map(live_data, ticker='KC')
+
+        self.assertEqual(result, {})
+
+
+class TestFindUntrackedIbkrPositions(unittest.TestCase):
+    """Tests for dashboard_utils.find_untracked_ibkr_positions()."""
+
+    def _make_item(self, local_symbol, position=1, unrealized_pnl=0, market_value=0, avg_cost=0):
+        class MockContract:
+            pass
+        class MockItem:
+            pass
+        contract = MockContract()
+        contract.localSymbol = local_symbol
+        item = MockItem()
+        item.contract = contract
+        item.position = position
+        item.unrealizedPNL = unrealized_pnl
+        item.marketValue = market_value
+        item.averageCost = avg_cost
+        return item
+
+    def test_all_tracked(self):
+        """No untracked items when all symbols map to active theses."""
+        import pandas as pd
+        from unittest.mock import patch
+
+        ledger = pd.DataFrame({
+            'local_symbol': ['KCH6 C3.5'],
+            'position_id': ['pid-001'],
+        })
+        live_data = {'portfolio_items': [self._make_item('KCH6 C3.5')]}
+        theses = [{'position_id': 'pid-001'}]
+
+        with patch('dashboard_utils.load_trade_data', return_value=ledger):
+            from dashboard_utils import find_untracked_ibkr_positions
+            result = find_untracked_ibkr_positions(live_data, theses, ticker='KC')
+
+        self.assertEqual(result, [])
+
+    def test_untracked_detected(self):
+        """Detects items not linked to any thesis."""
+        import pandas as pd
+        from unittest.mock import patch
+
+        ledger = pd.DataFrame({
+            'local_symbol': ['KCH6 C3.5'],
+            'position_id': ['pid-001'],
+        })
+        live_data = {'portfolio_items': [
+            self._make_item('KCH6 C3.5'),
+            self._make_item('KCH6 P3.0', position=2, unrealized_pnl=-50),
+        ]}
+        theses = [{'position_id': 'pid-001'}]
+
+        with patch('dashboard_utils.load_trade_data', return_value=ledger):
+            from dashboard_utils import find_untracked_ibkr_positions
+            result = find_untracked_ibkr_positions(live_data, theses, ticker='KC')
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['local_symbol'], 'KCH6 P3.0')
+
+    def test_zero_qty_excluded(self):
+        """Zero-quantity positions are not reported as untracked."""
+        import pandas as pd
+        from unittest.mock import patch
+
+        live_data = {'portfolio_items': [self._make_item('KCH6 C3.5', position=0)]}
+
+        with patch('dashboard_utils.load_trade_data', return_value=pd.DataFrame()):
+            from dashboard_utils import find_untracked_ibkr_positions
+            result = find_untracked_ibkr_positions(live_data, [], ticker='KC')
+
+        self.assertEqual(result, [])
+
+    def test_empty_theses(self):
+        """All non-zero positions reported when no theses exist."""
+        import pandas as pd
+        from unittest.mock import patch
+
+        live_data = {'portfolio_items': [self._make_item('KCH6 C3.5', position=1)]}
+
+        with patch('dashboard_utils.load_trade_data', return_value=pd.DataFrame()):
+            from dashboard_utils import find_untracked_ibkr_positions
+            result = find_untracked_ibkr_positions(live_data, [], ticker='KC')
+
+        self.assertEqual(len(result), 1)
+
+    def test_empty_portfolio(self):
+        """Empty portfolio returns empty list."""
+        from dashboard_utils import find_untracked_ibkr_positions
+        result = find_untracked_ibkr_positions({'portfolio_items': []}, [], ticker='KC')
+        self.assertEqual(result, [])
+
+
+class TestRenderThesisCardSignature(unittest.TestCase):
+    """AST tests: verify render_thesis_card_enhanced structure after refactor."""
+
+    def _get_tree_and_func(self):
+        file_path = os.path.join(
+            os.path.dirname(__file__), "..", "pages", "1_Cockpit.py"
+        )
+        with open(file_path, "r") as f:
+            tree = ast.parse(f.read())
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "render_thesis_card_enhanced":
+                return tree, node
+        self.fail("render_thesis_card_enhanced not found")
+
+    def test_pnl_map_param_present(self):
+        """Function must accept a pnl_map parameter."""
+        _, func = self._get_tree_and_func()
+        param_names = [arg.arg for arg in func.args.args]
+        self.assertIn("pnl_map", param_names)
+
+    def test_no_stop_price_metric(self):
+        """No st.metric call with 'Stop Price' label should exist."""
+        _, func = self._get_tree_and_func()
+        for node in ast.walk(func):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "metric":
+                if node.args and isinstance(node.args[0], ast.Constant) and node.args[0].value == "Stop Price":
+                    self.fail("Found 'Stop Price' metric — should have been removed")
+
+    def test_uses_three_columns(self):
+        """st.columns should be called with 3, not 4."""
+        _, func = self._get_tree_and_func()
+        for node in ast.walk(func):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "columns":
+                if node.args and isinstance(node.args[0], ast.Constant) and node.args[0].value == 4:
+                    self.fail("Found st.columns(4) — should be st.columns(3)")
+
+    def test_extract_stop_price_removed(self):
+        """extract_stop_price_from_triggers should not exist in the file."""
+        file_path = os.path.join(
+            os.path.dirname(__file__), "..", "pages", "1_Cockpit.py"
+        )
+        with open(file_path, "r") as f:
+            tree = ast.parse(f.read())
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "extract_stop_price_from_triggers":
+                self.fail("extract_stop_price_from_triggers still exists — should have been removed")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- **Fix #1175**: P&L in thesis cards now correctly maps IBKR `localSymbol` → `position_id` via the trade ledger, instead of the broken UUID-substring check that always returned N/A
- **Fix #1176**: IBKR positions with no matching active thesis now show a warning banner with an expandable dataframe of untracked positions
- **Fix #1177**: Removed the always-N/A Stop Price/Distance columns and the dead `extract_stop_price_from_triggers()` / `_parse_price_from_text()` code; invalidation triggers now display inline as a caption on each card

## Test plan

- [x] `pytest tests/test_ui_ux.py -v` — all 28 tests pass (13 existing + 15 new)
- [x] `pytest tests/` — full suite passes (880 passed, 0 failures)
- [ ] Visual: Cockpit shows real P&L values when IBKR connected
- [ ] Visual: Untracked positions warning appears if any exist
- [ ] Visual: No Stop Price/Distance columns; triggers shown inline

Closes #1175, closes #1176, closes #1177

🤖 Generated with [Claude Code](https://claude.com/claude-code)