### PR TITLE
feat: Dashboard date filtering + Brier chart smoothing

### DIFF
--- a/_date_filter.py
+++ b/_date_filter.py
@@ -1,0 +1,32 @@
+"""Reusable sidebar date range filter for dashboard pages."""
+
+import streamlit as st
+import pandas as pd
+from datetime import timedelta
+
+
+def date_range_filter(df, timestamp_col='timestamp', key_prefix=''):
+    """Sidebar date range picker. Returns filtered DataFrame."""
+    if df.empty or timestamp_col not in df.columns:
+        return df
+    ts = pd.to_datetime(df[timestamp_col], errors='coerce')
+    valid = ts.dropna()
+    if valid.empty:
+        return df
+    min_date = valid.min().date()
+    max_date = valid.max().date()
+    if min_date == max_date:
+        return df
+    default_start = max(min_date, max_date - timedelta(days=30))
+    date_val = st.sidebar.date_input(
+        "Date range", value=(default_start, max_date),
+        min_value=min_date, max_value=max_date,
+        key=f"{key_prefix}_daterange"
+    )
+    # date_input may return a single date if user hasn't finished selecting
+    if isinstance(date_val, (list, tuple)) and len(date_val) == 2:
+        start, end = date_val
+    else:
+        return df
+    mask = (ts.dt.date >= start) & (ts.dt.date <= end)
+    return df[mask].copy()

--- a/dashboard.py
+++ b/dashboard.py
@@ -42,6 +42,7 @@ from dashboard_utils import (
     get_starting_capital,
     _relative_time,
 )
+from _date_filter import date_range_filter
 
 config = get_config()
 
@@ -426,6 +427,7 @@ card_cols = st.columns(max(len(active_commodities), 1))
 for idx, ticker in enumerate(active_commodities):
     meta = _get_commodity_meta(ticker)
     council_df = load_council_history_for_commodity(ticker)
+    council_df = date_range_filter(council_df, key_prefix=f'home_{ticker}')
 
     with card_cols[idx]:
         st.markdown(f"#### {meta['emoji']} {meta['name']}")
@@ -472,6 +474,7 @@ try:
 
     if all_dfs:
         merged = pd.concat(all_dfs, ignore_index=True)
+        merged = date_range_filter(merged, key_prefix='home_activity')
         merged = merged.sort_values("timestamp", ascending=False).head(10).copy()
 
         graded_merged = grade_decision_quality(merged)

--- a/pages/2_The_Scorecard.py
+++ b/pages/2_The_Scorecard.py
@@ -28,6 +28,7 @@ from dashboard_utils import (
     _resolve_data_path_for,
 )
 import numpy as np
+from _date_filter import date_range_filter
 
 
 def create_process_outcome_matrix(df: pd.DataFrame):
@@ -129,6 +130,7 @@ st.caption(
 
 # --- Load Data ---
 council_df = load_council_history(ticker=ticker)
+council_df = date_range_filter(council_df, key_prefix='scorecard')
 config = get_config()
 
 if council_df.empty:

--- a/pages/4_Financials.py
+++ b/pages/4_Financials.py
@@ -20,6 +20,7 @@ from dashboard_utils import (
     get_config,
     grade_decision_quality
 )
+from _date_filter import date_range_filter
 
 st.set_page_config(layout="wide", page_title="Trade Analytics | Real Options")
 
@@ -32,6 +33,8 @@ st.caption("Per-commodity strategy performance, trade breakdown, and execution l
 # --- Load Data ---
 trade_df = load_trade_data(ticker=ticker)
 council_df = load_council_history(ticker=ticker)
+council_df = date_range_filter(council_df, key_prefix='financials')
+trade_df = date_range_filter(trade_df, key_prefix='financials_trades')
 config = get_config()
 
 st.markdown("---")

--- a/pages/7_Brier_Analysis.py
+++ b/pages/7_Brier_Analysis.py
@@ -18,6 +18,7 @@ import plotly.graph_objects as go
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from dashboard_utils import _resolve_data_path_for
+from _date_filter import date_range_filter
 
 st.set_page_config(layout="wide", page_title="Brier Analysis | Real Options")
 
@@ -324,7 +325,13 @@ st.caption("Agents above 1.0 have earned more influence through accurate predict
 
 weight_df = load_weight_evolution(ticker)
 
+weight_df = date_range_filter(weight_df, key_prefix='brier')
+
 if not weight_df.empty and len(weight_df) >= 5:
+    smoothing = st.slider("Smoothing window (cycles)", 1, 30, 7,
+                           help="Rolling average window. 1 = raw data.",
+                           key="brier_smoothing")
+
     available_agents = sorted(weight_df['agent'].unique())
 
     _AGENT_COLORS = {
@@ -350,12 +357,13 @@ if not weight_df.empty and len(weight_df) >= 5:
 
     for agent in available_agents:
         agent_data = weight_df[weight_df['agent'] == agent].sort_values('timestamp')
+        y_vals = agent_data['final_weight'].rolling(window=smoothing, min_periods=1).mean()
         display_name = _DISPLAY_NAMES.get(agent, agent.title())
         color = _AGENT_COLORS.get(agent, None)
 
         fig.add_trace(go.Scatter(
             x=agent_data['timestamp'],
-            y=agent_data['final_weight'],
+            y=y_vals,
             mode='lines',
             name=display_name,
             line=dict(color=color, width=2) if color else dict(width=2),

--- a/pages/8_LLM_Monitor.py
+++ b/pages/8_LLM_Monitor.py
@@ -25,6 +25,7 @@ from dashboard_utils import (
     load_llm_daily_costs,
     get_config,
 )
+from _date_filter import date_range_filter
 
 config = get_config()
 
@@ -239,12 +240,12 @@ st.markdown("---")
 st.subheader("Daily Cost Trend")
 
 costs_df = load_llm_daily_costs(ticker)
+costs_df = date_range_filter(costs_df, timestamp_col='date', key_prefix='llm')
 
 if not costs_df.empty and 'date' in costs_df.columns and 'total_usd' in costs_df.columns:
     import plotly.graph_objects as go
 
-    # Last 30 days
-    costs_df = costs_df.sort_values('date').tail(30)
+    costs_df = costs_df.sort_values('date')
 
     fig_trend = go.Figure()
 


### PR DESCRIPTION
## Summary
- **Date range filtering (#1200):** Adds a reusable sidebar date range picker (`_date_filter.py`) to the dashboard home, Scorecard, Trade Analytics, Brier Analysis, and LLM Monitor pages. Defaults to last 30 days. Replaces hardcoded `.tail(30)` in LLM Monitor.
- **Brier chart smoothing (#1199):** Adds a rolling average slider (1–30 cycles, default 7) to the Agent Influence Over Time chart, reducing per-cycle noise while preserving raw data access at window=1.

## Test plan
- [x] All 6 modified files compile cleanly
- [x] Full test suite passes (913 tests, 0 failures)
- [ ] Visual: Sidebar date pickers appear on dashboard home, pages 2, 4, 7, 8
- [ ] Visual: Brier influence chart is smooth at default window=7, raw at 1
- [ ] Visual: Changing date range filters data correctly on each page

Closes #1199, closes #1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)