### PR TITLE
Penalize direction-evidence mismatches in weighted voting

### DIFF
--- a/trading_bot/agents.py
+++ b/trading_bot/agents.py
@@ -1050,7 +1050,8 @@ OUTPUT FORMAT (JSON):
                 'data': formatted_text,
                 'confidence': parse_confidence(data.get('confidence', 0.5)),
                 'sentiment': data.get('sentiment', 'NEUTRAL'),
-                'data_freshness_hours': grounded_data.data_freshness_hours
+                'data_freshness_hours': grounded_data.data_freshness_hours,
+                'has_direction_mismatch': any('Direction-evidence mismatch' in i for i in issues),
             }
 
             # Record Trace

--- a/trading_bot/weighted_voting.py
+++ b/trading_bot/weighted_voting.py
@@ -62,6 +62,7 @@ class AgentVote:
     age_hours: float = 0.0  # Populated from StateManager metadata
     is_stale: bool = False
     data_freshness_hours: float = 0.0
+    has_direction_mismatch: bool = False
 
 
 def calculate_staleness_weight(age_hours: float, max_useful_age: float = 24.0) -> float:
@@ -596,6 +597,8 @@ async def calculate_weighted_decision(
                           f"Report type: {type(report).__name__}, is_stale: {is_stale}, "
                           f"Report preview: {str(report)[:100]}...")
 
+        has_mismatch = report.get('has_direction_mismatch', False) if isinstance(report, dict) else False
+
         votes.append(AgentVote(
             agent_name=agent_name,
             direction=direction,
@@ -603,7 +606,8 @@ async def calculate_weighted_decision(
             sentiment_tag=sentiment_tag,
             age_hours=age_hours,
             is_stale=is_data_stale,
-            data_freshness_hours=data_freshness
+            data_freshness_hours=data_freshness,
+            has_direction_mismatch=has_mismatch,
         ))
 
     # Quorum Check
@@ -662,7 +666,13 @@ async def calculate_weighted_decision(
             freshness_penalty = decay_factor
             logger.debug(f"Agent {vote.agent_name}: Freshness penalty applied: {freshness:.1f}h -> factor {decay_factor:.2f}")
 
-        final_weight = base_domain_weight * reliability_multiplier * staleness_weight * freshness_penalty
+        # Apply direction-evidence mismatch discount (Issue #1170)
+        mismatch_discount = 1.0
+        if vote.has_direction_mismatch:
+            mismatch_discount = 0.5
+            logger.info(f"Agent {vote.agent_name}: Direction-evidence mismatch detected, applying 0.5x weight discount")
+
+        final_weight = base_domain_weight * reliability_multiplier * staleness_weight * freshness_penalty * mismatch_discount
 
         contribution = vote.direction.value * vote.confidence * final_weight
         total_weighted_score += contribution
@@ -676,6 +686,7 @@ async def calculate_weighted_decision(
             'reliability_mult': round(reliability_multiplier, 2),
             'staleness_weight': round(staleness_weight, 2),
             'age_hours': round(vote.age_hours, 1),
+            'mismatch_discount': round(mismatch_discount, 2),
             'final_weight': round(final_weight, 2),
             'contribution': round(contribution, 3),
         })


### PR DESCRIPTION
## Summary

- **Fix #1170**: When an agent's stated direction contradicts its own evidence (e.g. says BEARISH but text has 10 bullish vs 4 bearish words), the agent's vote weight is now halved (0.5x discount) in weighted voting — on top of the existing confidence clamp from validation

The mismatch detection already existed in `agents.py` (`_validate_agent_output()`) but the flag was logged and discarded. Now it flows through:
1. `agents.py`: `has_direction_mismatch` flag added to `structured_result` dict
2. `weighted_voting.py`: `AgentVote` dataclass gains `has_direction_mismatch` field, extracted from report, applied as 0.5x multiplier in weight formula, and included in `vote_breakdown` for forensic visibility

## Test plan

- [x] `pytest tests/` — full suite passes (880 passed, 0 failures)
- [ ] Monitor: Next decision cycle should show `mismatch_discount: 0.5` in vote_breakdown for any agent with direction-evidence mismatch
- [ ] Verify in council_history.csv that mismatched agents have reduced contribution values

Closes #1170

🤖 Generated with [Claude Code](https://claude.com/claude-code)