### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure XML parsing in IB Flex Query Reconciler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** `pages/3_The_Council.py` used `st.markdown(..., unsafe_allow_html=True)` to render custom HTML badges for agent decisions and trigger events.
 **Learning:** Bypassing Streamlit's native HTML sanitization (`unsafe_allow_html=True`) exposes the dashboard to XSS if the data rendered (like agent strings or trigger payloads) contains malicious scripts.
 **Prevention:** Strictly avoid `unsafe_allow_html=True`. Use native, safe Streamlit components like `st.info`, `st.success`, `st.warning`, and `st.error` which automatically sanitize input while providing similar visual hierarchy.
+
+## 2026-03-08 - Insecure XML Parsing in IB Flex Query Reconciler
+**Vulnerability:** `reconcile_trades.py` parsed Interactive Brokers Flex Query reports using `xml.etree.ElementTree.fromstring()`.
+**Learning:** The Python standard library `xml.etree` is vulnerable to XML external entity (XXE) injection and exponential entity expansion (Billion Laughs) attacks. Even when data is fetched over HTTPS from a known provider, parsing external unvalidated XML with standard libraries risks DoS or potential exploitation.
+**Prevention:** Always use `defusedxml.ElementTree` instead of `xml.etree.ElementTree` when parsing any XML responses from third-party APIs. Added `defusedxml` to dependencies and swapped the import.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "anthropic>=0.79.0",
     "google-genai>=1.47.0",
     "aiohttp>=3.13.3",
+    "defusedxml",
 ]
 
 [tool.pytest.ini_options]

--- a/reconcile_trades.py
+++ b/reconcile_trades.py
@@ -10,7 +10,7 @@ import asyncio
 import io
 import logging
 import os
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 import httpx  # Added for HTTP requests
 import numpy as np

--- a/uv.lock
+++ b/uv.lock
@@ -499,6 +499,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },
+    { name = "defusedxml" },
     { name = "fastapi" },
     { name = "feedparser" },
     { name = "fredapi" },
@@ -531,6 +532,7 @@ dependencies = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "anthropic", specifier = ">=0.79.0" },
+    { name = "defusedxml" },
     { name = "fastapi" },
     { name = "feedparser" },
     { name = "fredapi" },
@@ -640,6 +642,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/91/6dd1910a212f2e8eafe57877bcf97748eb24849e1511a266687546066b8a/curl_cffi-0.13.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6d433ffcb455ab01dd0d7bde47109083aa38b59863aa183d29c668ae4c96bf8e", size = 8711908, upload-time = "2025-08-06T13:05:38.741Z" },
     { url = "https://files.pythonhosted.org/packages/6d/e4/15a253f9b4bf8d008c31e176c162d2704a7e0c5e24d35942f759df107b68/curl_cffi-0.13.0-cp39-abi3-win_amd64.whl", hash = "sha256:66a6b75ce971de9af64f1b6812e275f60b88880577bac47ef1fa19694fa21cd3", size = 1614510, upload-time = "2025-08-06T13:05:40.451Z" },
     { url = "https://files.pythonhosted.org/packages/f9/0f/9c5275f17ad6ff5be70edb8e0120fdc184a658c9577ca426d4230f654beb/curl_cffi-0.13.0-cp39-abi3-win_arm64.whl", hash = "sha256:d438a3b45244e874794bc4081dc1e356d2bb926dcc7021e5a8fef2e2105ef1d8", size = 1365753, upload-time = "2025-08-06T13:05:41.879Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** `reconcile_trades.py` parsed Interactive Brokers Flex Query reports using `xml.etree.ElementTree.fromstring()`. The Python standard library `xml.etree` is vulnerable to XML external entity (XXE) injection and exponential entity expansion (Billion Laughs) attacks. Even when data is fetched over HTTPS from a known provider, parsing external unvalidated XML with standard libraries risks DoS or potential exploitation.
🎯 **Impact:** Potential for DoS or remote code execution via XXE if IBKR network traffic is manipulated.
🔧 **Fix:** Swapped the import to use `defusedxml.ElementTree`, which is the industry standard for securely parsing untrusted XML data in Python. Added `defusedxml` to dependencies.
✅ **Verification:** Ran tests with `PYTHONPATH=. uv run pytest tests/test_reconciliation.py`. The secure parser works identically to the standard library but with mitigations enabled. Updated the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [14790596088402888105](https://jules.google.com/task/14790596088402888105) started by @rozavala*