### PR TITLE
fix: One date picker per page and use EWM for smoother Brier chart

### DIFF
--- a/_date_filter.py
+++ b/_date_filter.py
@@ -5,28 +5,45 @@ import pandas as pd
 from datetime import timedelta
 
 
-def date_range_filter(df, timestamp_col='timestamp', key_prefix=''):
-    """Sidebar date range picker. Returns filtered DataFrame."""
+def date_range_picker(df, timestamp_col='timestamp', key='page'):
+    """Render ONE sidebar date range picker derived from a DataFrame's timestamps.
+
+    Returns (start_date, end_date) or None if the df is empty / single-day.
+    Call this once per page, then use apply_date_filter() on each DataFrame.
+    """
     if df.empty or timestamp_col not in df.columns:
-        return df
+        return None
     ts = pd.to_datetime(df[timestamp_col], errors='coerce')
     valid = ts.dropna()
     if valid.empty:
-        return df
+        return None
     min_date = valid.min().date()
     max_date = valid.max().date()
     if min_date == max_date:
-        return df
+        return None
     default_start = max(min_date, max_date - timedelta(days=30))
     date_val = st.sidebar.date_input(
         "Date range", value=(default_start, max_date),
         min_value=min_date, max_value=max_date,
-        key=f"{key_prefix}_daterange"
+        key=f"{key}_daterange"
     )
-    # date_input may return a single date if user hasn't finished selecting
     if isinstance(date_val, (list, tuple)) and len(date_val) == 2:
-        start, end = date_val
-    else:
+        return date_val[0], date_val[1]
+    return None
+
+
+def apply_date_filter(df, start, end, timestamp_col='timestamp'):
+    """Filter a DataFrame to rows where timestamp_col falls within [start, end]."""
+    if df.empty or timestamp_col not in df.columns:
         return df
+    ts = pd.to_datetime(df[timestamp_col], errors='coerce')
     mask = (ts.dt.date >= start) & (ts.dt.date <= end)
     return df[mask].copy()
+
+
+def date_range_filter(df, timestamp_col='timestamp', key_prefix='page'):
+    """Convenience: render picker + filter in one call. Use on single-df pages."""
+    dates = date_range_picker(df, timestamp_col, key=key_prefix)
+    if dates is None:
+        return df
+    return apply_date_filter(df, dates[0], dates[1], timestamp_col)

--- a/dashboard.py
+++ b/dashboard.py
@@ -42,7 +42,7 @@ from dashboard_utils import (
     get_starting_capital,
     _relative_time,
 )
-from _date_filter import date_range_filter
+from _date_filter import date_range_picker, apply_date_filter
 
 config = get_config()
 
@@ -422,12 +422,18 @@ else:
 st.markdown("---")
 st.markdown("### Commodity Summary")
 
+# Build a merged df to derive date bounds for the single page-level picker
+_all_council = {t: load_council_history_for_commodity(t) for t in active_commodities}
+_reference_df = pd.concat([d for d in _all_council.values() if not d.empty], ignore_index=True) if _all_council else pd.DataFrame()
+_home_dates = date_range_picker(_reference_df, key='home')
+
 card_cols = st.columns(max(len(active_commodities), 1))
 
 for idx, ticker in enumerate(active_commodities):
     meta = _get_commodity_meta(ticker)
-    council_df = load_council_history_for_commodity(ticker)
-    council_df = date_range_filter(council_df, key_prefix=f'home_{ticker}')
+    council_df = _all_council[ticker]
+    if _home_dates:
+        council_df = apply_date_filter(council_df, *_home_dates)
 
     with card_cols[idx]:
         st.markdown(f"#### {meta['emoji']} {meta['name']}")
@@ -466,15 +472,12 @@ st.markdown("---")
 st.markdown("### Recent Activity")
 
 try:
-    all_dfs = []
-    for ticker in active_commodities:
-        df = load_council_history_for_commodity(ticker)
-        if not df.empty:
-            all_dfs.append(df)
+    all_dfs = [d for d in _all_council.values() if not d.empty]
 
     if all_dfs:
         merged = pd.concat(all_dfs, ignore_index=True)
-        merged = date_range_filter(merged, key_prefix='home_activity')
+        if _home_dates:
+            merged = apply_date_filter(merged, *_home_dates)
         merged = merged.sort_values("timestamp", ascending=False).head(10).copy()
 
         graded_merged = grade_decision_quality(merged)

--- a/pages/4_Financials.py
+++ b/pages/4_Financials.py
@@ -20,7 +20,7 @@ from dashboard_utils import (
     get_config,
     grade_decision_quality
 )
-from _date_filter import date_range_filter
+from _date_filter import date_range_picker, apply_date_filter
 
 st.set_page_config(layout="wide", page_title="Trade Analytics | Real Options")
 
@@ -33,8 +33,10 @@ st.caption("Per-commodity strategy performance, trade breakdown, and execution l
 # --- Load Data ---
 trade_df = load_trade_data(ticker=ticker)
 council_df = load_council_history(ticker=ticker)
-council_df = date_range_filter(council_df, key_prefix='financials')
-trade_df = date_range_filter(trade_df, key_prefix='financials_trades')
+_fin_dates = date_range_picker(council_df, key='financials')
+if _fin_dates:
+    council_df = apply_date_filter(council_df, *_fin_dates)
+    trade_df = apply_date_filter(trade_df, *_fin_dates)
 config = get_config()
 
 st.markdown("---")

--- a/pages/7_Brier_Analysis.py
+++ b/pages/7_Brier_Analysis.py
@@ -357,7 +357,7 @@ if not weight_df.empty and len(weight_df) >= 5:
 
     for agent in available_agents:
         agent_data = weight_df[weight_df['agent'] == agent].sort_values('timestamp')
-        y_vals = agent_data['final_weight'].rolling(window=smoothing, min_periods=1).mean()
+        y_vals = agent_data['final_weight'].ewm(span=smoothing, min_periods=1).mean()
         display_name = _DISPLAY_NAMES.get(agent, agent.title())
         color = _AGENT_COLORS.get(agent, None)
 


### PR DESCRIPTION
- Refactor _date_filter.py into date_range_picker() + apply_date_filter() so pages with multiple DataFrames share a single sidebar widget
- Dashboard home: one picker drives both commodity cards and activity feed
- Financials: one picker drives both council and trade data
- Brier chart: switch from rolling mean to exponential weighted moving average (ewm) which decays smoothly instead of creating entry/exit bumps