### PR TITLE
fix: DSPy metric abstention penalty and baseline accuracy tracking

### DIFF
--- a/trading_bot/dspy_optimizer.py
+++ b/trading_bot/dspy_optimizer.py
@@ -448,13 +448,14 @@ def optimize_agent(
             )
 
     # Metric: directional accuracy (0.7) + calibration (0.3)
-    # NEUTRAL predictions are penalized — agents should commit to a direction
+    # NEUTRAL predictions get flat 0.0 — agents must commit to a direction.
+    # Without this, NEUTRAL scores ~0.15 (via calibration credit), same as a
+    # wrong directional call, so the optimizer learns to abstain.
     def metric(example, prediction, trace=None):
         pred_dir = prediction.direction
         if pred_dir == "NEUTRAL":
-            direction_match = 0.0
-        else:
-            direction_match = 1.0 if pred_dir == example.actual else 0.0
+            return 0.0  # No credit for abstaining
+        direction_match = 1.0 if pred_dir == example.actual else 0.0
         try:
             pred_conf = float(prediction.confidence)
         except (ValueError, TypeError, AttributeError):
@@ -492,17 +493,22 @@ def optimize_agent(
     val_accuracy = val_correct / val_directional if val_directional else 0.0
     val_abstention = 1.0 - (val_directional / len(valset)) if valset else 0.0
 
-    # Extract optimized instruction and demos
+    # Extract optimized instruction and demos (filter out NEUTRAL demos —
+    # they teach abstention rather than directional commitment)
     instruction = persona_prompt  # BootstrapFewShot selects demos, keeps instruction
     demos = []
     if hasattr(compiled, "predict") and hasattr(compiled.predict, "demos"):
         for demo in compiled.predict.demos:
+            direction = getattr(demo, "direction", "")
+            if direction == "NEUTRAL":
+                logger.info(f"[{agent_name}] Filtering out NEUTRAL demo from export")
+                continue
             demos.append({
                 "input": {
                     "market_context": getattr(demo, "market_context", ""),
                 },
                 "output": {
-                    "direction": getattr(demo, "direction", ""),
+                    "direction": direction,
                     "confidence": str(getattr(demo, "confidence", "0.5")),
                     "analysis": getattr(demo, "analysis", ""),
                 },


### PR DESCRIPTION
## Summary
- **Fix NEUTRAL abstention exploit in DSPy metric**: The optimizer learned to abstain (say NEUTRAL) because NEUTRAL scored ~0.15 — same as a wrong directional call. Now NEUTRAL returns flat 0.0, creating clear incentive: correct (0.91) > wrong (0.15) > abstain (0.0)
- **Filter NEUTRAL demos from export**: Demos showing NEUTRAL predictions teach abstention rather than directional commitment
- **Populate baseline_directional_accuracy**: Was always `null` in prompt.json because `optimize_agent()` never computed it

## Context
First optimization run on KC showed agronomist achieving 62.5% directional accuracy but with **78% abstention** — the model was gaming the metric by only committing on the most obvious signals. These fixes ensure the optimizer selects demos that produce directional commitments.

## Test plan
- [x] All 15 Brier math tests pass
- [ ] Re-run `python scripts/optimize_prompts.py --optimize --ticker KC` and verify abstention rates drop significantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)