### PR TITLE
fix: increase reconciliation timestamp tolerance to 30s

### DIFF
--- a/reconcile_trades.py
+++ b/reconcile_trades.py
@@ -401,7 +401,8 @@ def reconcile_trades(ib_trades_df: pd.DataFrame, local_trades_df: pd.DataFrame) 
 
     This enhanced version ignores `combo_id` and `position_id` and instead
     matches trades based on a combination of symbol, quantity, action, and
-    a 2-second timestamp tolerance for robustness.
+    a 30-second timestamp tolerance (IB execution timestamps can differ
+    from system recording time by 10-15s due to order routing latency).
 
     Returns:
         A tuple containing two DataFrames:
@@ -441,8 +442,10 @@ def reconcile_trades(ib_trades_df: pd.DataFrame, local_trades_df: pd.DataFrame) 
             # Check for a timestamp match within the tolerance
             time_diff = (potential_matches['timestamp'] - ib_trade['timestamp']).abs()
 
-            # Find the index of the first match within the 2-second window
-            match_indices = potential_matches[time_diff <= pd.Timedelta(seconds=2)].index
+            # Find the closest match within a 30-second window.
+            # IB execution timestamps can differ from system recording time
+            # by 10-15 seconds due to order routing and callback latency.
+            match_indices = potential_matches[time_diff <= pd.Timedelta(seconds=30)].index
 
             if len(match_indices) > 0:
                 # If a match is found, remove it from the unmatched pool

--- a/scripts/cleanup_phantom_ledger.py
+++ b/scripts/cleanup_phantom_ledger.py
@@ -110,68 +110,50 @@ def cleanup_commodity(ticker: str, data_dir: str, dry_run: bool) -> dict:
     full["signed"] = np.where(full["action"] == "BUY", full["quantity"], -full["quantity"])
     reason_col = full["reason"].fillna("")
 
-    # Identify RECON_MISSING entries to remove:
-    # Strategy: remove RECON_MISSING entries for symbols where:
-    #   (a) base ledger (non-PHANTOM, non-RECON) is already balanced (net=0), OR
-    #   (b) RECON_MISSING creates imbalance beyond what base+RECON should show
+    # --- Pass 2b: Remove "Ledger reconciliation: phantom RECONCILIATION_MISSING"
+    # entries — these are counter-entries created to cancel RECON_MISSING entries
+    # that were later deemed invalid. With PHANTOM cleanup, they become orphaned.
+    phantom_recon_mask = reason_col.str.contains(
+        "phantom RECONCILIATION_MISSING", case=False
+    )
+    phantom_recon_to_remove = set(full[phantom_recon_mask].index)
+    if phantom_recon_to_remove:
+        for idx in phantom_recon_to_remove:
+            row = full.loc[idx]
+            logger.info(
+                f"  Orphaned counter-entry: {row['timestamp']} {row['action']} "
+                f"{row['local_symbol']} ({row['reason'][:55]})"
+            )
+
+    # --- Pass 2c: Remove duplicate RECON_MISSING entries (same pid+symbol+action
+    # as a base entry — proves the trade was already recorded)
     base_mask = ~reason_col.str.contains(
         "RECONCILIATION_MISSING|PHANTOM_RECONCILIATION", case=False
     )
     base = full[base_mask]
     recon = full[reason_col == "RECONCILIATION_MISSING"]
 
-    if recon.empty:
-        return stats
-
-    base_net = base.groupby("local_symbol")["signed"].sum()
-    recon_net = recon.groupby("local_symbol")["signed"].sum()
-
-    # Find RECON_MISSING entries that are duplicates (same pid, symbol, action
-    # as a base entry within 30 seconds)
-    dupes_to_remove = []
+    dupes_to_remove = set()
     if not base.empty and not recon.empty:
-        base_ts = base.copy()
-        recon_ts = recon.copy()
-        base_ts["timestamp"] = pd.to_datetime(base_ts["timestamp"], errors="coerce")
-        recon_ts["timestamp"] = pd.to_datetime(recon_ts["timestamp"], errors="coerce")
-
-        for idx, rrow in recon_ts.iterrows():
+        for idx, rrow in recon.iterrows():
             sym = rrow.get("local_symbol", "")
             pid = str(rrow.get("position_id", ""))
             action = rrow.get("action", "")
 
             # Check if a base entry exists with same pid, symbol, action
-            matches = base_ts[
-                (base_ts["local_symbol"] == sym)
-                & (base_ts["position_id"].astype(str) == pid)
-                & (base_ts["action"] == action)
+            matches = base[
+                (base["local_symbol"] == sym)
+                & (base["position_id"].astype(str) == pid)
+                & (base["action"] == action)
             ]
             if not matches.empty:
-                dupes_to_remove.append(idx)
+                dupes_to_remove.add(idx)
                 logger.info(
                     f"  Duplicate RECON_MISSING: {rrow['timestamp']} {action} {sym} "
                     f"pid={pid[:35]} (base has same trade)"
                 )
 
-    # Find RECON_MISSING entries for symbols already balanced in base
-    orphans_to_remove = []
-    for sym in recon["local_symbol"].unique():
-        sym_base_net = base_net.get(sym, 0)
-        sym_recon_net = recon_net.get(sym, 0)
-        combined = sym_base_net + sym_recon_net
-
-        if abs(sym_base_net) < 0.001 and abs(combined) > 0.001:
-            # Base is balanced but RECON creates imbalance — these are orphaned
-            orphan_entries = recon[recon["local_symbol"] == sym]
-            for idx, row in orphan_entries.iterrows():
-                if idx not in dupes_to_remove:  # Don't double-count
-                    orphans_to_remove.append(idx)
-                    logger.info(
-                        f"  Orphaned RECON_MISSING: {row['timestamp']} {row['action']} {sym} "
-                        f"(base already balanced, RECON adds {sym_recon_net:+.0f})"
-                    )
-
-    all_recon_to_remove = set(dupes_to_remove + orphans_to_remove)
+    all_recon_to_remove = phantom_recon_to_remove | dupes_to_remove
     stats["recon_dupes_removed"] = len(all_recon_to_remove)
 
     if all_recon_to_remove and not dry_run:


### PR DESCRIPTION
## Summary
Follow-up to #1233. During post-merge cleanup, discovered that the Flex Query reconciliation re-creates RECON_MISSING entries every cycle because:

1. **10-second timestamp gap** between IB execution and system recording causes the 2-second matching tolerance to miss valid trades (KOK6 C2.975 at 14:11:44 vs 14:11:54)
2. **Cleanup script was too aggressive** — removed RECON_MISSING entries needed for self-matching on future reconciliation cycles

Changes:
- Increase `reconcile_trades()` timestamp tolerance from 2s to 30s
- Fix cleanup script: only remove PHANTOM entries, true duplicates (same pid), and orphaned counter-entries. No longer removes "orphaned" RECON_MISSING entries

## Test plan
- [x] All 12 reconciliation tests pass
- [ ] Merge and deploy to DEV
- [ ] Re-run cleanup: `python scripts/cleanup_phantom_ledger.py --commodity KC`
- [ ] Verify KOK6 C2.975/C3.025 are no longer re-detected on next reconciliation cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)