### PR TITLE
fix: remove paired RECON_MISSING entries in cleanup script

### DIFF
--- a/scripts/cleanup_phantom_ledger.py
+++ b/scripts/cleanup_phantom_ledger.py
@@ -153,7 +153,30 @@ def cleanup_commodity(ticker: str, data_dir: str, dry_run: bool) -> dict:
                     f"pid={pid[:35]} (base has same trade)"
                 )
 
-    all_recon_to_remove = phantom_recon_to_remove | dupes_to_remove
+    # --- Pass 2d: Remove paired RECON_MISSING entries ---
+    # When one leg of a RECON_MISSING pair (same pid, opposite action) is flagged
+    # as a duplicate, the other leg becomes orphaned and must also be removed.
+    # Example: BUY+SELL RECON_MISSING with same pid — if SELL matches base
+    # EMERGENCY_HARD_CLOSE, the BUY is also a duplicate of the original trade.
+    paired_to_remove = set()
+    if dupes_to_remove and not recon.empty:
+        flagged_pids = {
+            str(full.loc[idx, "position_id"])
+            for idx in dupes_to_remove
+            if idx in full.index
+        }
+        for idx, rrow in recon.iterrows():
+            if idx in dupes_to_remove:
+                continue
+            pid = str(rrow.get("position_id", ""))
+            if pid in flagged_pids:
+                paired_to_remove.add(idx)
+                logger.info(
+                    f"  Paired RECON_MISSING: {rrow['timestamp']} {rrow['action']} "
+                    f"{rrow['local_symbol']} pid={pid[:35]} (counterpart is duplicate)"
+                )
+
+    all_recon_to_remove = phantom_recon_to_remove | dupes_to_remove | paired_to_remove
     stats["recon_dupes_removed"] = len(all_recon_to_remove)
 
     if all_recon_to_remove and not dry_run:


### PR DESCRIPTION
## Summary
- When one leg of a RECON_MISSING pair (same `position_id`, opposite action) is flagged as duplicate, the counterpart must also be removed
- Without this, NG cleanup removes the SELL RECON_MISSING for LNEQ6 P3500 (matches base EMERGENCY_HARD_CLOSE) but leaves the BUY RECON_MISSING, creating a +1 imbalance on a symbol that should be net 0
- Adds Pass 2d to the cleanup script that detects RECON_MISSING entries sharing a `position_id` with any already-flagged duplicate

## Test plan
- [x] Simulated paired detection logic — correctly flags all 4 NG RECON_MISSING entries
- [ ] Dry-run on NG should show 4 entries to remove (2 duplicate + 2 paired) instead of 2
- [ ] After cleanup, all NG symbols should be net 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)