### PR TITLE
Fix BAG order ratio for multi-qty spreads (Error 321)

### DIFF
--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -2920,30 +2920,25 @@ async def close_stale_positions(config: dict, connection_purpose: str = "orchest
                     contract.currency = final_legs_list[0]['currency']
                     contract.exchange = final_legs_list[0]['exchange'] or config.get('exchange', 'SMART')
 
+                    # IB BAG orders: ratio must be 1 (per leg), totalQuantity
+                    # carries the size.  Compute GCD so unbalanced legs are
+                    # still possible (e.g. 2:1 ratio condor).
+                    from math import gcd
+                    from functools import reduce
+                    leg_qtys = [int(leg['quantity']) for leg in final_legs_list]
+                    qty_gcd = reduce(gcd, leg_qtys)
+
                     combo_legs = []
                     for leg in final_legs_list:
                         combo_leg = ComboLeg()
                         combo_leg.conId = leg['conId']
-                        combo_leg.ratio = int(leg['quantity']) # Assuming integer ratios for now
+                        combo_leg.ratio = int(leg['quantity']) // qty_gcd
                         combo_leg.action = leg['action']
                         combo_leg.exchange = leg['exchange'] or config.get('exchange', 'SMART')
                         combo_legs.append(combo_leg)
 
                     contract.comboLegs = combo_legs
-
-                    # For BAG orders, the totalQuantity is usually 1 (multiplied by ratio)
-                    # Use the GCD of quantities if possible, but for simple closes, usually ratio is quantity and bag size is 1.
-                    # Or ratio is 1 and bag size is quantity?
-                    # If we have 5 spreads, we usually set ratio 1, size 5.
-                    # Here we might have different quantities for different legs? (Unbalanced close).
-                    # If quantities differ (e.g. 2 calls, 1 put), we can't do a simple 1:1 spread.
-                    # We will assume balanced spread or use ratio=qty, size=1.
-
-                    # Logic: Find GCD of quantities?
-                    # Simplification: Set Ratio = Quantity, Bag Order Size = 1.
-                    # This works for "Closing what we have".
-
-                    order_size = 1
+                    order_size = qty_gcd
 
                     logger.info(f"Constructed BAG order for Pos ID {pos_id}: {[l.action + ' ' + str(l.ratio) + ' x ' + str(l.conId) for l in combo_legs]}")
 


### PR DESCRIPTION
## Summary
IB rejects BAG orders with `ratio=N, totalQuantity=1`. For qty=2 bear put spreads in NG, the stale close sent `ratio=2` per leg — IB returned Error 321 "Invalid leg ratio", cancelling all 3 close attempts.

The successful close (qty=1 spread) worked because `ratio=1` is valid.

## Fix
Compute GCD of leg quantities. Set `ratio=qty/GCD` (usually 1) and `order_size=GCD`. For a 2-leg spread with qty=2 each: `ratio=1, totalQuantity=2`.

## Test plan
- [x] 882 tests pass
- [ ] Next stale close of multi-qty NG spreads succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)