### PR TITLE
🎨 Palette: Complete Tooltip Coverage for High-Impact Buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -57,3 +57,7 @@ This journal records CRITICAL UX/accessibility learnings.
 ## 2026-03-05 - Completing the Micro-UX Tooltip Coverage
 **Learning:** During a codebase audit, several Streamlit metric components (`st.metric`) across utility and financial pages were found to be missing the `help` parameter. Consistency in providing native tooltips for metrics (like System Health, Failed Checks, and Realized P&L) is critical for a predictable user experience, as users learn to rely on hover states for context.
 **Action:** Always ensure that `st.metric` calls include a descriptive `help` attribute, especially for derived or aggregated values where the calculation or significance might not be immediately obvious.
+
+## 2026-03-05 - Completing Tooltip Coverage for High-Impact Actions
+**Learning:** While the dashboard has a standard of using tooltips (`help` parameter) on high-stakes manual triggers (like "Force Generate & Execute Orders" and "Clear All Caches"), several critical buttons (e.g., "Cancel All Open Orders" and "Force Close Stale Positions") were found lacking them. Users need immediate, clear context for what destructive actions will do before clicking them, even if there is a safety interlock checkbox.
+**Action:** Ensure exhaustive tooltip coverage across all Streamlit components that trigger state mutations or irreversible actions. The `help` string should explicitly describe the scope and consequence of the action (e.g., "Immediately cancels all unfilled DAY orders in Interactive Brokers.").

--- a/pages/5_Utilities.py
+++ b/pages/5_Utilities.py
@@ -311,7 +311,11 @@ with manual_cols[1]:
     st.caption("Immediately cancels all unfilled DAY orders in IB")
 
     confirm_cancel_all = st.checkbox("I confirm I want to CANCEL all open orders", key="confirm_cancel_all")
-    if st.button("🛑 Cancel All Open Orders", disabled=not confirm_cancel_all):
+    if st.button(
+        "🛑 Cancel All Open Orders",
+        disabled=not confirm_cancel_all,
+        help="Immediately cancels all unfilled DAY orders in Interactive Brokers."
+    ):
         if not config:
             st.error("❌ Config not loaded")
         else:
@@ -343,7 +347,11 @@ with manual_cols2[0]:
     st.caption("Closes positions held longer than max_holding_days")
 
     confirm_close_stale = st.checkbox("I confirm I want to CLOSE stale positions", key="confirm_close_stale")
-    if st.button("🔄 Force Close Stale Positions", disabled=not confirm_close_stale):
+    if st.button(
+        "🔄 Force Close Stale Positions",
+        disabled=not confirm_close_stale,
+        help="Forces the closure of any open positions that have exceeded their maximum configured holding period."
+    ):
         if not config:
             st.error("❌ Config not loaded")
         else:


### PR DESCRIPTION
This PR implements a micro-UX improvement by adding descriptive tooltips to destructive manual trading buttons on the Utilities page ("Cancel All Open Orders" and "Force Close Stale Positions"). This provides immediate, clear context for what these actions will do before clicking them, reducing operational risk. A corresponding journal entry was added to `.jules/palette.md`.

---
*PR created automatically by Jules for task [1871651496856221504](https://jules.google.com/task/1871651496856221504) started by @rozavala*