### PR TITLE
fix: volatility-aware Brier resolution for STAYED_FLAT cycles

### DIFF
--- a/scripts/rescore_volatility_brier.py
+++ b/scripts/rescore_volatility_brier.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+One-time re-scoring: Fix historical VOLATILITY/STAYED_FLAT Brier resolutions.
+
+Prior to the volatility-aware fix, STAYED_FLAT cycles were resolved using
+directional price movement (BULLISH/BEARISH). This penalized agents who
+correctly predicted NEUTRAL. This script retroactively corrects those
+resolutions to NEUTRAL and recalculates Brier scores.
+
+NOTE: This script rebuilds agent_scores and calibration_buckets in
+enhanced_brier.json. It does NOT rebuild weight_evolution.csv — those
+weights will gradually adapt over the next 1–3 reconciliation cycles
+as new Brier values flow into the voting pipeline.
+
+Usage (must run from project root, e.g. /home/rodrigo/real_options):
+    python scripts/rescore_volatility_brier.py --commodity KC
+    python scripts/rescore_volatility_brier.py --commodity KC --dry-run
+    python scripts/rescore_volatility_brier.py --commodity KC --output-csv
+    python scripts/rescore_volatility_brier.py  # all active commodities
+
+Safe to run multiple times — only modifies predictions that need correction.
+"""
+
+import argparse
+import csv
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+# Add project root to path
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from trading_bot.enhanced_brier import (
+    EnhancedBrierTracker,
+    resolve_outcome_for_cycle,
+)
+
+
+def rescore_commodity(ticker: str, dry_run: bool = False, output_csv: bool = False) -> dict:
+    """
+    Re-score historical VOLATILITY/STAYED_FLAT predictions for one commodity.
+
+    Returns dict with stats: {checked, corrected, skipped, errors}
+    """
+    data_dir = f"data/{ticker}"
+    enhanced_path = os.path.join(data_dir, "enhanced_brier.json")
+    council_path = os.path.join(data_dir, "council_history.csv")
+
+    stats = {"checked": 0, "corrected": 0, "skipped": 0, "errors": 0}
+
+    if not os.path.exists(enhanced_path):
+        print(f"  [{ticker}] No enhanced_brier.json found — skipping")
+        return stats
+
+    if not os.path.exists(council_path):
+        print(f"  [{ticker}] No council_history.csv found — skipping")
+        return stats
+
+    # Load council_history to build cycle_id → (prediction_type, volatility_outcome) lookup
+    try:
+        ch_df = pd.read_csv(council_path, on_bad_lines="warn")
+    except Exception as e:
+        print(f"  [{ticker}] Failed to read council_history.csv: {e}")
+        stats["errors"] += 1
+        return stats
+
+    cycle_info = {}
+    for _, row in ch_df.iterrows():
+        cid = str(row.get("cycle_id", "")).strip()
+        if not cid:
+            continue
+        cycle_info[cid] = {
+            "prediction_type": str(row.get("prediction_type", "")).strip(),
+            "volatility_outcome": str(row.get("volatility_outcome", "")).strip(),
+            "actual_trend_direction": str(row.get("actual_trend_direction", "")).strip(),
+        }
+
+    vol_stayed_flat_cycles = {
+        cid for cid, info in cycle_info.items()
+        if info["prediction_type"].upper() == "VOLATILITY"
+        and info["volatility_outcome"].upper() == "STAYED_FLAT"
+    }
+
+    print(f"  [{ticker}] Found {len(vol_stayed_flat_cycles)} VOLATILITY/STAYED_FLAT cycles in council_history")
+
+    if not vol_stayed_flat_cycles:
+        print(f"  [{ticker}] Nothing to re-score")
+        return stats
+
+    # Load tracker
+    tracker = EnhancedBrierTracker(data_path=enhanced_path)
+    print(f"  [{ticker}] Loaded {len(tracker.predictions)} predictions from enhanced_brier.json")
+
+    corrections = []
+
+    for pred in tracker.predictions:
+        if pred.cycle_id not in vol_stayed_flat_cycles:
+            continue
+
+        stats["checked"] += 1
+
+        # Only fix predictions that were resolved with a directional outcome
+        if pred.actual_outcome is None:
+            stats["skipped"] += 1
+            continue
+
+        if pred.actual_outcome == "NEUTRAL":
+            # Already correct — skip
+            stats["skipped"] += 1
+            continue
+
+        if pred.actual_outcome == "ORPHANED":
+            stats["skipped"] += 1
+            continue
+
+        # This prediction was resolved as BULLISH or BEARISH during a STAYED_FLAT cycle — fix it
+        old_outcome = pred.actual_outcome
+        new_outcome = "NEUTRAL"
+
+        # Mutate-restore pattern: set new outcome to compute Brier, restore if dry-run
+        pred.actual_outcome = new_outcome
+        new_brier = pred.calc_brier_score()
+        if dry_run:
+            pred.actual_outcome = old_outcome
+
+        corrections.append({
+            "agent": pred.agent,
+            "cycle_id": pred.cycle_id,
+            "old_outcome": old_outcome,
+            "new_outcome": new_outcome,
+            "new_brier": f"{new_brier:.4f}" if new_brier is not None else "N/A",
+            "timestamp": pred.timestamp.isoformat(),
+        })
+        stats["corrected"] += 1
+
+    # Report
+    if corrections:
+        print(f"\n  [{ticker}] Corrections ({'DRY RUN' if dry_run else 'LIVE'}):")
+        for c in corrections[:20]:  # Show first 20
+            print(
+                f"    {c['agent']:15s} | cycle={c['cycle_id'][:16]} | "
+                f"{c['old_outcome']:>8s} → {c['new_outcome']:>8s} | "
+                f"Brier={c['new_brier']}"
+            )
+        if len(corrections) > 20:
+            print(f"    ... and {len(corrections) - 20} more")
+
+    # Write audit trail CSV if requested
+    if output_csv and corrections:
+        csv_path = os.path.join(
+            data_dir,
+            f"rescore_corrections_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}.csv"
+        )
+        with open(csv_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=["agent", "cycle_id", "old_outcome", "new_outcome", "new_brier", "timestamp"])
+            writer.writeheader()
+            writer.writerows(corrections)
+        print(f"  [{ticker}] Audit trail written to {csv_path}")
+
+    if not dry_run and corrections:
+        # Rebuild agent_scores from scratch (most accurate approach)
+        tracker.agent_scores = {}
+        for bucket_list in tracker.calibration_buckets.values():
+            for b in bucket_list:
+                b.predictions = 0
+                b.correct = 0
+
+        resolved_count = 0
+        for pred in tracker.predictions:
+            if pred.actual_outcome is None or pred.actual_outcome == "ORPHANED":
+                continue
+            brier = pred.calc_brier_score()
+            if brier is not None:
+                tracker._update_agent_score(pred.agent, pred.regime.value, brier)
+                tracker._update_calibration(pred)
+                resolved_count += 1
+
+        tracker._save()
+        print(f"\n  [{ticker}] Saved. Rebuilt scores from {resolved_count} resolved predictions.")
+        print(f"  [{ticker}] NOTE: weight_evolution.csv is NOT rebuilt by this script.")
+        print(f"  [{ticker}]       Weights will adapt over next 1-3 reconciliation cycles.")
+
+    return stats
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Re-score historical VOLATILITY/STAYED_FLAT Brier predictions"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Preview without writing changes")
+    parser.add_argument("--commodity", type=str, help="Process a single commodity (e.g., KC, CC, NG)")
+    parser.add_argument("--output-csv", action="store_true", help="Write corrections audit trail to CSV")
+    args = parser.parse_args()
+
+    # Determine commodities
+    if args.commodity:
+        tickers = [args.commodity.upper()]
+    else:
+        try:
+            from config_loader import load_config
+            config = load_config()
+            tickers = config.get("active_commodities", ["KC"])
+        except Exception:
+            tickers = ["KC", "CC", "NG"]
+
+    print("=" * 60)
+    print(f"Volatility Brier Re-Scoring — {'DRY RUN' if args.dry_run else 'LIVE'}")
+    print(f"Commodities: {tickers}")
+    print("=" * 60)
+
+    total_stats = {"checked": 0, "corrected": 0, "skipped": 0, "errors": 0}
+
+    for ticker in tickers:
+        print(f"\n--- {ticker} ---")
+        stats = rescore_commodity(ticker, dry_run=args.dry_run, output_csv=args.output_csv)
+        for k in total_stats:
+            total_stats[k] += stats[k]
+
+    print("\n" + "=" * 60)
+    print(f"Total: checked={total_stats['checked']}, "
+          f"corrected={total_stats['corrected']}, "
+          f"skipped={total_stats['skipped']}, "
+          f"errors={total_stats['errors']}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_enhanced_brier_math.py
+++ b/tests/test_enhanced_brier_math.py
@@ -235,5 +235,74 @@ class TestEnhancedBrierMath(unittest.TestCase):
         self.assertEqual(result, 1.0)
 
 
+    # === Volatility-Aware Resolution Tests ===
+
+    def test_resolve_outcome_for_cycle_directional(self):
+        """Directional cycles use actual_trend_direction unchanged."""
+        from trading_bot.enhanced_brier import resolve_outcome_for_cycle
+        assert resolve_outcome_for_cycle("BULLISH", "DIRECTIONAL", "") == "BULLISH"
+        assert resolve_outcome_for_cycle("BEARISH", "DIRECTIONAL", "") == "BEARISH"
+        assert resolve_outcome_for_cycle("NEUTRAL", "DIRECTIONAL", "") == "NEUTRAL"
+
+    def test_resolve_outcome_for_cycle_vol_stayed_flat(self):
+        """VOLATILITY + STAYED_FLAT → always NEUTRAL.
+
+        This is the most business-critical case: an iron condor that profited
+        because the market stayed flat. Without this fix, agents who correctly
+        predicted NEUTRAL get penalized because a tiny price uptick (e.g., +0.3%)
+        resolves the cycle as BULLISH in actual_trend_direction.
+        """
+        from trading_bot.enhanced_brier import resolve_outcome_for_cycle
+        # Even if price ticked up (BULLISH), condor staying flat = NEUTRAL
+        assert resolve_outcome_for_cycle("BULLISH", "VOLATILITY", "STAYED_FLAT") == "NEUTRAL"
+        assert resolve_outcome_for_cycle("BEARISH", "VOLATILITY", "STAYED_FLAT") == "NEUTRAL"
+        # Even NEUTRAL direction + STAYED_FLAT = NEUTRAL (no change, but consistent)
+        assert resolve_outcome_for_cycle("NEUTRAL", "VOLATILITY", "STAYED_FLAT") == "NEUTRAL"
+
+    def test_resolve_outcome_for_cycle_vol_big_move(self):
+        """VOLATILITY + BIG_MOVE → use actual direction.
+
+        When the market breaks out, agents who predicted the right direction
+        should be rewarded. Agents who predicted NEUTRAL should be penalized.
+        """
+        from trading_bot.enhanced_brier import resolve_outcome_for_cycle
+        assert resolve_outcome_for_cycle("BULLISH", "VOLATILITY", "BIG_MOVE") == "BULLISH"
+        assert resolve_outcome_for_cycle("BEARISH", "VOLATILITY", "BIG_MOVE") == "BEARISH"
+
+    def test_resolve_outcome_for_cycle_missing_fields(self):
+        """Missing/empty fields fall back to directional safely."""
+        from trading_bot.enhanced_brier import resolve_outcome_for_cycle
+        assert resolve_outcome_for_cycle("BULLISH", "", "") == "BULLISH"
+        assert resolve_outcome_for_cycle("BEARISH", "VOLATILITY", "") == "BEARISH"
+        assert resolve_outcome_for_cycle("", "VOLATILITY", "BIG_MOVE") == ""
+
+    def test_resolve_outcome_for_cycle_nan_handling(self):
+        """Pandas NaN and None values don't cause incorrect matches."""
+        from trading_bot.enhanced_brier import resolve_outcome_for_cycle
+        # float('nan') stringifies to "nan" → should not match any valid outcome
+        assert resolve_outcome_for_cycle("BULLISH", "nan", "nan") == "BULLISH"
+        # None values handled safely
+        assert resolve_outcome_for_cycle("BEARISH", None, None) == "BEARISH"
+        assert resolve_outcome_for_cycle(None, "VOLATILITY", "STAYED_FLAT") == "NEUTRAL"
+
+    def test_resolve_outcome_unexpected_vol_outcome_warns(self):
+        """Unexpected volatility_outcome values emit a warning and fall through."""
+        from trading_bot.enhanced_brier import resolve_outcome_for_cycle
+        with self.assertLogs('trading_bot.enhanced_brier', level='WARNING') as cm:
+            result = resolve_outcome_for_cycle("BULLISH", "VOLATILITY", "SOMETHING_WEIRD")
+        # Should fall through to directional
+        assert result == "BULLISH"
+        # Should have logged a warning about unexpected value
+        assert any("Unexpected volatility_outcome" in msg for msg in cm.output)
+
+    def test_resolve_outcome_unresolvable_warns(self):
+        """Completely unresolvable inputs emit a warning and return empty string."""
+        from trading_bot.enhanced_brier import resolve_outcome_for_cycle
+        with self.assertLogs('trading_bot.enhanced_brier', level='WARNING') as cm:
+            result = resolve_outcome_for_cycle("GARBAGE", "VOLATILITY", "BIG_MOVE")
+        assert result == ""
+        assert any("Unresolvable outcome" in msg for msg in cm.output)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/trading_bot/enhanced_brier.py
+++ b/trading_bot/enhanced_brier.py
@@ -90,6 +90,73 @@ def normalize_regime(regime_str: str) -> MarketRegime:
     return result
 
 
+def resolve_outcome_for_cycle(
+    actual_trend_direction: str,
+    prediction_type: str = "",
+    volatility_outcome: str = "",
+) -> str:
+    """
+    Determine the correct Brier resolution outcome for a prediction.
+
+    For DIRECTIONAL cycles: use actual_trend_direction as-is.
+    For VOLATILITY cycles where market STAYED_FLAT: resolve as NEUTRAL
+      (rewards agents who correctly predicted range-bound conditions).
+    For VOLATILITY cycles with BIG_MOVE: use actual directional movement
+      (rewards agents who predicted the breakout direction).
+
+    This is the SINGLE SOURCE OF TRUTH for outcome resolution.
+    All resolution paths (enhanced_brier backfill, brier_reconciliation,
+    re-scoring scripts) must use this function.
+
+    Args:
+        actual_trend_direction: BULLISH, BEARISH, or NEUTRAL from reconciliation
+        prediction_type: DIRECTIONAL or VOLATILITY from council_history
+        volatility_outcome: BIG_MOVE or STAYED_FLAT from council_history
+
+    Returns:
+        Resolution outcome: BULLISH, BEARISH, or NEUTRAL.
+        Empty string if unresolvable.
+    """
+    # NaN-safe string conversion: pandas NaN → "NAN", None → "NONE"
+    atd = str(actual_trend_direction).strip().upper() if actual_trend_direction is not None else ""
+    ptype = str(prediction_type).strip().upper() if prediction_type is not None else ""
+    vol_out = str(volatility_outcome).strip().upper() if volatility_outcome is not None else ""
+
+    # Guard against pandas NaN stringification
+    if atd in ("NAN", "NONE", ""):
+        atd = ""
+    if ptype in ("NAN", "NONE", ""):
+        ptype = ""
+    if vol_out in ("NAN", "NONE", ""):
+        vol_out = ""
+
+    if ptype == "VOLATILITY":
+        if vol_out == "STAYED_FLAT":
+            return "NEUTRAL"
+        if vol_out == "BIG_MOVE":
+            # Use directional movement — intentional.
+            # Agents who predicted the breakout direction get rewarded.
+            pass
+        elif vol_out:
+            # Unexpected value — log but fall through to directional
+            logger.warning(
+                f"Unexpected volatility_outcome '{volatility_outcome}' "
+                f"for VOLATILITY cycle. Falling back to directional resolution."
+            )
+
+    # Default path: use directional movement
+    if atd in ("BULLISH", "BEARISH", "NEUTRAL"):
+        return atd
+
+    # Truly unresolvable
+    if atd or ptype or vol_out:
+        logger.warning(
+            f"Unresolvable outcome: atd='{actual_trend_direction}', "
+            f"ptype='{prediction_type}', vol='{volatility_outcome}'"
+        )
+    return ""
+
+
 @dataclass
 class ProbabilisticPrediction:
     """A prediction with full probability distribution."""
@@ -503,13 +570,17 @@ class EnhancedBrierTracker:
         if os.path.exists(council_path):
             try:
                 ch_df = pd.read_csv(council_path, on_bad_lines='warn')
-                # Build cycle_id → actual_trend_direction lookup
+                # Build cycle_id → outcome lookup (volatility-aware)
                 ch_outcomes = {}
                 for _, row in ch_df.iterrows():
                     cid = str(row.get('cycle_id', '')).strip()
-                    atd = str(row.get('actual_trend_direction', '')).strip().upper()
-                    if cid and atd and atd in ('BULLISH', 'BEARISH', 'NEUTRAL'):
-                        ch_outcomes[cid] = atd
+                    atd = str(row.get('actual_trend_direction', '')).strip()
+                    prediction_type = str(row.get('prediction_type', '')).strip()
+                    vol_outcome = str(row.get('volatility_outcome', '')).strip()
+
+                    outcome = resolve_outcome_for_cycle(atd, prediction_type, vol_outcome)
+                    if cid and outcome:
+                        ch_outcomes[cid] = outcome
 
                 for pred in self.predictions:
                     if pred.actual_outcome is not None:


### PR DESCRIPTION
## Summary

- VOLATILITY/STAYED_FLAT cycles were incorrectly resolved using directional price movement (BULLISH/BEARISH), penalizing agents who correctly predicted NEUTRAL for iron condor trades
- Affected 12.4% of KC cycles (41 of 330), corrupting 130 prediction scores across all 9 agents
- Adds `resolve_outcome_for_cycle()` as single source of truth for Brier outcome resolution (NaN-safe, with warning logs)
- Updates `backfill_from_resolved_csv()` Pass 3 to use the new helper
- Includes one-time re-scoring script (`scripts/rescore_volatility_brier.py`) to fix historical data

## Post-merge deployment steps

```bash
# 1. Dry-run to preview corrections
python scripts/rescore_volatility_brier.py --dry-run

# 2. Apply corrections with audit trail
python scripts/rescore_volatility_brier.py --output-csv
```

## Test plan

- [x] 15/15 `test_enhanced_brier_math.py` pass (7 new tests for `resolve_outcome_for_cycle`)
- [x] 9/9 `test_brier_bridge.py` pass (no regressions)
- [x] 5/5 `test_brier_scoring_new.py` pass (no regressions)
- [x] Dry-run on production KC data: 130 corrections across 41 cycles, 0 errors
- [ ] Run re-scoring script live after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)