### PR TITLE
fix: drop superseded synthetics in position calculation

### DIFF
--- a/reconcile_trades.py
+++ b/reconcile_trades.py
@@ -87,6 +87,36 @@ def get_local_active_positions(ledger: pd.DataFrame = None) -> pd.DataFrame:
     # If I Buy 1 contract (to close short), my position is 0.
     # So: BUY is always +Quantity, SELL is always -Quantity.
 
+    # Drop synthetic entries superseded by RECONCILIATION_MISSING.
+    # Phantom reconciliation creates synthetic closes (fabricated timestamp,
+    # $0 price) when IB shows no position. Later, Flex reconciliation finds
+    # the real trade and writes a RECONCILIATION_MISSING entry. Both account
+    # for the same close → double-counting. When both exist for the same
+    # (symbol, action), the synthetic is redundant — drop it.
+    if 'reason' in ledger.columns:
+        reasons = ledger['reason'].fillna('')
+        synthetic_mask = reasons.str.contains(
+            'Ledger reconciliation|PHANTOM_RECONCILIATION', case=False
+        )
+        recon_mask = reasons.str.contains('RECONCILIATION_MISSING', case=False)
+
+        if synthetic_mask.any() and recon_mask.any():
+            # Find (symbol, action) pairs that have RECONCILIATION_MISSING
+            recon_pairs = set(
+                ledger.loc[recon_mask, ['local_symbol', 'action']]
+                .apply(tuple, axis=1)
+            )
+            # Drop synthetics whose (symbol, action) is covered
+            superseded = synthetic_mask & ledger.apply(
+                lambda r: (r['local_symbol'], r['action']) in recon_pairs, axis=1
+            )
+            if superseded.any():
+                logger.info(
+                    f"Dropping {superseded.sum()} synthetic entries superseded "
+                    f"by RECONCILIATION_MISSING"
+                )
+                ledger = ledger[~superseded].copy()
+
     # ⚡ Bolt: Vectorized np.where provides ~100x speedup over row-wise .apply() for conditional arithmetic
     ledger['signed_quantity'] = np.where(ledger['action'] == 'BUY', ledger['quantity'], -ledger['quantity'])
 

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -166,11 +166,11 @@ async def test_reconcile_council_history_pnl_calc(reconciliation_patches):
 
 
 # ---------------------------------------------------------------------------
-# invalidate_superseded_synthetics tests
+# get_local_active_positions: synthetic dedup tests
 # ---------------------------------------------------------------------------
 
-class TestInvalidateSupersededSynthetics:
-    """Tests for the double-counting fix in reconcile_trades.py."""
+class TestSyntheticDedup:
+    """Tests for dropping superseded synthetics in get_local_active_positions."""
 
     def _make_ledger_row(self, symbol, action, qty, reason, ts='2026-03-05 12:00:00'):
         return {
@@ -180,143 +180,11 @@ class TestInvalidateSupersededSynthetics:
             'total_value_usd': 0.0, 'reason': reason,
         }
 
-    def test_invalidates_superseded_synthetic(self, tmp_path):
-        """When both synthetic and RECONCILIATION_MISSING exist for same
-        (symbol, action), a reversal entry should be written."""
-        from reconcile_trades import invalidate_superseded_synthetics
+    def test_synthetic_dropped_when_recon_missing_exists(self):
+        """Synthetic BUY is dropped when RECONCILIATION_MISSING BUY exists
+        for the same symbol — net position should be flat."""
+        from reconcile_trades import get_local_active_positions
 
-        archive_dir = tmp_path / 'archive_ledger'
-        archive_dir.mkdir()
-
-        # Create a ledger with a synthetic BUY and a RECONCILIATION_MISSING BUY
-        rows = [
-            self._make_ledger_row('KO N25 C2.85', 'BUY', 1,
-                                  'Ledger reconciliation - closed manually in TWS'),
-            self._make_ledger_row('KO N25 C2.85', 'BUY', 1,
-                                  'RECONCILIATION_MISSING',
-                                  ts='2026-03-05 15:10:00'),
-        ]
-        df = pd.DataFrame(rows)
-        df.to_csv(tmp_path / 'trade_ledger.csv', index=False)
-
-        n = invalidate_superseded_synthetics(str(tmp_path))
-        assert n == 1
-
-        # Verify the invalidation file was written
-        inv_path = archive_dir / 'trade_ledger_synthetic_invalidations.csv'
-        assert inv_path.exists()
-        inv_df = pd.read_csv(inv_path)
-        assert len(inv_df) == 1
-        assert inv_df.iloc[0]['local_symbol'] == 'KO N25 C2.85'
-        assert inv_df.iloc[0]['action'] == 'SELL'  # opposite of BUY
-        assert inv_df.iloc[0]['quantity'] == 1
-
-    def test_no_overlap_no_invalidation(self, tmp_path):
-        """No invalidation when synthetics and RECONCILIATION_MISSING are
-        for different symbols."""
-        from reconcile_trades import invalidate_superseded_synthetics
-
-        rows = [
-            self._make_ledger_row('KO N25 C2.85', 'BUY', 1,
-                                  'Ledger reconciliation - closed manually'),
-            self._make_ledger_row('KO N25 P2.70', 'SELL', 1,
-                                  'RECONCILIATION_MISSING'),
-        ]
-        df = pd.DataFrame(rows)
-        df.to_csv(tmp_path / 'trade_ledger.csv', index=False)
-
-        n = invalidate_superseded_synthetics(str(tmp_path))
-        assert n == 0
-
-    def test_idempotent_reruns(self, tmp_path):
-        """Running twice should produce the same result (idempotent)."""
-        from reconcile_trades import invalidate_superseded_synthetics
-
-        archive_dir = tmp_path / 'archive_ledger'
-        archive_dir.mkdir()
-
-        rows = [
-            self._make_ledger_row('KO N25 C2.85', 'BUY', 1,
-                                  'Ledger reconciliation - closed manually'),
-            self._make_ledger_row('KO N25 C2.85', 'BUY', 1,
-                                  'RECONCILIATION_MISSING'),
-        ]
-        df = pd.DataFrame(rows)
-        df.to_csv(tmp_path / 'trade_ledger.csv', index=False)
-
-        n1 = invalidate_superseded_synthetics(str(tmp_path))
-        assert n1 == 1
-
-        # Second run should still write 1 (it excludes existing invalidations
-        # from analysis and rewrites the file)
-        n2 = invalidate_superseded_synthetics(str(tmp_path))
-        assert n2 == 1
-
-    def test_multiple_symbols_and_actions(self, tmp_path):
-        """Handles multiple symbols with different actions correctly."""
-        from reconcile_trades import invalidate_superseded_synthetics
-
-        archive_dir = tmp_path / 'archive_ledger'
-        archive_dir.mkdir()
-
-        rows = [
-            # C2.85: synthetic BUY + RECON_MISSING BUY → invalidate
-            self._make_ledger_row('KO N25 C2.85', 'BUY', 1,
-                                  'Ledger reconciliation - closed manually'),
-            self._make_ledger_row('KO N25 C2.85', 'BUY', 1,
-                                  'RECONCILIATION_MISSING'),
-            # C2.8: synthetic SELL + RECON_MISSING SELL → invalidate
-            self._make_ledger_row('KO N25 C2.8', 'SELL', 1,
-                                  'PHANTOM_RECONCILIATION - closed externally'),
-            self._make_ledger_row('KO N25 C2.8', 'SELL', 1,
-                                  'RECONCILIATION_MISSING'),
-            # P2.8: synthetic SELL 2 + RECON_MISSING SELL 2 → invalidate
-            self._make_ledger_row('KO N25 P2.8', 'SELL', 2,
-                                  'Ledger reconciliation - closed externally'),
-            self._make_ledger_row('KO N25 P2.8', 'SELL', 2,
-                                  'RECONCILIATION_MISSING'),
-        ]
-        df = pd.DataFrame(rows)
-        df.to_csv(tmp_path / 'trade_ledger.csv', index=False)
-
-        n = invalidate_superseded_synthetics(str(tmp_path))
-        assert n == 3
-
-        inv_df = pd.read_csv(archive_dir / 'trade_ledger_synthetic_invalidations.csv')
-        assert len(inv_df) == 3
-
-    def test_partial_overlap(self, tmp_path):
-        """When synthetic qty > RECON_MISSING qty, only overlap is invalidated."""
-        from reconcile_trades import invalidate_superseded_synthetics
-
-        archive_dir = tmp_path / 'archive_ledger'
-        archive_dir.mkdir()
-
-        rows = [
-            self._make_ledger_row('KO N25 P2.8', 'SELL', 3,
-                                  'Ledger reconciliation - closed externally'),
-            self._make_ledger_row('KO N25 P2.8', 'SELL', 2,
-                                  'RECONCILIATION_MISSING'),
-        ]
-        df = pd.DataFrame(rows)
-        df.to_csv(tmp_path / 'trade_ledger.csv', index=False)
-
-        n = invalidate_superseded_synthetics(str(tmp_path))
-        assert n == 1
-
-        inv_df = pd.read_csv(archive_dir / 'trade_ledger_synthetic_invalidations.csv')
-        assert inv_df.iloc[0]['quantity'] == 2  # min(3, 2)
-
-    def test_net_position_corrected(self, tmp_path):
-        """After invalidation, get_local_active_positions should show
-        correct net positions."""
-        from reconcile_trades import invalidate_superseded_synthetics, get_local_active_positions
-
-        archive_dir = tmp_path / 'archive_ledger'
-        archive_dir.mkdir()
-
-        # Simulate the real scenario: original SELL, synthetic BUY (close),
-        # RECONCILIATION_MISSING BUY (real close)
         rows = [
             self._make_ledger_row('KO N25 C2.85', 'SELL', 1,
                                   'Strategy Execution',
@@ -329,25 +197,67 @@ class TestInvalidateSupersededSynthetics:
                                   ts='2026-03-05 15:10:00'),
         ]
         df = pd.DataFrame(rows)
-        df.to_csv(tmp_path / 'trade_ledger.csv', index=False)
+        positions = get_local_active_positions(df)
 
-        # Before fix: net = -1 + 1 + 1 = +1 (wrong)
-        positions_before = get_local_active_positions(
-            pd.read_csv(tmp_path / 'trade_ledger.csv')
-        )
-        assert not positions_before.empty, "Should show phantom position before fix"
-
-        # Apply fix
-        invalidate_superseded_synthetics(str(tmp_path))
-
-        # After fix: load full ledger including invalidation file
-        from reconcile_trades import get_trade_ledger_df
-        full_ledger = get_trade_ledger_df(str(tmp_path))
-        positions_after = get_local_active_positions(full_ledger)
-
-        # Net should be 0 (SELL 1 + BUY 1 synthetic + BUY 1 recon
-        #                    + SELL 1 invalidation = 0)
-        c285 = positions_after[
-            positions_after['Symbol'] == 'KO N25 C2.85'
-        ]
+        # SELL 1 + BUY 1 (recon, kept) = 0; synthetic BUY dropped
+        c285 = positions[positions['Symbol'] == 'KO N25 C2.85']
         assert c285.empty, f"Position should be flat, got: {c285}"
+
+    def test_no_drop_when_no_overlap(self):
+        """Synthetics for different symbols than RECONCILIATION_MISSING are kept."""
+        from reconcile_trades import get_local_active_positions
+
+        rows = [
+            self._make_ledger_row('KO N25 C2.85', 'SELL', 1,
+                                  'Strategy Execution'),
+            self._make_ledger_row('KO N25 C2.85', 'BUY', 1,
+                                  'Ledger reconciliation - closed manually'),
+            # RECON_MISSING is for a DIFFERENT symbol
+            self._make_ledger_row('KO N25 P2.70', 'SELL', 1,
+                                  'RECONCILIATION_MISSING'),
+        ]
+        df = pd.DataFrame(rows)
+        positions = get_local_active_positions(df)
+
+        # C2.85: SELL 1 + BUY 1 (synthetic kept, no overlap) = 0
+        # P2.70: SELL 1 (RECON_MISSING) = -1
+        c285 = positions[positions['Symbol'] == 'KO N25 C2.85']
+        assert c285.empty, "C2.85 should be flat"
+        p270 = positions[positions['Symbol'] == 'KO N25 P2.70']
+        assert not p270.empty, "P2.70 should show position"
+
+    def test_multiple_symbols(self):
+        """Handles multiple symbols with mixed actions correctly."""
+        from reconcile_trades import get_local_active_positions
+
+        rows = [
+            # C2.85: open SELL + synthetic BUY + RECON_MISSING BUY
+            self._make_ledger_row('KO N25 C2.85', 'SELL', 1, 'Strategy Execution'),
+            self._make_ledger_row('KO N25 C2.85', 'BUY', 1,
+                                  'Ledger reconciliation - closed manually'),
+            self._make_ledger_row('KO N25 C2.85', 'BUY', 1, 'RECONCILIATION_MISSING'),
+            # C2.8: open BUY + synthetic SELL + RECON_MISSING SELL
+            self._make_ledger_row('KO N25 C2.8', 'BUY', 1, 'Strategy Execution'),
+            self._make_ledger_row('KO N25 C2.8', 'SELL', 1,
+                                  'PHANTOM_RECONCILIATION: synthetic close'),
+            self._make_ledger_row('KO N25 C2.8', 'SELL', 1, 'RECONCILIATION_MISSING'),
+        ]
+        df = pd.DataFrame(rows)
+        positions = get_local_active_positions(df)
+
+        assert positions.empty, f"All positions should be flat, got:\n{positions}"
+
+    def test_no_reason_column(self):
+        """Works without a reason column (legacy ledgers)."""
+        from reconcile_trades import get_local_active_positions
+
+        rows = [
+            {'timestamp': '2026-03-04', 'position_id': 'x', 'combo_id': '',
+             'local_symbol': 'KO N25 C2.85', 'action': 'BUY', 'quantity': 1,
+             'avg_fill_price': 0.5},
+        ]
+        df = pd.DataFrame(rows)
+        positions = get_local_active_positions(df)
+
+        assert len(positions) == 1
+        assert positions.iloc[0]['Quantity'] == 1


### PR DESCRIPTION
## Summary

- Replaces the `invalidate_superseded_synthetics()` approach from #1217 which wrote reversal entries that then showed up as "superfluous" in trade ledger reconciliation — creating a new problem
- Instead, `get_local_active_positions()` now simply drops synthetic entries (Ledger reconciliation / PHANTOM_RECONCILIATION) when a RECONCILIATION_MISSING entry exists for the same (symbol, action)
- No extra files written, no reversal entries, no side effects on other reconciliation paths
- Also removes the stale `trade_ledger_synthetic_invalidations.csv` from production

## Test plan

- [x] `test_synthetic_dropped_when_recon_missing_exists` — SELL + synthetic BUY + RECON_MISSING BUY → flat
- [x] `test_no_drop_when_no_overlap` — synthetics kept when no matching RECON_MISSING
- [x] `test_multiple_symbols` — mixed symbols and actions all resolve correctly
- [x] `test_no_reason_column` — legacy ledgers without reason column still work
- [x] Verified against production KC data: all positions flat

🤖 Generated with [Claude Code](https://claude.com/claude-code)