### PR TITLE
fix: guard Brier recording to prevent DSPy/test pollution

### DIFF
--- a/tests/test_brier_bridge.py
+++ b/tests/test_brier_bridge.py
@@ -71,8 +71,9 @@ class TestGetAgentReliability(unittest.TestCase):
 
 
 class TestRecordAgentPrediction(unittest.TestCase):
+    @patch('trading_bot.data_dir_context.get_engine_runtime', return_value=MagicMock())
     @patch('trading_bot.brier_bridge._get_enhanced_tracker')
-    def test_writes_to_enhanced_only(self, mock_enhanced_fn):
+    def test_writes_to_enhanced_only(self, mock_enhanced_fn, _mock_rt):
         """record_agent_prediction writes to enhanced system only (legacy removed)."""
         mock_enhanced_tracker = MagicMock()
         mock_enhanced_fn.return_value = mock_enhanced_tracker

--- a/trading_bot/brier_bridge.py
+++ b/trading_bot/brier_bridge.py
@@ -40,6 +40,17 @@ def record_agent_prediction(
     """
     ts = timestamp or datetime.now(timezone.utc)
 
+    # Guard: only record predictions inside a live orchestrator session.
+    # Prevents DSPy evaluations, manual tests, and scripts from polluting
+    # the production Brier data.
+    try:
+        from trading_bot.data_dir_context import get_engine_runtime
+        if get_engine_runtime() is None:
+            logger.debug(f"Skipping Brier recording for {agent}: no EngineRuntime (non-orchestrator context)")
+            return
+    except Exception:
+        pass  # If ContextVar lookup fails, allow recording (legacy single-engine mode)
+
     # === ENHANCED SYSTEM (JSON) — sole write path ===
     try:
         from trading_bot.enhanced_brier import EnhancedBrierTracker, MarketRegime, normalize_regime


### PR DESCRIPTION
## Summary
- Adds an `EngineRuntime` guard in `record_agent_prediction()` — predictions are only recorded when running inside a live orchestrator session
- Prevents DSPy evaluations, manual scripts, and test runs from writing orphan predictions to `enhanced_brier.json`
- Cleaned 96 orphan predictions from production that were created during a DSPy testing session on 2026-03-06 (included expired contract KCZ25, default probabilities, no matching council_history entries)

## Test plan
- [x] `tests/test_brier_bridge.py` — all 9 pass (test updated to mock EngineRuntime)
- [x] `tests/test_signal_flow.py` — 3 pass (already mocks `record_agent_prediction`)
- [x] `tests/test_guardrails.py` — 3 pass (already mocks `record_agent_prediction`)
- [x] `tests/test_reconciliation.py` — 8 pass
- [ ] Verify on production that Brier recording works normally during live trading cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)