### PR TITLE
fix: DSPy data path and class balance for ORPHANED/NEUTRAL

### DIFF
--- a/scripts/optimize_prompts.py
+++ b/scripts/optimize_prompts.py
@@ -177,7 +177,7 @@ def main():
     min_for_suggest = dspy_config.get("min_examples_for_suggest", DEFAULT_MIN_EXAMPLES_FOR_SUGGEST)
 
     # Load data
-    dataset = CouncilDataset(data_dir)
+    dataset = CouncilDataset(os.path.join(data_dir, ticker))
     try:
         predictions = dataset.load()
     except FileNotFoundError as e:


### PR DESCRIPTION
## Summary
- `--ticker KC` was used for output paths but never injected into the input `CouncilDataset` data path — script looked for `data/agent_accuracy_structured.csv` instead of `data/KC/agent_accuracy_structured.csv`
- ORPHANED predictions (no valid ground truth) were included in training data and poisoned class balance — 1 ORPHANED row out of 209 made the minority class 0.5%, blocking 5 of 9 agents
- `_class_balance()` now only considers BULLISH/BEARISH for balance calculation — a single stray NEUTRAL outcome shouldn't block optimization

**Before:** 4/9 agents ready, 5 blocked by false class imbalance  
**After:** 9/9 agents ready

## Test plan
- [x] `python scripts/optimize_prompts.py --ticker KC` — all 9 agents show YES, 1,774 resolved predictions
- [ ] `python scripts/optimize_prompts.py --ticker NG` — works for NG
- [ ] `python scripts/optimize_prompts.py --ticker CC` — works for CC

🤖 Generated with [Claude Code](https://claude.com/claude-code)