### PR TITLE
🎨 Palette: Complete Micro-UX Tooltip Coverage

### DIFF
--- a/pages/2_The_Scorecard.py
+++ b/pages/2_The_Scorecard.py
@@ -1035,9 +1035,9 @@ if _brier_data and _brier_data.get('predictions'):
     rate = resolved / total * 100 if total > 0 else 0
 
     health_cols = st.columns(4)
-    health_cols[0].metric("Total Predictions", total)
-    health_cols[1].metric("Resolved", resolved)
-    health_cols[2].metric("Pending", pending)
+    health_cols[0].metric("Total Predictions", total, help="Total number of Brier score predictions")
+    health_cols[1].metric("Resolved", resolved, help="Number of predictions with a known outcome")
+    health_cols[2].metric("Pending", pending, help="Number of predictions waiting for resolution")
     health_cols[3].metric(
         "Resolution Rate", f"{rate:.0f}%", help="Resolved / Total predictions"
     )

--- a/pages/3_The_Council.py
+++ b/pages/3_The_Council.py
@@ -751,11 +751,12 @@ else:
                 matched = len(routed[routed['assigned_provider'] == routed['model_provider']])
                 fallback_count = total - matched
                 col1, col2, col3 = st.columns(3)
-                col1.metric("Total Routed Calls", total)
-                col2.metric("Primary Success", matched)
+                col1.metric("Total Routed Calls", total, help="Total number of LLM calls made during this session")
+                col2.metric("Primary Success", matched, help="Number of calls successfully routed to the primary assigned provider")
                 col3.metric("Fallbacks", fallback_count,
                             delta=f"-{fallback_count}" if fallback_count > 0 else None,
-                            delta_color="inverse")
+                            delta_color="inverse",
+                            help="Number of calls that fell back to a secondary provider due to failure or timeout")
                 if fallback_count > 0:
                     fallbacks = routed[routed['assigned_provider'] != routed['model_provider']]
                     st.dataframe(

--- a/pages/7_Brier_Analysis.py
+++ b/pages/7_Brier_Analysis.py
@@ -81,9 +81,9 @@ if enhanced_data:
     col3.metric("Pending", pending, help="Predictions waiting for market resolution (T+1).")
     col4.metric(
         "Resolution Rate",
-        f"{resolved / total * 100:.0f}%" if total > 0 else "N/A"
+        f"{resolved / total * 100:.0f}%" if total > 0 else "N/A",
+        help="Percentage of predictions that have been resolved"
     )
-
 else:
     st.info("No prediction data available yet.")
 


### PR DESCRIPTION
Added `help` parameters to several `st.metric` components across the dashboard pages (`The Scorecard`, `The Council`, and `Brier Analysis`) that were missing tooltips. This ensures complete micro-UX tooltip coverage and better context for users interacting with the data-dense UI. Fixed an indentation bug accidentally introduced during patching, and ran all tests.

---
*PR created automatically by Jules for task [3801738084175120268](https://jules.google.com/task/3801738084175120268) started by @rozavala*