### PR TITLE
Fix VaR returning zeros with open positions

### DIFF
--- a/tests/test_var_calculator.py
+++ b/tests/test_var_calculator.py
@@ -702,6 +702,48 @@ async def test_fut_invalid_market_price_excluded(calculator, sample_config):
     assert len(snapshots) == 0, "FUT with marketPrice=-1 should be excluded"
 
 
+# --- Test 21b: FOP with invalid marketPrice uses B-S model fallback ---
+
+async def test_fop_invalid_market_price_uses_model(calculator, sample_config):
+    """Options with marketPrice=-1 (IB 'no data') should use B-S model price, not -1."""
+    mock_ib = MagicMock()
+
+    # Valid FUT so underlying_price is available
+    mock_fut = MagicMock()
+    mock_fut.position = 1
+    mock_fut.contract = MagicMock(
+        secType="FUT", symbol="KC", conId=100,
+        localSymbol="KCN6", multiplier="37500",
+    )
+    mock_fut.marketPrice = 380.0
+
+    # FOP with invalid market price (-1 from IB)
+    mock_opt = MagicMock()
+    mock_opt.position = 1
+    mock_opt.contract = MagicMock(
+        secType="FOP", symbol="KC", conId=200,
+        localSymbol="KCN6 C400", multiplier="37500",
+        strike=400.0, right="C",
+        lastTradeDateOrContractMonth="20260701",
+    )
+    mock_opt.marketPrice = -1.0  # IB sentinel for "no data"
+
+    mock_ib.portfolio.return_value = [mock_fut, mock_opt]
+
+    # Mock IV batch fetch
+    with patch.object(calculator, '_batch_fetch_iv', return_value={200: 0.35}):
+        snapshots = await calculator._snapshot_portfolio(mock_ib, sample_config)
+
+    # FUT should be included
+    futs = [s for s in snapshots if s.sec_type == "FUT"]
+    assert len(futs) == 1
+
+    # FOP should be included with B-S model price (NOT -1.0)
+    opts = [s for s in snapshots if s.sec_type == "FOP"]
+    assert len(opts) == 1, "Option with invalid price should still be included via B-S fallback"
+    assert opts[0].current_price > 0, f"current_price should be B-S model price, got {opts[0].current_price}"
+
+
 # --- Test 22: Negative shocked_S clamped in B-S revaluation ---
 
 def test_negative_shocked_price_clamped(calculator):

--- a/trading_bot/var_calculator.py
+++ b/trading_bot/var_calculator.py
@@ -175,6 +175,13 @@ class PortfolioVaRCalculator:
             var_95 = max(var_95, 0.0)
             var_99 = max(var_99, 0.0)
 
+            # Sanity check: VaR=0 with positions is suspect (#1164)
+            if len(positions) > 0 and var_95 == 0.0 and var_99 == 0.0:
+                logger.warning(
+                    f"VaR returned $0 with {len(positions)} positions — "
+                    f"likely invalid market data. Check option prices."
+                )
+
             result = VaRResult(
                 var_95=round(var_95, 2),
                 var_99=round(var_99, 2),
@@ -508,6 +515,21 @@ class PortfolioVaRCalculator:
                     )
                     continue
 
+                # Validate option market price — IB returns -1.0 for "no data"
+                opt_price = item.marketPrice
+                if opt_price is None or opt_price <= 0 or (isinstance(opt_price, float) and np.isnan(opt_price)):
+                    # Fallback: use B-S model price as current_price (#1164)
+                    r_rate = config.get("compliance", {}).get("var_risk_free_rate", 0.04)
+                    model_price = self._bs_price(
+                        und_price, float(c.strike), expiry_years,
+                        r_rate, iv_val, c.right
+                    )
+                    logger.warning(
+                        f"Invalid market price for option {c.localSymbol}: "
+                        f"{opt_price} — using B-S model price {model_price:.4f}"
+                    )
+                    opt_price = model_price
+
                 snapshots.append(PositionSnapshot(
                     symbol=ticker_sym,
                     sec_type=c.secType,
@@ -517,7 +539,7 @@ class PortfolioVaRCalculator:
                     expiry_years=expiry_years,
                     iv=iv_val,
                     underlying_price=und_price,
-                    current_price=item.marketPrice,  # option's current market price
+                    current_price=opt_price,
                     dollar_multiplier=multiplier,
                 ))
 


### PR DESCRIPTION
## Summary

- Validate `marketPrice` for FOP/OPT positions (was only validated for FUT)
- When IB returns `-1.0` (sentinel for "no data"), use Black-Scholes model price as fallback instead of poisoning the P&L formula
- Add sanity warning when VaR = $0 with non-zero positions

**Root cause**: `(new_price - (-1.0)) * qty * multiplier` made every scenario positive, clamping VaR to $0.00.

## Test plan

- [x] All 882 tests pass (881 existing + 1 new)
- [x] `test_fop_invalid_market_price_uses_model` — verifies B-S fallback when marketPrice=-1
- [x] `test_fut_invalid_market_price_excluded` — existing FUT validation still works

Closes #1164

🤖 Generated with [Claude Code](https://claude.com/claude-code)