### PR TITLE
🎨 Palette: Standardize Contextual Clarity via Tooltips on Streamlit Metrics

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -53,3 +53,7 @@ This journal records CRITICAL UX/accessibility learnings.
 ## 2026-03-04 - Semantic Highlighting for Task Failures
 **Learning:** Using `delta_color="inverse"` for failure-prone counts (like Overdue Tasks) ensures that non-zero values are highlighted in red (Streamlit default for inverse delta), making operational issues stand out even when the primary metric is numeric.
 **Action:** Apply the inverse delta pattern to metrics where "up" is "bad" to ensure consistent visual signaling of system friction.
+
+## 2026-03-05 - Completing the Micro-UX Tooltip Coverage
+**Learning:** During a codebase audit, several Streamlit metric components (`st.metric`) across utility and financial pages were found to be missing the `help` parameter. Consistency in providing native tooltips for metrics (like System Health, Failed Checks, and Realized P&L) is critical for a predictable user experience, as users learn to rely on hover states for context.
+**Action:** Always ensure that `st.metric` calls include a descriptive `help` attribute, especially for derived or aggregated values where the calculation or significance might not be immediately obvious.

--- a/pages/4_Financials.py
+++ b/pages/4_Financials.py
@@ -75,7 +75,7 @@ with metric_cols[2]:
             help="Sum of P&L from reconciled trades in council_history"
         )
     else:
-        st.metric("Realized P&L", "$0.00")
+        st.metric("Realized P&L", "$0.00", help="Sum of P&L from reconciled trades in council_history")
 
 # Pre-compute graded trades for sections that need it
 graded_fin = grade_decision_quality(council_df) if not council_df.empty else pd.DataFrame()

--- a/pages/5_Utilities.py
+++ b/pages/5_Utilities.py
@@ -549,7 +549,7 @@ with digest_cols[0]:
                         for i, (key, (label, icon)) in enumerate(labels.items()):
                             with comp_cols[i]:
                                 val = components.get(key)
-                                st.metric(f"{icon} {label}", f"{val:.2f}" if val is not None else "N/A")
+                                st.metric(f"{icon} {label}", f"{val:.2f}" if val is not None else "N/A", help=f"Health score for the {label} component (0.0 to 1.0).")
 
                     # Executive summary
                     st.info(f"**Summary:** {digest.get('executive_summary', 'N/A')}")
@@ -616,10 +616,10 @@ with digest_cols[1]:
                 last_digest = json.load(f)
             score = last_digest.get('system_health_score', {}).get('overall')
             if score is not None:
-                st.metric("Health Score", f"{score:.2f}")
+                st.metric("Health Score", f"{score:.2f}", help="Overall system health score from the last digest (0.0 to 1.0).")
             opps = last_digest.get('improvement_opportunities', [])
             high_count = sum(1 for o in opps if o.get('priority') == 'HIGH')
-            st.metric("Issues", f"{high_count} HIGH / {len(opps)} total")
+            st.metric("Issues", f"{high_count} HIGH / {len(opps)} total", help="Number of HIGH priority issues identified in the last digest.")
         else:
             st.caption("No previous digest found")
     except Exception:
@@ -752,13 +752,13 @@ if run_validation:
                         total = summary.get('total', 0)
                         passed = summary.get('passed', 0)
                         health = (passed / total * 100) if total > 0 else 0
-                        st.metric("Health", f"{health:.1f}%")
+                        st.metric("Health", f"{health:.1f}%", help="Percentage of successful validation checks.")
                     with metric_cols[1]:
-                        st.metric("Passed", summary.get('passed', 0), delta=None)
+                        st.metric("Passed", summary.get('passed', 0), delta=None, help="Number of validation checks that passed successfully.")
                     with metric_cols[2]:
-                        st.metric("Warnings", summary.get('warnings', 0), delta=None, delta_color="off")
+                        st.metric("Warnings", summary.get('warnings', 0), delta=None, delta_color="off", help="Number of validation checks that returned a warning.")
                     with metric_cols[3]:
-                        st.metric("Failures", summary.get('failed', 0), delta=None, delta_color="inverse")
+                        st.metric("Failures", summary.get('failed', 0), delta=None, delta_color="inverse", help="Number of validation checks that failed.")
 
                     # Results table
                     if data.get('checks'):

--- a/pages/9_Portfolio.py
+++ b/pages/9_Portfolio.py
@@ -146,7 +146,7 @@ if active_tickers:
                     )
                 )
             else:
-                st.metric(ticker, "No data", delta="OFFLINE", delta_color="inverse")
+                st.metric(ticker, "No data", delta="OFFLINE", delta_color="inverse", help=f"Engine state file not found for {ticker}")
 else:
     st.info("No engine state files found.")
 


### PR DESCRIPTION
💡 What: Added the `help` parameter to multiple `st.metric` calls in `pages/4_Financials.py`, `pages/5_Utilities.py`, and `pages/9_Portfolio.py`.
🎯 Why: In a data-dense trading dashboard, raw numbers or status texts (like "Health Score" or "Realized P&L") can lack context for the user. Adding the native Streamlit `help` tooltip provides immediate, accessible explanations without cluttering the main UI.
📸 Before/After: Generated in local verification step (tooltips are now visible upon hovering over the `?` icon next to metrics).
♿ Accessibility: Improves accessibility by explicitly defining the purpose or calculation behind derived metrics, assisting users with cognitive load and clarifying system states.

Learnings were recorded in `.jules/palette.md`.

---
*PR created automatically by Jules for task [8928897457800245451](https://jules.google.com/task/8928897457800245451) started by @rozavala*