### PR TITLE
fix: tests creating spurious data/SB and data/TEST dirs

### DIFF
--- a/tests/test_contextvar_isolation.py
+++ b/tests/test_contextvar_isolation.py
@@ -59,12 +59,13 @@ async def test_contextvar_post_trade_math():
 
 
 @pytest.mark.asyncio
-async def test_contextvar_set_and_get():
+async def test_contextvar_set_and_get(tmp_path):
     """Basic set/get works within a single task."""
+    test_dir = str(tmp_path / "TEST")
     async def _task():
-        set_engine_data_dir('data/TEST')
+        set_engine_data_dir(test_dir)
         result = get_engine_data_dir()
-        assert result == 'data/TEST', f"Expected 'data/TEST', got '{result}'"
+        assert result == test_dir, f"Expected '{test_dir}', got '{result}'"
     await asyncio.create_task(_task())
 
 

--- a/tests/test_master_orchestrator.py
+++ b/tests/test_master_orchestrator.py
@@ -126,7 +126,7 @@ async def test_ib_pool_no_prefix_in_legacy():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_engine_runtime_full_isolation():
+async def test_engine_runtime_full_isolation(tmp_path):
     """Verify complete isolation of deduplicator, drawdown_guard across engines."""
     results = {}
 
@@ -140,7 +140,8 @@ async def test_engine_runtime_full_isolation():
             drawdown_guard=MagicMock(),
         )
         set_engine_runtime(rt)
-        set_engine_data_dir(f"data/{ticker}")
+        data_dir = str(tmp_path / ticker)
+        set_engine_data_dir(data_dir)
 
         await asyncio.sleep(0.05)  # Yield to other tasks
 
@@ -160,9 +161,9 @@ async def test_engine_runtime_full_isolation():
     assert results["KC"]["runtime_ticker"] == "KC"
     assert results["CC"]["runtime_ticker"] == "CC"
     assert results["SB"]["runtime_ticker"] == "SB"
-    assert results["KC"]["data_dir"] == "data/KC"
-    assert results["CC"]["data_dir"] == "data/CC"
-    assert results["SB"]["data_dir"] == "data/SB"
+    assert results["KC"]["data_dir"] == str(tmp_path / "KC")
+    assert results["CC"]["data_dir"] == str(tmp_path / "CC")
+    assert results["SB"]["data_dir"] == str(tmp_path / "SB")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `test_engine_runtime_full_isolation` in `test_master_orchestrator.py` called `set_engine_data_dir("data/SB")` which creates `data/SB/` via `os.makedirs` — SB is not an active commodity
- `test_contextvar_set_and_get` in `test_contextvar_isolation.py` called `set_engine_data_dir("data/TEST")` which creates `data/TEST/`
- Both now use pytest's `tmp_path` fixture instead of hardcoded relative paths

## Test plan

- [x] Both modified tests pass
- [x] Verified `data/SB` and `data/TEST` are no longer created after running the tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)