### PR TITLE
fix: switch DSPy to enhanced_brier.json, remove legacy CSV paths

### DIFF
--- a/tests/test_brier_bridge.py
+++ b/tests/test_brier_bridge.py
@@ -71,19 +71,9 @@ class TestGetAgentReliability(unittest.TestCase):
 
 
 class TestRecordAgentPrediction(unittest.TestCase):
-    @patch('trading_bot.brier_bridge.datetime')
     @patch('trading_bot.brier_bridge._get_enhanced_tracker')
-    @patch('trading_bot.brier_scoring.get_brier_tracker')
-    def test_dual_write_both_systems(self, mock_legacy, mock_enhanced_fn, mock_dt):
-        """Before deprecation date, both legacy and enhanced are called."""
-        # Pin time before deprecation date so legacy branch executes
-        pre_deprecation = datetime(2026, 2, 15, tzinfo=timezone.utc)
-        mock_dt.now.return_value = pre_deprecation
-        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
-
-        mock_legacy_tracker = MagicMock()
-        mock_legacy.return_value = mock_legacy_tracker
-
+    def test_writes_to_enhanced_only(self, mock_enhanced_fn):
+        """record_agent_prediction writes to enhanced system only (legacy removed)."""
         mock_enhanced_tracker = MagicMock()
         mock_enhanced_fn.return_value = mock_enhanced_tracker
 
@@ -94,38 +84,7 @@ class TestRecordAgentPrediction(unittest.TestCase):
             cycle_id='test_cycle_001',
         )
 
-        # Verify legacy was called
-        mock_legacy_tracker.record_prediction_structured.assert_called_once()
-
-        # Verify enhanced was called
-        mock_enhanced_tracker.record_prediction.assert_called_once()
-
-    @patch('trading_bot.brier_bridge.datetime')
-    @patch('trading_bot.brier_bridge._get_enhanced_tracker')
-    @patch('trading_bot.brier_scoring.get_brier_tracker')
-    def test_legacy_skipped_after_deprecation(self, mock_legacy, mock_enhanced_fn, mock_dt):
-        """After deprecation date, only enhanced is called."""
-        post_deprecation = datetime(2026, 3, 2, tzinfo=timezone.utc)
-        mock_dt.now.return_value = post_deprecation
-        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
-
-        mock_legacy_tracker = MagicMock()
-        mock_legacy.return_value = mock_legacy_tracker
-
-        mock_enhanced_tracker = MagicMock()
-        mock_enhanced_fn.return_value = mock_enhanced_tracker
-
-        record_agent_prediction(
-            agent='agronomist',
-            predicted_direction='BULLISH',
-            predicted_confidence=0.75,
-            cycle_id='test_cycle_001',
-        )
-
-        # Legacy should NOT be called after deprecation
-        mock_legacy_tracker.record_prediction_structured.assert_not_called()
-
-        # Enhanced should still be called
+        # Enhanced should be called
         mock_enhanced_tracker.record_prediction.assert_called_once()
 
 

--- a/trading_bot/brier_bridge.py
+++ b/trading_bot/brier_bridge.py
@@ -1,12 +1,9 @@
 """
-Brier Bridge: Unified prediction recording across legacy and enhanced systems.
+Brier Bridge: Unified prediction recording via the enhanced Brier system.
 
-This module provides a single entry point for recording and resolving predictions,
-ensuring both the legacy CSV-based system and the enhanced probabilistic system
-stay in sync.
-
-ARCHITECTURE PRINCIPLE: Dual-write pattern ensures backward compatibility.
-The enhanced system can fail without impacting legacy behavior.
+This module provides a single entry point for recording and resolving predictions
+using enhanced_brier.json as the sole data store. The legacy CSV dual-write path
+was removed after its deprecation date (2026-03-01).
 """
 
 import logging
@@ -15,10 +12,6 @@ from datetime import datetime, timezone
 from typing import Optional, Dict
 
 logger = logging.getLogger(__name__)
-
-# B1 FIX: Track legacy usage for migration
-_LEGACY_USAGE_COUNT = 0
-_LEGACY_DEPRECATION_DATE = datetime(2026, 3, 1, tzinfo=timezone.utc)
 
 
 def record_agent_prediction(
@@ -46,16 +39,13 @@ def record_agent_prediction(
         timestamp: When prediction was made (default: now UTC)
     """
     ts = timestamp or datetime.now(timezone.utc)
-    global _LEGACY_USAGE_COUNT
 
-    # === ENHANCED SYSTEM (JSON) — fail-safe ===
+    # === ENHANCED SYSTEM (JSON) — sole write path ===
     try:
         from trading_bot.enhanced_brier import EnhancedBrierTracker, MarketRegime, normalize_regime
 
         tracker = _get_enhanced_tracker()
-        if tracker is None:
-            pass # Fall through to legacy if enabled
-        else:
+        if tracker is not None:
             # Convert confidence to probability distribution
             prob_bullish, prob_neutral, prob_bearish = _confidence_to_probs(
                 predicted_direction, predicted_confidence
@@ -78,29 +68,6 @@ def record_agent_prediction(
     except Exception as e:
         # Enhanced system failure MUST NOT block trading
         logger.warning(f"Enhanced Brier recording failed for {agent}: {e}")
-
-    # === LEGACY SYSTEM (CSV) — Deprecated ===
-    if datetime.now(timezone.utc) < _LEGACY_DEPRECATION_DATE:
-        try:
-            from trading_bot.brier_scoring import get_brier_tracker
-            legacy_tracker = get_brier_tracker()
-            legacy_tracker.record_prediction_structured(
-                agent=agent,
-                predicted_direction=predicted_direction,
-                predicted_confidence=predicted_confidence,
-                actual='PENDING',
-                timestamp=ts,
-                cycle_id=cycle_id,
-            )
-            _LEGACY_USAGE_COUNT += 1
-
-            if _LEGACY_USAGE_COUNT % 100 == 0:
-                logger.warning(
-                    f"DEPRECATION: Legacy Brier system used {_LEGACY_USAGE_COUNT} times. "
-                    f"Will be removed after {_LEGACY_DEPRECATION_DATE}"
-                )
-        except Exception as e:
-            logger.error(f"Legacy Brier recording failed for {agent}: {e}")
 
 
 def resolve_agent_prediction(

--- a/trading_bot/brier_reconciliation.py
+++ b/trading_bot/brier_reconciliation.py
@@ -25,14 +25,13 @@ def set_data_dir(data_dir: str):
 
 
 def _get_paths():
-    """Return (structured_file, council_file, accuracy_file) for active commodity."""
+    """Return (council_file, accuracy_file) for active commodity."""
     try:
         from trading_bot.data_dir_context import get_engine_data_dir
         base = get_engine_data_dir()
     except LookupError:
         base = _data_dir or os.path.join("data", os.environ.get("COMMODITY_TICKER", "KC"))
     return (
-        os.path.join(base, "agent_accuracy_structured.csv"),
         os.path.join(base, "council_history.csv"),
         os.path.join(base, "agent_accuracy.csv"),
     )
@@ -52,13 +51,20 @@ def resolve_with_cycle_aware_match(dry_run: bool = False):
     2. Check if that cycle's council decision has been reconciled
     3. Only resolve if reconciled; otherwise classify as "awaiting reconciliation"
     """
-    STRUCTURED_FILE, COUNCIL_FILE, ACCURACY_FILE = _get_paths()
+    COUNCIL_FILE, ACCURACY_FILE = _get_paths()
 
-    if not os.path.exists(STRUCTURED_FILE) or not os.path.exists(COUNCIL_FILE):
+    if not os.path.exists(COUNCIL_FILE):
         logger.info("Missing required files for resolution")
         return 0
 
-    predictions_df = pd.read_csv(STRUCTURED_FILE)
+    # Legacy structured CSV no longer exists — resolution is handled by
+    # the enhanced Brier system (enhanced_brier.json) directly.
+    structured_file = os.path.join(os.path.dirname(COUNCIL_FILE), "agent_accuracy_structured.csv")
+    if not os.path.exists(structured_file):
+        logger.info("agent_accuracy_structured.csv removed; resolution handled by enhanced Brier system")
+        return 0
+
+    predictions_df = pd.read_csv(structured_file)
     council_df = pd.read_csv(COUNCIL_FILE)
 
     if predictions_df.empty or council_df.empty:
@@ -194,8 +200,8 @@ def resolve_with_cycle_aware_match(dry_run: bool = False):
 
     # Save changes if any (resolved or orphaned)
     if (resolved_count > 0 or orphaned_count > 0) and not dry_run:
-        predictions_df.to_csv(STRUCTURED_FILE, index=False)
-        logger.info(f"Saved updated {STRUCTURED_FILE}")
+        predictions_df.to_csv(structured_file, index=False)
+        logger.info(f"Saved updated {structured_file}")
 
         # Sync to legacy file (only resolved ones, orphans don't go to legacy)
         if resolved_count > 0:

--- a/trading_bot/dspy_optimizer.py
+++ b/trading_bot/dspy_optimizer.py
@@ -47,7 +47,7 @@ def _validate_path_component(value: str, label: str) -> str:
 # ---------------------------------------------------------------------------
 
 class CouncilDataset:
-    """Load labeled examples from council_history.csv + agent_accuracy_structured.csv."""
+    """Load labeled examples from enhanced_brier.json + council_history.csv."""
 
     def __init__(self, data_dir: str):
         self.data_dir = Path(data_dir)
@@ -56,6 +56,8 @@ class CouncilDataset:
     def load(self) -> dict[str, list[dict]]:
         """Return {agent_name: [example_dict]} with resolved predictions only.
 
+        Reads from enhanced_brier.json (source of truth) and enriches with
+        market context from council_history.csv.
         Agent names are discovered from the data, not hardcoded.
         Each example_dict has keys: cycle_id, timestamp, direction, confidence,
         prob_bullish, actual, market_context (from council_history join).
@@ -63,45 +65,56 @@ class CouncilDataset:
         if self._predictions_cache is not None:
             return self._predictions_cache
 
-        accuracy_path = self.data_dir / "agent_accuracy_structured.csv"
+        brier_path = self.data_dir / "enhanced_brier.json"
         council_path = self.data_dir / "council_history.csv"
 
-        if not accuracy_path.exists():
-            raise FileNotFoundError(f"Agent accuracy data not found: {accuracy_path}")
+        if not brier_path.exists():
+            raise FileNotFoundError(f"Enhanced Brier data not found: {brier_path}")
 
-        # Load agent predictions, filter resolved
+        # Load enhanced Brier predictions
+        with open(brier_path, "r") as f:
+            brier_data = json.load(f)
+
+        # Filter to resolved, non-ORPHANED predictions
         predictions: dict[str, list[dict]] = {}
         skipped_rows = 0
-        with open(accuracy_path, "r", newline="") as f:
-            reader = csv.DictReader(f)
-            for row_num, row in enumerate(reader, start=2):
-                try:
-                    actual = row.get("actual", "PENDING").strip()
-                    if actual in ("PENDING", "ORPHANED") or not actual:
-                        continue
-                    agent = row["agent"].strip()
-                    if not agent:
-                        continue
-
-                    # Safe float conversion with fallback
-                    confidence = _safe_float(row.get("confidence"), 0.5)
-                    prob_bullish = _safe_float(row.get("prob_bullish"), 0.5)
-
-                    predictions.setdefault(agent, []).append({
-                        "cycle_id": row.get("cycle_id", "").strip(),
-                        "timestamp": row.get("timestamp", "").strip(),
-                        "direction": row.get("direction", "").strip(),
-                        "confidence": confidence,
-                        "prob_bullish": prob_bullish,
-                        "actual": actual,
-                    })
-                except (KeyError, ValueError) as e:
-                    skipped_rows += 1
-                    logger.debug(f"Skipping malformed row {row_num}: {e}")
+        for pred in brier_data.get("predictions", []):
+            try:
+                actual = pred.get("actual_outcome")
+                if actual is None or actual == "ORPHANED":
+                    continue
+                agent = pred.get("agent", "").strip()
+                if not agent:
                     continue
 
+                # Derive direction and confidence from probability triple
+                prob_bullish = _safe_float(pred.get("prob_bullish"), 1 / 3)
+                prob_neutral = _safe_float(pred.get("prob_neutral"), 1 / 3)
+                prob_bearish = _safe_float(pred.get("prob_bearish"), 1 / 3)
+
+                probs = {
+                    "BULLISH": prob_bullish,
+                    "NEUTRAL": prob_neutral,
+                    "BEARISH": prob_bearish,
+                }
+                direction = max(probs, key=probs.get)
+                confidence = max(prob_bullish, prob_neutral, prob_bearish)
+
+                predictions.setdefault(agent, []).append({
+                    "cycle_id": pred.get("cycle_id", ""),
+                    "timestamp": pred.get("timestamp", ""),
+                    "direction": direction,
+                    "confidence": confidence,
+                    "prob_bullish": prob_bullish,
+                    "actual": actual,
+                })
+            except (KeyError, ValueError) as e:
+                skipped_rows += 1
+                logger.debug(f"Skipping malformed prediction: {e}")
+                continue
+
         if skipped_rows > 0:
-            logger.warning(f"Skipped {skipped_rows} malformed rows in {accuracy_path}")
+            logger.warning(f"Skipped {skipped_rows} malformed predictions in {brier_path}")
 
         # Load council history for market context (optional enrichment)
         council_context: dict[str, dict] = {}

--- a/trading_bot/enhanced_brier.py
+++ b/trading_bot/enhanced_brier.py
@@ -217,15 +217,8 @@ class EnhancedBrierTracker:
         # Per-agent, per-regime Brier scores
         self.agent_scores: Dict[str, Dict[str, List[float]]] = {}
 
-        # Load existing data and sync with CSV
+        # Load existing data
         self._load()
-        # Auto-backfill from structured CSV in same directory as data_path
-        try:
-            csv_dir = os.path.dirname(self.data_path) or '.'
-            structured_csv = os.path.join(csv_dir, "agent_accuracy_structured.csv")
-            self.backfill_from_resolved_csv(structured_csv_path=structured_csv)
-        except Exception as e:
-            logger.warning(f"Auto-backfill on init failed (non-fatal): {e}")
         try:
             self.auto_orphan_stale_predictions()
         except Exception as e:


### PR DESCRIPTION
## Summary

- **DSPy data source**: `CouncilDataset.load()` now reads from `enhanced_brier.json` instead of the stale `agent_accuracy_structured.csv` (which stopped receiving data on March 1 when the legacy deprecation date passed)
- **Legacy cleanup**: Removed dead dual-write path from `brier_bridge.py`, auto-backfill from structured CSV on `EnhancedBrierTracker` init, and `agent_accuracy_structured.csv` from `brier_reconciliation.py` paths
- **Direction derivation**: DSPy now derives direction/confidence from the probability triple (`argmax(prob_bullish, prob_neutral, prob_bearish)`) rather than reading pre-computed CSV columns

## Test plan

- [x] `pytest tests/test_brier_bridge.py tests/test_brier_scoring_new.py tests/test_brier_integration.py` — 22 passed
- [x] `pytest tests/` — full suite 912 passed
- [ ] `python scripts/optimize_prompts.py --ticker KC` — verify data through March 5 (~1,416 resolved predictions)
- [ ] `python scripts/optimize_prompts.py --ticker NG` — works for NG
- [ ] Delete stale CSVs on production: `data/{KC,CC,NG}/agent_accuracy_structured.csv` and `data/{KC,CC,NG}/agent_accuracy.csv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)