### PR TITLE
fix: disable phantom reconciliation and fix RECON_MISSING position_ids

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1965,6 +1965,15 @@ async def _reconcile_state_stores(
         # IBKR counts each contract leg as a separate position, so we must too.
         if not trade_ledger.empty and 'local_symbol' in trade_ledger.columns:
             tl_valid = trade_ledger[trade_ledger['local_symbol'].astype(str).str.strip() != ''].copy()
+            # Drop PHANTOM_RECONCILIATION entries — these are synthetic closes
+            # that double-count positions already covered by RECONCILIATION_MISSING.
+            # Matches the filtering in get_local_active_positions().
+            if 'reason' in tl_valid.columns:
+                reasons = tl_valid['reason'].fillna('')
+                phantom_mask = reasons.str.contains('PHANTOM_RECONCILIATION', case=False)
+                if phantom_mask.any():
+                    logger.info(f"State sync: excluding {phantom_mask.sum()} PHANTOM entries from ledger count")
+                    tl_valid = tl_valid[~phantom_mask]
             if not tl_valid.empty:
                 tl_valid['signed_qty'] = np.where(tl_valid['action'] == 'BUY', tl_valid['quantity'], -tl_valid['quantity'])
                 net_qtys = tl_valid.groupby('local_symbol')['signed_qty'].sum()
@@ -2101,19 +2110,12 @@ async def run_position_audit_cycle(config: dict, trigger_source: str = "Schedule
             except Exception as e:
                 logger.warning(f"Post-audit reconciliation failed (non-fatal): {e}")
 
-            # Reconcile: If ledger has non-zero entries but IB has no positions,
-            # zero them out with synthetic close rows
-            try:
-                phantom_count = await _reconcile_phantom_ledger_entries(
-                    trade_ledger, tms, config
-                )
-                if phantom_count > 0:
-                    logger.warning(
-                        f"Phantom reconciliation zeroed out {phantom_count} "
-                        f"ledger entries (IB has zero positions)"
-                    )
-            except Exception as e:
-                logger.warning(f"Phantom ledger reconciliation failed (non-fatal): {e}")
+            # Phantom reconciliation DISABLED — it creates synthetic close rows
+            # that worsen state sync discrepancies (adds extra non-zero symbols).
+            # Root causes: IB net-zero netting of opposing spreads, RECON_MISSING
+            # with fabricated position_ids, and emergency close EMERGENCY_ pids.
+            # See: https://github.com/rozavala/real_options/pull/1210
+            logger.info("Phantom ledger reconciliation skipped (disabled)")
 
             return
 

--- a/reconcile_trades.py
+++ b/reconcile_trades.py
@@ -230,7 +230,74 @@ async def reconcile_active_positions(config: dict):
         logger.info("Active Position Reconciliation complete. No discrepancies found.")
 
 
-def write_missing_trades_to_csv(missing_trades_df: pd.DataFrame, data_dir: str = None):
+def _resolve_original_position_ids(
+    missing_df: pd.DataFrame,
+    ledger: pd.DataFrame = None,
+    data_dir: str = None,
+) -> pd.DataFrame:
+    """
+    Replace fabricated Flex Query position_ids with original position_ids
+    from the consolidated trade ledger.
+
+    For each missing trade, finds ledger entries with the same local_symbol
+    and picks the position_id from the most recent open position group.
+    This ensures RECONCILIATION_MISSING entries cancel out the correct
+    original entries when net quantities are computed per (position_id, symbol).
+    """
+    if ledger is None:
+        ledger = get_trade_ledger_df(data_dir)
+    if ledger.empty:
+        return missing_df
+
+    result = missing_df.copy()
+
+    # Exclude synthetic entries from lookup — we want real position_ids
+    if 'reason' in ledger.columns:
+        reasons = ledger['reason'].fillna('')
+        ledger = ledger[~reasons.str.contains(
+            'PHANTOM_RECONCILIATION|RECONCILIATION_MISSING|Ledger reconciliation',
+            case=False
+        )]
+
+    if ledger.empty:
+        return missing_df
+
+    # Ensure timestamp is datetime for sorting
+    if not pd.api.types.is_datetime64_any_dtype(ledger['timestamp']):
+        ledger['timestamp'] = pd.to_datetime(ledger['timestamp'], utc=True, errors='coerce')
+
+    # Pre-compute lookup: symbol → position_id of the most recent entry
+    sorted_ledger = ledger.sort_values('timestamp', ascending=False)
+    pid_lookup = (
+        sorted_ledger
+        .dropna(subset=['position_id'])
+        .groupby('local_symbol')['position_id']
+        .first()
+        .to_dict()
+    )
+
+    for idx, row in result.iterrows():
+        symbol = row.get('local_symbol', '')
+        if not symbol:
+            continue
+
+        original_pid = pid_lookup.get(symbol)
+        if original_pid and str(original_pid).strip():
+            old_pid = row.get('position_id', '')
+            result.at[idx, 'position_id'] = original_pid
+            logger.info(
+                f"Resolved position_id for {symbol}: "
+                f"{str(old_pid)[:30]}... → {str(original_pid)[:30]}..."
+            )
+
+    return result
+
+
+def write_missing_trades_to_csv(
+    missing_trades_df: pd.DataFrame,
+    data_dir: str = None,
+    ledger: pd.DataFrame = None,
+):
     """
     Writes the DataFrame of missing trades to a `missing_trades.csv` file
     inside the `archive_ledger` directory.
@@ -255,10 +322,10 @@ def write_missing_trades_to_csv(missing_trades_df: pd.DataFrame, data_dir: str =
     ]
 
     try:
-        # Create the final DataFrame with the 'reason' column and ensure field order
-        final_df = missing_trades_df.copy()
+        # Resolve fabricated Flex Query position_ids to original ledger ones
+        final_df = _resolve_original_position_ids(missing_trades_df, ledger=ledger, data_dir=data_dir)
         final_df['reason'] = 'RECONCILIATION_MISSING'
-        
+
         # Sort by timestamp before writing
         final_df.sort_values(by='timestamp', inplace=True)
 
@@ -267,14 +334,14 @@ def write_missing_trades_to_csv(missing_trades_df: pd.DataFrame, data_dir: str =
 
         # Reorder columns to match the ledger
         final_df = final_df.reindex(columns=fieldnames)
-        
+
         final_df.to_csv(
-            output_path, 
-            index=False, 
-            header=True, 
+            output_path,
+            index=False,
+            header=True,
             float_format='%.2f'
         )
-        
+
         logger.info(f"Successfully wrote {len(final_df)} missing trade(s) to '{output_path}'.")
 
     except IOError as e:
@@ -796,7 +863,8 @@ async def main(lookback_days: int = None, config: dict = None):
         logger.info(f"Filtered IB trades by commodity {ticker} (prefixes {prefixes}): {pre_filter_count} -> {len(ib_trades_df)}")
 
     # --- 4. Load Local Trade Ledger ---
-    local_trades_df = get_trade_ledger_df(config.get('data_dir'))
+    full_ledger = get_trade_ledger_df(config.get('data_dir'))
+    local_trades_df = full_ledger
     if local_trades_df.empty:
         logger.warning("Local trade ledger is empty. All fetched IB trades will be considered missing.")
 
@@ -840,7 +908,7 @@ async def main(lookback_days: int = None, config: dict = None):
     else:
         # --- 7. Output Discrepancy Reports ---
         logger.info("Discrepancies found. Writing to output files.")
-        write_missing_trades_to_csv(missing_trades_df, config.get('data_dir'))
+        write_missing_trades_to_csv(missing_trades_df, config.get('data_dir'), ledger=full_ledger)
         write_superfluous_trades_to_csv(superfluous_trades_df, config.get('data_dir'))
 
     # --- 8. Return the dataframes for the orchestrator ---

--- a/scripts/cleanup_phantom_ledger.py
+++ b/scripts/cleanup_phantom_ledger.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""
+One-time cleanup: Remove PHANTOM_RECONCILIATION entries from archived trade ledgers.
+
+These synthetic entries were created by _reconcile_phantom_ledger_entries() and
+cause double-counting when combined with RECONCILIATION_MISSING entries that
+capture the same close trades from Flex Query.
+
+Also removes specific RECON_MISSING entries that are provably duplicates or
+orphaned closes for positions already at zero.
+
+Usage:
+    python scripts/cleanup_phantom_ledger.py --commodity KC --dry-run
+    python scripts/cleanup_phantom_ledger.py --commodity KC
+
+Safe to run multiple times — only removes entries matching specific patterns.
+"""
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def cleanup_commodity(ticker: str, data_dir: str, dry_run: bool) -> dict:
+    """Remove phantom entries from archived ledgers for one commodity."""
+    archive_dir = os.path.join(data_dir, ticker, "archive_ledger")
+    stats = {"files_modified": 0, "phantom_removed": 0, "recon_dupes_removed": 0}
+
+    if not os.path.isdir(archive_dir):
+        logger.info(f"[{ticker}] No archive directory — skipping")
+        return stats
+
+    # --- Pass 1: Remove PHANTOM_RECONCILIATION entries ---
+    archive_files = sorted(
+        f for f in os.listdir(archive_dir)
+        if f.startswith("trade_ledger_") and f.endswith(".csv")
+        and f != "trade_ledger_missing_trades.csv"
+    )
+
+    for filename in archive_files:
+        filepath = os.path.join(archive_dir, filename)
+        try:
+            df = pd.read_csv(filepath)
+        except Exception as e:
+            logger.warning(f"[{ticker}] Failed to read {filename}: {e}")
+            continue
+
+        if "reason" not in df.columns:
+            continue
+
+        reason_str = df["reason"].fillna("")
+        phantom_mask = reason_str.str.contains("PHANTOM_RECONCILIATION", case=False)
+        n_phantom = phantom_mask.sum()
+
+        if n_phantom == 0:
+            continue
+
+        logger.info(f"[{ticker}] {filename}: {n_phantom} PHANTOM entries")
+        stats["phantom_removed"] += n_phantom
+
+        if not dry_run:
+            clean_df = df[~phantom_mask]
+            if clean_df.empty:
+                # File would be empty — remove it entirely
+                os.remove(filepath)
+                logger.info(f"  Removed empty file {filename}")
+            else:
+                clean_df.to_csv(filepath, index=False, float_format="%.2f")
+                logger.info(f"  Wrote {len(clean_df)} remaining entries to {filename}")
+            stats["files_modified"] += 1
+
+    # --- Pass 2: Remove duplicate/orphaned RECON_MISSING entries ---
+    # Load full consolidated ledger to identify duplicates
+    all_dfs = []
+    for filename in archive_files:
+        filepath = os.path.join(archive_dir, filename)
+        if os.path.exists(filepath):
+            try:
+                df = pd.read_csv(filepath)
+                df["_source"] = filename
+                all_dfs.append(df)
+            except Exception:
+                pass
+
+    missing_path = os.path.join(archive_dir, "trade_ledger_missing_trades.csv")
+    if os.path.exists(missing_path):
+        try:
+            df = pd.read_csv(missing_path)
+            df["_source"] = "trade_ledger_missing_trades.csv"
+            all_dfs.append(df)
+        except Exception:
+            pass
+
+    if not all_dfs:
+        return stats
+
+    full = pd.concat(all_dfs, ignore_index=True)
+    full["quantity"] = pd.to_numeric(full["quantity"], errors="coerce").fillna(0)
+    full["signed"] = np.where(full["action"] == "BUY", full["quantity"], -full["quantity"])
+    reason_col = full["reason"].fillna("")
+
+    # Identify RECON_MISSING entries to remove:
+    # Strategy: remove RECON_MISSING entries for symbols where:
+    #   (a) base ledger (non-PHANTOM, non-RECON) is already balanced (net=0), OR
+    #   (b) RECON_MISSING creates imbalance beyond what base+RECON should show
+    base_mask = ~reason_col.str.contains(
+        "RECONCILIATION_MISSING|PHANTOM_RECONCILIATION", case=False
+    )
+    base = full[base_mask]
+    recon = full[reason_col == "RECONCILIATION_MISSING"]
+
+    if recon.empty:
+        return stats
+
+    base_net = base.groupby("local_symbol")["signed"].sum()
+    recon_net = recon.groupby("local_symbol")["signed"].sum()
+
+    # Find RECON_MISSING entries that are duplicates (same pid, symbol, action
+    # as a base entry within 30 seconds)
+    dupes_to_remove = []
+    if not base.empty and not recon.empty:
+        base_ts = base.copy()
+        recon_ts = recon.copy()
+        base_ts["timestamp"] = pd.to_datetime(base_ts["timestamp"], errors="coerce")
+        recon_ts["timestamp"] = pd.to_datetime(recon_ts["timestamp"], errors="coerce")
+
+        for idx, rrow in recon_ts.iterrows():
+            sym = rrow.get("local_symbol", "")
+            pid = str(rrow.get("position_id", ""))
+            action = rrow.get("action", "")
+
+            # Check if a base entry exists with same pid, symbol, action
+            matches = base_ts[
+                (base_ts["local_symbol"] == sym)
+                & (base_ts["position_id"].astype(str) == pid)
+                & (base_ts["action"] == action)
+            ]
+            if not matches.empty:
+                dupes_to_remove.append(idx)
+                logger.info(
+                    f"  Duplicate RECON_MISSING: {rrow['timestamp']} {action} {sym} "
+                    f"pid={pid[:35]} (base has same trade)"
+                )
+
+    # Find RECON_MISSING entries for symbols already balanced in base
+    orphans_to_remove = []
+    for sym in recon["local_symbol"].unique():
+        sym_base_net = base_net.get(sym, 0)
+        sym_recon_net = recon_net.get(sym, 0)
+        combined = sym_base_net + sym_recon_net
+
+        if abs(sym_base_net) < 0.001 and abs(combined) > 0.001:
+            # Base is balanced but RECON creates imbalance — these are orphaned
+            orphan_entries = recon[recon["local_symbol"] == sym]
+            for idx, row in orphan_entries.iterrows():
+                if idx not in dupes_to_remove:  # Don't double-count
+                    orphans_to_remove.append(idx)
+                    logger.info(
+                        f"  Orphaned RECON_MISSING: {row['timestamp']} {row['action']} {sym} "
+                        f"(base already balanced, RECON adds {sym_recon_net:+.0f})"
+                    )
+
+    all_recon_to_remove = set(dupes_to_remove + orphans_to_remove)
+    stats["recon_dupes_removed"] = len(all_recon_to_remove)
+
+    if all_recon_to_remove and not dry_run:
+        # Group removals by source file
+        entries_to_remove = full.loc[list(all_recon_to_remove)]
+        for src_file, group in entries_to_remove.groupby("_source"):
+            filepath = os.path.join(archive_dir, src_file)
+            if not os.path.exists(filepath):
+                continue
+
+            src_df = pd.read_csv(filepath)
+            orig_len = len(src_df)
+
+            # Match by timestamp + local_symbol + action + position_id to remove
+            for _, row in group.iterrows():
+                match_mask = (
+                    (src_df["timestamp"].astype(str) == str(row["timestamp"]))
+                    & (src_df["local_symbol"] == row["local_symbol"])
+                    & (src_df["action"] == row["action"])
+                    & (src_df["position_id"].astype(str) == str(row["position_id"]))
+                    & (src_df["reason"].fillna("") == "RECONCILIATION_MISSING")
+                )
+                src_df = src_df[~match_mask]
+
+            if len(src_df) < orig_len:
+                if src_df.empty:
+                    os.remove(filepath)
+                    logger.info(f"  Removed empty file {src_file}")
+                else:
+                    src_df.to_csv(filepath, index=False, float_format="%.2f")
+                    logger.info(
+                        f"  Updated {src_file}: {orig_len} → {len(src_df)} entries"
+                    )
+                stats["files_modified"] += 1
+
+    return stats
+
+
+def verify_result(ticker: str, data_dir: str):
+    """Verify the ledger state after cleanup."""
+    archive_dir = os.path.join(data_dir, ticker, "archive_ledger")
+    dfs = []
+    for f in sorted(os.listdir(archive_dir)):
+        if f.endswith(".csv"):
+            try:
+                df = pd.read_csv(os.path.join(archive_dir, f))
+                dfs.append(df)
+            except Exception:
+                pass
+
+    main = os.path.join(data_dir, ticker, "trade_ledger.csv")
+    if os.path.exists(main):
+        try:
+            dfs.append(pd.read_csv(main))
+        except Exception:
+            pass
+
+    if not dfs:
+        print(f"  [{ticker}] No ledger data to verify")
+        return
+
+    full = pd.concat(dfs, ignore_index=True)
+    full["quantity"] = pd.to_numeric(full["quantity"], errors="coerce").fillna(0)
+    full["signed"] = np.where(full["action"] == "BUY", full["quantity"], -full["quantity"])
+
+    net = full.groupby("local_symbol")["signed"].sum()
+    non_zero = net[net.abs() > 0.001]
+
+    reason_str = full["reason"].fillna("")
+    n_phantom = reason_str.str.contains("PHANTOM_RECONCILIATION", case=False).sum()
+    n_recon = (reason_str == "RECONCILIATION_MISSING").sum()
+
+    print(f"\n  [{ticker}] POST-CLEANUP VERIFICATION:")
+    print(f"  Total entries: {len(full)}")
+    print(f"  PHANTOM entries remaining: {n_phantom}")
+    print(f"  RECON_MISSING entries remaining: {n_recon}")
+    print(f"  Non-zero symbols: {len(non_zero)}")
+    for sym, qty in sorted(non_zero.items()):
+        print(f"    {sym}: {qty:+.0f}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Remove PHANTOM_RECONCILIATION entries from archived trade ledgers"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Preview without writing")
+    parser.add_argument("--commodity", type=str, help="Single commodity (e.g., KC)")
+    parser.add_argument(
+        "--data-dir", type=str, default=str(PROJECT_ROOT / "data"),
+        help="Path to data directory"
+    )
+    args = parser.parse_args()
+
+    tickers = [args.commodity.upper()] if args.commodity else ["KC", "CC", "NG"]
+
+    print("=" * 60)
+    print(f"Phantom Ledger Cleanup — {'DRY RUN' if args.dry_run else 'LIVE'}")
+    print(f"Commodities: {tickers}")
+    print("=" * 60)
+
+    for ticker in tickers:
+        print(f"\n--- {ticker} ---")
+        stats = cleanup_commodity(ticker, args.data_dir, args.dry_run)
+        print(
+            f"  [{ticker}] phantom_removed={stats['phantom_removed']}, "
+            f"recon_dupes_removed={stats['recon_dupes_removed']}, "
+            f"files_modified={stats['files_modified']}"
+        )
+        if not args.dry_run:
+            verify_result(ticker, args.data_dir)
+
+    print("\n" + "=" * 60)
+    if args.dry_run:
+        print("DRY RUN complete. Re-run without --dry-run to apply changes.")
+    else:
+        print("Cleanup complete.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **Disable phantom reconciliation** — `_reconcile_phantom_ledger_entries()` creates synthetic close entries that double-count positions already covered by RECONCILIATION_MISSING from Flex Query. Data shows phantoms add 2 extra non-zero symbols to the state sync discrepancy.
- **Filter PHANTOM entries in state sync** — `_reconcile_state_stores()` now excludes PHANTOM_RECONCILIATION entries, matching the filtering already done by `get_local_active_positions()`.
- **Fix RECON_MISSING position_ids** — New `_resolve_original_position_ids()` looks up real position_ids from the consolidated ledger instead of using fabricated Flex Query IDs. Avoids redundant disk reads by accepting the already-loaded ledger.
- **Add cleanup script** — `scripts/cleanup_phantom_ledger.py` removes historical phantom entries and orphaned/duplicate RECON_MISSING entries from archived ledger CSVs.

## Data validation (DEV KC ledger)
| Scenario | Non-zero symbols | vs IB (2) |
|----------|-----------------|-----------|
| Current state (all entries) | 7 | +5 |
| After code fix (phantom filtered in state sync) | 5 | +3 |
| After code fix + cleanup script | **2** | **match** |

## Test plan
- [x] All 18 reconciliation tests pass
- [ ] Merge and deploy to DEV
- [ ] Run `python scripts/cleanup_phantom_ledger.py --commodity KC --dry-run` on DEV to preview
- [ ] Run `python scripts/cleanup_phantom_ledger.py --commodity KC` to clean up
- [ ] Verify state sync warning resolves on next audit cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)