### PR TITLE
Fix cross-commodity contamination in stale/emergency close

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -4548,9 +4548,17 @@ async def emergency_hard_close(config: dict):
                 if not trade_ledger.empty and 'local_symbol' in trade_ledger.columns:
                     sym_rows = trade_ledger[trade_ledger['local_symbol'] == sym]
                     if not sym_rows.empty:
-                        earliest = pd.Timestamp(sym_rows['timestamp'].min())
+                        # Use most recent opening entry (matching direction), not
+                        # earliest-ever.  Old closed positions for the same symbol
+                        # must not inflate the age of the current live position.
+                        action_dir = 'BUY' if pos.position > 0 else 'SELL'
+                        dir_rows = sym_rows[sym_rows['action'] == action_dir]
+                        ref_ts = pd.Timestamp(
+                            dir_rows['timestamp'].max() if not dir_rows.empty
+                            else sym_rows['timestamp'].max()
+                        )
                         trading_days = pd.date_range(
-                            start=earliest.date(), end=today_date, freq=custom_bday
+                            start=ref_ts.date(), end=today_date, freq=custom_bday
                         )
                         if len(trading_days) >= max_holding_days:
                             stale_symbols.add(sym)

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -2815,7 +2815,7 @@ async def close_stale_positions(config: dict, connection_purpose: str = "orchest
         # --- 4. FIFO Reconstruction and Age Verification ---
         # Map unique local symbols to live positions
         # Note: If multiple accounts, this assumes unique local_symbol per account or aggregated.
-        live_pos_map = {p.contract.localSymbol: p for p in live_positions if p.position != 0}
+        live_pos_map = {p.contract.localSymbol: p for p in non_zero_positions}
 
         for symbol, pos in live_pos_map.items():
             live_qty = abs(pos.position)


### PR DESCRIPTION
## Summary
- **Bug 1**: `close_stale_positions` used unfiltered `live_positions` (all IBKR account) instead of `non_zero_positions` (commodity-filtered). NG options (LNE*) appeared as KC orphans. On weekly close, they would have been **closed by the wrong engine**.
- **Bug 2**: `emergency_hard_close` used `timestamp.min()` (oldest-ever entry for a symbol) for age calculation. Historical entries from closed positions inflated age — a 1-day-old bear put spread was market-closed as "stale".

## Fix
- Bug 1: Use `non_zero_positions` (already filtered at line 2783) in the FIFO loop
- Bug 2: Use `timestamp.max()` of most recent opening entry matching current direction

## Test plan
- [x] 882 tests pass
- [ ] Deploy and verify: no LNE orphans in KC notifications, no incorrect emergency closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)