### PR TITLE
fix: resolve 8 phantom position discrepancies in NG reconciliation

### DIFF
--- a/reconcile_trades.py
+++ b/reconcile_trades.py
@@ -91,8 +91,11 @@ def get_local_active_positions(ledger: pd.DataFrame = None) -> pd.DataFrame:
     # Phantom reconciliation creates synthetic closes (fabricated timestamp,
     # $0 price) when IB shows no position. Later, Flex reconciliation finds
     # the real trade and writes a RECONCILIATION_MISSING entry. Both account
-    # for the same close → double-counting. When both exist for the same
-    # (symbol, action), the synthetic is redundant — drop it.
+    # for the same close → double-counting. When a RECONCILIATION_MISSING
+    # exists for a symbol, ALL synthetic entries for that symbol are
+    # redundant — drop them regardless of action direction. (The phantom
+    # reconciliation creates both legs of a round-trip, so matching only on
+    # (symbol, action) leaves the opposite-direction phantom orphaned.)
     if 'reason' in ledger.columns:
         reasons = ledger['reason'].fillna('')
         synthetic_mask = reasons.str.contains(
@@ -101,15 +104,10 @@ def get_local_active_positions(ledger: pd.DataFrame = None) -> pd.DataFrame:
         recon_mask = reasons.str.contains('RECONCILIATION_MISSING', case=False)
 
         if synthetic_mask.any() and recon_mask.any():
-            # Find (symbol, action) pairs that have RECONCILIATION_MISSING
-            recon_pairs = set(
-                ledger.loc[recon_mask, ['local_symbol', 'action']]
-                .apply(tuple, axis=1)
-            )
-            # Drop synthetics whose (symbol, action) is covered
-            superseded = synthetic_mask & ledger.apply(
-                lambda r: (r['local_symbol'], r['action']) in recon_pairs, axis=1
-            )
+            # Find symbols that have any RECONCILIATION_MISSING entry
+            recon_symbols = set(ledger.loc[recon_mask, 'local_symbol'])
+            # Drop ALL synthetics for those symbols (both action directions)
+            superseded = synthetic_mask & ledger['local_symbol'].isin(recon_symbols)
             if superseded.any():
                 logger.info(
                     f"Dropping {superseded.sum()} synthetic entries superseded "

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -247,6 +247,36 @@ class TestSyntheticDedup:
 
         assert positions.empty, f"All positions should be flat, got:\n{positions}"
 
+    def test_cross_direction_phantom_dropped(self):
+        """Phantom entries in BOTH directions are dropped when RECONCILIATION_MISSING
+        exists for that symbol — reproduces the NG bear put spread phantom bug."""
+        from reconcile_trades import get_local_active_positions
+
+        rows = [
+            # Original open: SELL P2800 (short leg of bear put spread)
+            self._make_ledger_row('LNEK6 P2800', 'SELL', 1,
+                                  'Strategy Execution', ts='2026-02-26 10:00:00'),
+            # Flex recon found the close: BUY P2800
+            self._make_ledger_row('LNEK6 P2800', 'BUY', 1,
+                                  'RECONCILIATION_MISSING', ts='2026-02-26 15:00:00'),
+            # Phantom recon also created a BUY close (same position_id)
+            self._make_ledger_row('LNEK6 P2800', 'BUY', 1,
+                                  'PHANTOM_RECONCILIATION', ts='2026-02-27 19:00:00'),
+            # Phantom recon ALSO created a SELL for the recon position_id
+            self._make_ledger_row('LNEK6 P2800', 'SELL', 1,
+                                  'PHANTOM_RECONCILIATION', ts='2026-02-27 19:00:00'),
+        ]
+        df = pd.DataFrame(rows)
+        positions = get_local_active_positions(df)
+
+        # All phantoms (both BUY and SELL) should be dropped.
+        # Net: SELL 1 (original) + BUY 1 (RECON_MISSING) = 0
+        p2800 = positions[positions['Symbol'] == 'LNEK6 P2800']
+        assert p2800.empty, (
+            f"LNEK6 P2800 should be flat after dropping both-direction phantoms, "
+            f"got: {p2800}"
+        )
+
     def test_no_reason_column(self):
         """Works without a reason column (legacy ledgers)."""
         from reconcile_trades import get_local_active_positions


### PR DESCRIPTION
## Summary
- The superseding logic in `get_local_active_positions()` matched phantom entries against `RECONCILIATION_MISSING` on `(symbol, action)` pairs, but phantom reconciliation creates entries in **both directions** for a round-trip — so the opposite-direction phantom survived, creating 8 false position discrepancies in the NG engine
- Fix: match on **symbol alone** — when `RECONCILIATION_MISSING` exists for a symbol, drop ALL synthetic entries for that symbol regardless of action direction
- Validated against actual KC and NG production ledger data: NG resolves from 8 phantoms to zero, KC has no regressions

## Root cause
Legacy phantom entries (created Feb 27, before the RECONCILIATION_MISSING guard in orchestrator line 1536 existed) cascaded across position_ids. Example for LNEK6 P2800:

| Entry | Action | Reason | Dropped by old logic? |
|-------|--------|--------|-----------------------|
| SELL 1 | Strategy Execution | — |
| BUY 1 | RECONCILIATION_MISSING | — |
| BUY 1 | PHANTOM_RECONCILIATION | Yes (same action) |
| SELL 1 | PHANTOM_RECONCILIATION | **No** (opposite action) |

Entry 4 survived → net = -1 instead of 0.

## Test plan
- [x] New test `test_cross_direction_phantom_dropped` reproduces the exact NG bug pattern
- [x] All 8 existing reconciliation tests pass
- [x] Verified fix against actual production data: `python3 -c "from reconcile_trades import ..."` shows NG=0, KC=0
- [x] Future occurrences prevented by orchestrator guard (line 1536-1539)

🤖 Generated with [Claude Code](https://claude.com/claude-code)