### PR TITLE
Fix 5 production bugs: VaR, fill tasks, PRG guards

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -3254,6 +3254,19 @@ async def run_emergency_cycle(trigger: SentinelTrigger, config: dict, ib: IB):
                      await emergency_hard_close(config)
                      return
 
+            # === Portfolio-wide risk gate (Phase 3: SharedContext) ===
+            try:
+                from trading_bot.data_dir_context import get_engine_runtime
+                _ert = get_engine_runtime()
+                if _ert and _ert.shared and _ert.shared.portfolio_guard:
+                    _allowed, _prg_reason = await _ert.shared.portfolio_guard.can_open_position(_ert.ticker, 0)
+                    if not _allowed:
+                        logger.warning(f"Emergency cycle BLOCKED by PortfolioRiskGuard: {_prg_reason}")
+                        _sentinel_diag.info(f"OUTCOME {trigger.source}: BLOCKED (PRG: {_prg_reason})")
+                        return
+            except Exception as _prg_e:
+                logger.debug(f"PRG check in emergency cycle failed (non-fatal): {_prg_e}")
+
             # === Generate Cycle ID for prediction tracking ===
             active_ticker = config.get('commodity', {}).get('ticker', config.get('symbol', 'KC'))
             cycle_id = generate_cycle_id(active_ticker)
@@ -4918,14 +4931,24 @@ async def guarded_generate_orders(config: dict, schedule_id: str = None):
     # v3.1: Check equity data freshness before cycle
     await check_and_recover_equity_data(config)
 
+    # === Sync portfolio-wide position count from TMS (live, not stale file) ===
+    from trading_bot.data_dir_context import get_engine_runtime
+    rt = get_engine_runtime()
+    if rt and rt.shared and rt.shared.portfolio_guard:
+        try:
+            _tms = TransactiveMemory()
+            _active = _tms.get_active_theses()
+            _count = len(_active) if _active else 0
+            await rt.shared.portfolio_guard.update_positions(rt.ticker, _count, 0)
+        except Exception as _up_e:
+            logger.debug(f"Scheduled path: PRG position sync failed (non-fatal): {_up_e}")
+
     _bg = _get_budget_guard()
     if _bg and _bg.is_budget_hit:
         logger.warning("Budget hit - skipping scheduled orders.")
         return
 
     # === Portfolio-wide risk gate (Phase 3: SharedContext) ===
-    from trading_bot.data_dir_context import get_engine_runtime
-    rt = get_engine_runtime()
     if rt and rt.shared and rt.shared.portfolio_guard:
         allowed, reason = await rt.shared.portfolio_guard.can_open_position(rt.ticker, 0)
         if not allowed:

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -1709,6 +1709,7 @@ async def place_queued_orders(config: dict, orders_list: list = None, connection
         return  # Fail closed - cannot place orders without connection
 
     live_orders = {} # Dictionary to track order status by orderId
+    _fill_tasks = []  # Collect fill handler tasks so we can await them before disconnect
 
     # --- Event Handlers ---
     def on_order_status(trade: Trade):
@@ -1743,6 +1744,7 @@ async def place_queued_orders(config: dict, orders_list: list = None, connection
             logger.info(f"Fill received for leg {leg_con_id} in order {order_id}. Processing with Position ID {position_uuid}.")
             fill_task = asyncio.create_task(_handle_and_log_fill(ib, trade, fill, combo_perm_id, position_uuid, decision_data, config))
             fill_task.add_done_callback(lambda t: _log_task_exception(t, f"fill_logging_{order_id}"))
+            _fill_tasks.append(fill_task)
 
             order_details['filled_legs'].add(leg_con_id)
             order_details['fill_prices'][leg_con_id] = fill.execution.avgPrice
@@ -2580,6 +2582,25 @@ async def place_queued_orders(config: dict, orders_list: list = None, connection
     finally:
         # NOTE: _recorded_thesis_positions is cleared at START of next run,
         # not here, to avoid racing with inflight _handle_and_log_fill tasks.
+
+        # Await all inflight fill handler tasks before disconnecting IB.
+        # Without this, fill tasks that create TMS theses or trigger CONTRADICT
+        # auto-close would lose the IB connection mid-flight.
+        if _fill_tasks:
+            pending = [t for t in _fill_tasks if not t.done()]
+            if pending:
+                logger.info(f"Awaiting {len(pending)} inflight fill tasks before disconnect...")
+                try:
+                    await asyncio.wait_for(
+                        asyncio.gather(*pending, return_exceptions=True),
+                        timeout=15.0
+                    )
+                    logger.info("All fill tasks completed.")
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        f"Fill task await timed out after 15s — "
+                        f"{sum(1 for t in pending if not t.done())} tasks still pending"
+                    )
 
         try:
             if ib.isConnected():

--- a/trading_bot/var_calculator.py
+++ b/trading_bot/var_calculator.py
@@ -28,10 +28,34 @@ from typing import Any, Optional
 
 import numpy as np
 
-from trading_bot.utils import price_option_black_scholes, get_dollar_multiplier
+from trading_bot.utils import price_option_black_scholes, get_dollar_multiplier, CENTS_INDICATORS
 from config.commodity_profiles import get_commodity_profile
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_dollar_multiplier(symbol: str, ib_multiplier: str = None) -> float:
+    """Resolve dollar multiplier per 1.0 price unit move for a given symbol.
+
+    Uses commodity profile to handle cents-quoted contracts (e.g., KC is quoted
+    in cents/lb, so 37500 lbs * 1 cent = $375, not $37500).
+    Falls back to raw IB multiplier if profile lookup fails.
+    """
+    try:
+        profile = get_commodity_profile(symbol)
+        raw = float(profile.contract.contract_size)
+        unit = profile.contract.unit.lower()
+        if any(ind in unit for ind in CENTS_INDICATORS):
+            return raw / 100.0
+        return raw
+    except (ValueError, KeyError):
+        # Unknown commodity — fall back to IB multiplier
+        if ib_multiplier:
+            try:
+                return float(ib_multiplier)
+            except (ValueError, TypeError):
+                pass
+        return 375.0  # conservative KC default
 
 # --- Module-level state ---
 _var_data_dir: str = "data"
@@ -374,10 +398,7 @@ class PortfolioVaRCalculator:
                     )
                     continue
 
-                try:
-                    multiplier = float(c.multiplier) if c.multiplier else get_dollar_multiplier(config)
-                except (ValueError, TypeError):
-                    multiplier = get_dollar_multiplier(config)
+                multiplier = _resolve_dollar_multiplier(ticker_sym, c.multiplier)
 
                 underlying_price_map[ticker_sym] = item.marketPrice
 
@@ -494,10 +515,7 @@ class PortfolioVaRCalculator:
                     )
 
                 ticker_sym = c.symbol
-                try:
-                    multiplier = float(c.multiplier) if c.multiplier else get_dollar_multiplier(config)
-                except (ValueError, TypeError):
-                    multiplier = get_dollar_multiplier(config)
+                multiplier = _resolve_dollar_multiplier(ticker_sym, c.multiplier)
 
                 # Calculate time to expiry
                 expiry_str = c.lastTradeDateOrContractMonth
@@ -515,20 +533,33 @@ class PortfolioVaRCalculator:
                     )
                     continue
 
-                # Validate option market price — IB returns -1.0 for "no data"
+                # Always compute B-S model price for cross-validation
+                r_rate = config.get("compliance", {}).get("var_risk_free_rate", 0.04)
+                model_price = self._bs_price(
+                    und_price, float(c.strike), expiry_years,
+                    r_rate, iv_val, c.right
+                )
+
+                # Validate option market price — IB returns -1.0 for "no data",
+                # and under FORCE_DELAYED_DATA returns averageCost as marketPrice
                 opt_price = item.marketPrice
                 if opt_price is None or opt_price <= 0 or (isinstance(opt_price, float) and np.isnan(opt_price)):
-                    # Fallback: use B-S model price as current_price (#1164)
-                    r_rate = config.get("compliance", {}).get("var_risk_free_rate", 0.04)
-                    model_price = self._bs_price(
-                        und_price, float(c.strike), expiry_years,
-                        r_rate, iv_val, c.right
-                    )
                     logger.warning(
                         f"Invalid market price for option {c.localSymbol}: "
                         f"{opt_price} — using B-S model price {model_price:.4f}"
                     )
                     opt_price = model_price
+                elif model_price > 0:
+                    # Cross-validate: if IB price deviates >80% from B-S model,
+                    # it's likely averageCost under delayed data, not a live quote
+                    deviation = abs(opt_price - model_price) / model_price
+                    if deviation > 0.80:
+                        logger.warning(
+                            f"Market price for {c.localSymbol} ({opt_price:.4f}) "
+                            f"deviates {deviation:.0%} from B-S model ({model_price:.4f}) "
+                            f"— likely stale/averageCost. Substituting model price."
+                        )
+                        opt_price = model_price
 
                 snapshots.append(PositionSnapshot(
                     symbol=ticker_sym,


### PR DESCRIPTION
## Summary

Fixes 5 confirmed production bugs identified during log/data audit:

- **P0 — VaR stale prices**: Under `FORCE_DELAYED_DATA`, IB returns `averageCost` as `marketPrice` for illiquid options. VaR now always computes B-S model price and cross-validates — if IB price deviates >80%, substitutes model price. Fixes VaR returning $0 with 13 open positions.
- **P0 — Fill task lifecycle**: `_handle_and_log_fill` tasks were fire-and-forget (`asyncio.create_task` never awaited). The monitoring loop would exit and release the IB connection while fill tasks (including CONTRADICT auto-close) were still running. Now collects tasks and awaits them with 15s timeout before disconnect.
- **P2 — Dollar multiplier 100x off**: `float(c.multiplier)` returns 37500 (contract size) for KC, but correct dollar multiplier is 375 (cents-quoted). Added `_resolve_dollar_multiplier()` using commodity profile lookup for both FUT and FOP blocks.
- **P1 — Emergency cycle skips PRG**: Emergency cycles checked `DrawdownGuard` but not `PortfolioRiskGuard`. Added PRG gate after drawdown checks so emergency cycles respect account-wide HALT status.
- **P1 — `update_positions()` not called from scheduled path**: Only the emergency path called `update_positions()`. Added TMS-based position count sync in `guarded_generate_orders()` before the PRG gate.

## Test plan

- [x] All 882 tests pass
- [x] `py_compile` passes on all 3 modified files
- [ ] Verify VaR no longer returns $0 in production (delayed data mode)
- [ ] Verify fill tasks complete before IB disconnect in order placement logs
- [ ] Verify emergency cycles log PRG check

🤖 Generated with [Claude Code](https://claude.com/claude-code)