### PR TITLE
config: disable NG passive emergency dry run in DEV

### DIFF
--- a/config/profiles/ng.json
+++ b/config/profiles/ng.json
@@ -22,7 +22,7 @@
         "emergency_cooldown_seconds": 1800,
         "emergency_council_timeout_seconds": 300,
         "passive_new_positions_only": true,
-        "emergency_dry_run": true,
+        "emergency_dry_run": false,
         "blackout_windows": [
             {
                 "name": "EIA Natural Gas Storage Report",


### PR DESCRIPTION
## Summary

- Disables `emergency_dry_run` for NG in DEV so the full passive emergency pipeline (council invocation on 7%+ price moves) can be validated end-to-end
- Three-tier market state model deployed cleanly: zero errors across all sentinels, JSON profile loading working, NG correctly enters PASSIVE with IB connections maintained

## Test plan

- [x] Verified clean deployment with 0 errors (excluding transient IB Gateway connectivity)
- [x] NG enters PASSIVE mode and maintains IB connections overnight
- [x] KC/CC behavior unchanged (SLEEPING, no IB connections)
- [ ] Monitor for DRY RUN → live emergency council invocation on next 7%+ NG move

🤖 Generated with [Claude Code](https://claude.com/claude-code)