### PR TITLE
Exclude manual reconciliation entries from Flex comparison

### DIFF
--- a/reconcile_trades.py
+++ b/reconcile_trades.py
@@ -773,15 +773,17 @@ async def main(lookback_days: int = None, config: dict = None):
         logger.warning("Local trade ledger is empty. All fetched IB trades will be considered missing.")
 
     # --- 4b. Exclude synthetic bookkeeping entries from comparison ---
-    # PHANTOM_RECONCILIATION entries are internal synthetic closes (zero-value,
-    # fabricated timestamps) that will never match any IB Flex record. Including
-    # them inflates the "superfluous" count with false positives every cycle.
+    # These entries are internal synthetic closes (zero-value, fabricated
+    # timestamps) that will never match any IB Flex record.  Including them
+    # inflates the "superfluous" count with false positives every cycle.
     if not local_trades_df.empty and 'reason' in local_trades_df.columns:
-        synthetic_mask = local_trades_df['reason'].fillna('').str.contains('PHANTOM_RECONCILIATION')
+        synthetic_mask = local_trades_df['reason'].fillna('').str.contains(
+            'PHANTOM_RECONCILIATION|Ledger reconciliation', case=False
+        )
         n_synthetic = synthetic_mask.sum()
         if n_synthetic > 0:
             local_trades_df = local_trades_df[~synthetic_mask]
-            logger.info(f"Excluded {n_synthetic} synthetic PHANTOM_RECONCILIATION entries from reconciliation comparison.")
+            logger.info(f"Excluded {n_synthetic} synthetic/manual reconciliation entries from comparison.")
 
     # --- 5. Filter trades to the last 33 days for comparison ---
     # v3.1: Configurable lookback with environment override


### PR DESCRIPTION
## Summary
Entries with reason containing `Ledger reconciliation` are synthetic bookkeeping (no real IBKR execution) — same concept as existing `PHANTOM_RECONCILIATION` exclusion. Without this, they appear as "superfluous" every reconciliation cycle.

## Context
Manual close entries were added to the ledger to fix position count mismatches (positions closed externally, in TWS, or phantom reconciliation entries). These will never have matching Flex executions.

## Test plan
- [x] 882 tests pass
- [ ] Next reconciliation run shows 0 superfluous for these entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)