### PR TITLE
fix: YYYYMM contract dates incorrectly skipped in Brier reconciliation

### DIFF
--- a/trading_bot/reconciliation.py
+++ b/trading_bot/reconciliation.py
@@ -310,7 +310,18 @@ async def _process_reconciliation(ib: IB, df: pd.DataFrame, config: dict, file_p
                 # returns no data for long-expired contracts (Error 162),
                 # and retrying every cycle is futile.
                 try:
-                    expiry_date = datetime.strptime(last_trade_date, '%Y%m%d')
+                    if len(last_trade_date) == 6:
+                        # YYYYMM format — use last day of month
+                        expiry_date = datetime.strptime(last_trade_date, '%Y%m')
+                        # Advance to last day of that month
+                        if expiry_date.month == 12:
+                            expiry_date = expiry_date.replace(month=12, day=31)
+                        else:
+                            expiry_date = expiry_date.replace(
+                                month=expiry_date.month + 1, day=1
+                            ) - timedelta(days=1)
+                    else:
+                        expiry_date = datetime.strptime(last_trade_date, '%Y%m%d')
                     if (datetime.now() - expiry_date).days > 60:
                         logger.info(
                             f"Skipping reconciliation for expired contract "


### PR DESCRIPTION
## Summary

- `strptime('202612', '%Y%m%d')` silently parses as **January 2, 2026** (not December 2026), because `%m` consumes just `1` and `%d` consumes `2`
- This made KCZ6 and CCZ6 appear 62 days old → skipped as "expired"
- All Z6 council_history rows permanently stuck with no `exit_price` or `actual_trend_direction`
- ~125 KC and ~123 CC Brier predictions from Mar 3+ were blocked from resolution
- Fix: detect 6-char `YYYYMM` format and parse correctly with `%Y%m`, using last day of month for comparison

## Test plan

- [x] Verified `202612` → Dec 31, 2026 → PROCESS (was incorrectly SKIP)
- [x] Verified `202503` → Mar 31, 2025 → SKIP (truly expired, still works)
- [x] Verified 8-digit `20260319` → unchanged behavior
- [x] 882 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)