### PR TITLE
Fix Portfolio page: live positions, engine health, VaR fields, drawdown

### DIFF
--- a/pages/9_Portfolio.py
+++ b/pages/9_Portfolio.py
@@ -157,31 +157,63 @@ st.subheader("VaR Utilization")
 
 var_state = _load_json(os.path.join(DATA_ROOT, "var_state.json"))
 if var_state:
-    cols = st.columns(3)
+    var_95 = var_state.get("var_95", 0)
+    var_95_pct = var_state.get("var_95_pct", 0)
+    var_99 = var_state.get("var_99", 0)
+    var_99_pct = var_state.get("var_99_pct", 0)
+    pos_count = var_state.get("position_count", 0)
+    commodities = var_state.get("commodities", [])
+
+    # VaR limit comes from config, not var_state.json
+    try:
+        from config_loader import load_config as _load_cfg
+        _cfg = _load_cfg()
+        var_limit_pct = _cfg.get('compliance', {}).get('var_limit_pct', 0.03)
+    except Exception:
+        var_limit_pct = 0.03
+
+    cols = st.columns(4)
     with cols[0]:
-        var_95 = var_state.get("var_95", 0)
         st.metric(
-            "VaR (95%)", f"${var_95:,.0f}" if var_95 else "N/A",
-            help="Value at Risk (95% confidence): Estimated maximum loss over one day based on current portfolio correlations."
+            "VaR (95%)", f"{var_95_pct:.1%}" if var_95_pct else "N/A",
+            delta=f"${var_95:,.0f}" if var_95 else None,
+            delta_color="off",
+            help="Value at Risk (95% confidence): Estimated maximum loss over one day."
         )
     with cols[1]:
-        var_limit = var_state.get("var_limit", 0)
         st.metric(
-            "VaR Limit", f"${var_limit:,.0f}" if var_limit else "N/A",
-            help="Maximum daily VaR allowed by the compliance system."
+            "VaR (99%)", f"{var_99_pct:.1%}" if var_99_pct else "N/A",
+            delta=f"${var_99:,.0f}" if var_99 else None,
+            delta_color="off",
+            help="Value at Risk (99% confidence): Estimated maximum loss in extreme conditions."
         )
     with cols[2]:
-        if var_95 and var_limit and var_limit > 0:
-            utilization = (var_95 / var_limit) * 100
+        if var_95_pct and var_limit_pct > 0:
+            utilization = (var_95_pct / var_limit_pct) * 100
             st.metric(
-                "Utilization", f"{utilization:.1f}%",
-                help="Percentage of the VaR limit currently being used."
+                "Utilization", f"{utilization:.0f}%",
+                help=f"VaR(95%) as percentage of the {var_limit_pct:.0%} limit."
             )
         else:
             st.metric("Utilization", "N/A", help="VaR utilization not available.")
+    with cols[3]:
+        commodity_str = ", ".join(commodities) if commodities else "None"
+        st.metric(
+            "Legs", f"{pos_count}",
+            help=f"Option contract legs across: {commodity_str}"
+        )
 
-    enforcement = var_state.get("enforcement_mode", "unknown")
-    last_comp = var_state.get('last_computed', 'unknown')
-    st.caption(f"Enforcement mode: **{enforcement}** | Last computed: {last_comp} ({_relative_time(last_comp)})")
+    # Staleness check
+    import time as _time
+    computed_epoch = var_state.get("computed_epoch", 0)
+    if computed_epoch:
+        age_hours = (_time.time() - computed_epoch) / 3600
+        age_label = f"{age_hours * 60:.0f}m ago" if age_hours < 1 else f"{age_hours:.1f}h ago"
+    else:
+        age_label = "unknown"
+    status = var_state.get("last_attempt_status", "OK")
+    st.caption(f"Last computed: {age_label} | Status: **{status}**")
+    if status == "FAILED":
+        st.warning(f"Last VaR computation failed: {var_state.get('last_attempt_error', 'Unknown')}")
 else:
     st.info("No VaR state found. VaR calculator has not run yet.")

--- a/tests/test_ui_ux.py
+++ b/tests/test_ui_ux.py
@@ -315,8 +315,9 @@ class TestPortfolioUX(unittest.TestCase):
             "Daily P&L",
             "Drawdown",
             "VaR (95%)",
-            "VaR Limit",
+            "VaR (99%)",
             "Utilization",
+            "Legs",
         ]
         found_metrics = {m: False for m in target_metrics}
 


### PR DESCRIPTION
## Summary
All 4 sections of the Portfolio page (`pages/9_Portfolio.py`) were reading non-existent or stale data. Every section now reads from fields that actually exist.

- **Section 1 (Drawdown)**: Was using `(starting_equity - equity) / starting_equity` — an intraday measure. Now uses `(peak_equity - equity) / peak_equity` matching the circuit breaker semantics.
- **Section 2 (Position Breakdown)**: Was reading `portfolio_risk_state.json` positions which only incremented on entry and never decremented on close. Now queries TMS live via `get_active_theses()` per commodity — matches Cockpit page behavior.
- **Section 3 (Engine Health)**: Was reading `active_theses`, `cycle_count`, `last_cycle_time` from `state.json` — none of these keys exist. Always showed "0 Theses" and "Pulse: unknown". Now uses live TMS count and `sensors.last_ib_success` timestamp.
- **Section 4 (VaR)**: Was reading `var_limit`, `enforcement_mode`, `last_computed` from `var_state.json` — none exist in `VaRResult`. Now reads actual fields (`var_95_pct`, `var_99_pct`, `position_count`, `commodities`, `computed_epoch`) and gets `var_limit_pct` from `config.json`.

## Test plan
- [x] All 882 tests pass (including updated `test_portfolio_metric_tooltips`)
- [ ] Visual: Portfolio page shows accurate thesis counts matching Cockpit
- [ ] Visual: Engine Health shows real timestamps and thesis counts
- [ ] Visual: VaR section shows percentage + dollar values with staleness indicator
- [ ] Visual: Drawdown matches circuit breaker peak-to-trough measure

🤖 Generated with [Claude Code](https://claude.com/claude-code)