### PR TITLE
feat: upgrade DSPy bootstrap model to Grok, configurable demo counts

### DIFF
--- a/config.json
+++ b/config.json
@@ -559,6 +559,9 @@
   "dspy": {
     "use_optimized_prompts": {},
     "optimized_prompts_dir": "data/dspy_optimized",
+    "bootstrap_model": "xai/grok-4-1-fast-reasoning",
+    "max_bootstrapped_demos": 4,
+    "max_labeled_demos": 2,
     "min_examples_per_agent": 30,
     "min_examples_for_suggest": 100
   },

--- a/scripts/optimize_prompts.py
+++ b/scripts/optimize_prompts.py
@@ -200,11 +200,17 @@ def main():
     # Optimization mode — pre-flight checks
     # Check for required API key before starting (avoids N identical failures)
     bootstrap_model = dspy_config.get("bootstrap_model", "openai/gpt-4o-mini")
-    if bootstrap_model.startswith("openai/") and not os.environ.get("OPENAI_API_KEY"):
-        print("Error: OPENAI_API_KEY environment variable is required for --optimize mode.")
-        print(f"  Bootstrap model: {bootstrap_model}")
-        print("  Set the key or configure dspy.bootstrap_model in config.json.")
-        sys.exit(1)
+    api_key_map = {
+        "openai/": "OPENAI_API_KEY",
+        "xai/": "XAI_API_KEY",
+        "anthropic/": "ANTHROPIC_API_KEY",
+    }
+    for prefix, env_var in api_key_map.items():
+        if bootstrap_model.startswith(prefix) and not os.environ.get(env_var):
+            print(f"Error: {env_var} environment variable is required for --optimize mode.")
+            print(f"  Bootstrap model: {bootstrap_model}")
+            print("  Set the key or configure dspy.bootstrap_model in config.json.")
+            sys.exit(1)
 
     _ensure_signature()
 

--- a/trading_bot/dspy_optimizer.py
+++ b/trading_bot/dspy_optimizer.py
@@ -458,11 +458,14 @@ def optimize_agent(
         calibration = 1.0 - abs(pred_conf - actual_hit)
         return direction_match * 0.7 + calibration * 0.3
 
-    # Run BootstrapFewShot
+    # Run BootstrapFewShot (demo counts configurable via config.dspy)
+    dspy_cfg = config.get("dspy", {})
+    max_bootstrapped = dspy_cfg.get("max_bootstrapped_demos", 4)
+    max_labeled = dspy_cfg.get("max_labeled_demos", 4)
     optimizer = dspy.BootstrapFewShot(
         metric=metric,
-        max_bootstrapped_demos=4,
-        max_labeled_demos=4,
+        max_bootstrapped_demos=max_bootstrapped,
+        max_labeled_demos=max_labeled,
     )
 
     module = AgentPredictor()


### PR DESCRIPTION
## Summary
- Switch DSPy bootstrap model from `gpt-4o-mini` to `xai/grok-4-1-fast-reasoning` — same cost tier, better reasoning traces, already trusted in production for 5 agent roles
- Make `max_bootstrapped_demos` (4) and `max_labeled_demos` (2) configurable via `config.json` instead of hardcoded
- Extend API key pre-flight check in `optimize_prompts.py` to support `xai/` and `anthropic/` model prefixes

## Context
KC agents have 174–187 resolved predictions each (well above the 30-sample optimization threshold). Directional accuracy ranges from 29% (macro) to 65% (supply_chain) — significant room for DSPy to improve worst performers. The bootstrap model upgrade ensures optimization reasoning traces are generated by a production-grade model rather than a capability-reduced one.

## Test plan
- [x] All 15 Brier math tests pass
- [ ] Run `python scripts/optimize_prompts.py --ticker KC` (readiness eval, no API calls)
- [ ] Run `python scripts/optimize_prompts.py --optimize --ticker KC` post-deploy to validate Grok bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)