### PR TITLE
🎨 Palette: Add context tooltips to safety interlock checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -61,3 +61,7 @@ This journal records CRITICAL UX/accessibility learnings.
 ## 2026-03-05 - Completing Tooltip Coverage for High-Impact Actions
 **Learning:** While the dashboard has a standard of using tooltips (`help` parameter) on high-stakes manual triggers (like "Force Generate & Execute Orders" and "Clear All Caches"), several critical buttons (e.g., "Cancel All Open Orders" and "Force Close Stale Positions") were found lacking them. Users need immediate, clear context for what destructive actions will do before clicking them, even if there is a safety interlock checkbox.
 **Action:** Ensure exhaustive tooltip coverage across all Streamlit components that trigger state mutations or irreversible actions. The `help` string should explicitly describe the scope and consequence of the action (e.g., "Immediately cancels all unfilled DAY orders in Interactive Brokers.").
+
+## $(date +%Y-%m-%d) - Safety Interlock Tooltips
+**Learning:** While the dashboard has a standard of using the Safety Interlock pattern (`st.checkbox` gating a dangerous `st.button`), the checkboxes themselves often lacked tooltips (`help` parameter). Users need to know exactly what they are agreeing to enable before checking the box, as the action button text alone might not provide full context until it is un-disabled.
+**Action:** Always provide descriptive `help` tooltips on `st.checkbox` components used as safety interlocks to clarify what enabling the checkbox will allow the user to do.

--- a/pages/1_Cockpit.py
+++ b/pages/1_Cockpit.py
@@ -1129,7 +1129,7 @@ with ctrl_cols[0]:
     st.caption("No active cooldown")
 
 with ctrl_cols[1]:
-    confirm_halt = st.checkbox("I confirm I want to HALT all orders", key="confirm_halt")
+    confirm_halt = st.checkbox("I confirm I want to HALT all orders", key="confirm_halt", help="Check this to enable the EMERGENCY HALT button.")
     if st.button(
         "🛑 EMERGENCY HALT",
         type="primary",
@@ -1162,7 +1162,7 @@ with ctrl_cols[1]:
             st.error("Config not loaded")
 
 with ctrl_cols[2]:
-    confirm_refresh = st.checkbox("I confirm I want to reload all data", key="confirm_refresh")
+    confirm_refresh = st.checkbox("I confirm I want to reload all data", key="confirm_refresh", help="Check this to enable the Refresh All Data button.")
     if st.button(
         "🔄 Refresh All Data",
         width="stretch",

--- a/pages/5_Utilities.py
+++ b/pages/5_Utilities.py
@@ -53,7 +53,7 @@ Collect and archive logs to the centralized logs branch for analysis and debuggi
 This captures orchestrator logs, dashboard logs, state files, and trading data.
 """)
 
-confirm_collect = st.checkbox("I confirm I want to collect logs", key="confirm_collect")
+confirm_collect = st.checkbox("I confirm I want to collect logs", key="confirm_collect", help="Check this to enable the Collect Logs button.")
 if st.button(
     "🚀 Collect Logs",
     type="primary",
@@ -216,7 +216,7 @@ with manual_cols[0]:
     st.caption("Runs full order generation cycle: data pull → Council deliberation → signals → order placement")
 
     # Safety Interlock
-    confirm_exec = st.checkbox("I confirm I want to execute live trades", key="confirm_exec_orders")
+    confirm_exec = st.checkbox("I confirm I want to execute live trades", key="confirm_exec_orders", help="Check this to enable the Force Generate & Execute Orders button.")
     confirm_text = st.text_input("Type 'EXECUTE' to confirm:", key="confirm_text_orders")
 
     is_authorized = confirm_exec and confirm_text == "EXECUTE"
@@ -310,7 +310,7 @@ with manual_cols[1]:
     st.warning("⚠️ **Cancel All Open Orders**")
     st.caption("Immediately cancels all unfilled DAY orders in IB")
 
-    confirm_cancel_all = st.checkbox("I confirm I want to CANCEL all open orders", key="confirm_cancel_all")
+    confirm_cancel_all = st.checkbox("I confirm I want to CANCEL all open orders", key="confirm_cancel_all", help="Check this to enable the Cancel All Open Orders button.")
     if st.button(
         "🛑 Cancel All Open Orders",
         disabled=not confirm_cancel_all,
@@ -346,7 +346,7 @@ with manual_cols2[0]:
     st.warning("⚠️ **Close Stale Positions**")
     st.caption("Closes positions held longer than max_holding_days")
 
-    confirm_close_stale = st.checkbox("I confirm I want to CLOSE stale positions", key="confirm_close_stale")
+    confirm_close_stale = st.checkbox("I confirm I want to CLOSE stale positions", key="confirm_close_stale", help="Check this to enable the Force Close Stale Positions button.")
     if st.button(
         "🔄 Force Close Stale Positions",
         disabled=not confirm_close_stale,
@@ -380,7 +380,7 @@ with manual_cols2[1]:
     st.info("ℹ️ **Sync Equity Data**")
     st.caption("Forces fresh equity sync from IB Flex Query")
 
-    confirm_sync = st.checkbox("I confirm I want to force equity sync", key="confirm_sync")
+    confirm_sync = st.checkbox("I confirm I want to force equity sync", key="confirm_sync", help="Check this to enable the Force Equity Sync button.")
     if st.button(
         "💰 Force Equity Sync",
         disabled=not confirm_sync,
@@ -665,7 +665,7 @@ with state_cols[1]:
 
     # Use a form with confirmation checkbox to prevent accidental clicks
     with st.form("clear_state_form"):
-        confirm_clear = st.checkbox("I understand this will clear all state data")
+        confirm_clear = st.checkbox("I understand this will clear all state data", help="Check this to confirm clearing the state.")
         submit_clear = st.form_submit_button("🗑️ Clear State File")
 
         if submit_clear:
@@ -704,12 +704,12 @@ This validates the entire architecture from sentinels to council to order execut
 validation_cols = st.columns([2, 1])
 
 with validation_cols[0]:
-    confirm_val = st.checkbox("I confirm I want to run system validation", key="confirm_val")
+    confirm_val = st.checkbox("I confirm I want to run system validation", key="confirm_val", help="Check this to enable the Run System Validation button.")
     run_validation = st.button("🚀 Run System Validation", type="primary", width='stretch', disabled=not confirm_val, help="Run preflight checks on all system components (~30s in quick mode, ~2min full).")
 
 with validation_cols[1]:
-    json_output = st.checkbox("JSON Output", value=False)
-    quick_mode = st.checkbox("Quick Mode (Skip slow tests)", value=True)
+    json_output = st.checkbox("JSON Output", value=False, help="Enable to output raw JSON results.")
+    quick_mode = st.checkbox("Quick Mode (Skip slow tests)", value=True, help="Enable to skip longer-running integration tests.")
 
 if run_validation:
     with st.spinner("Running comprehensive system validation..."):
@@ -1143,7 +1143,7 @@ st.markdown("Clear cached data to force fresh data loads from sources.")
 cache_cols = st.columns(2)
 
 with cache_cols[0]:
-    confirm_clear_cache = st.checkbox("I confirm I want to clear all cached data", key="confirm_clear_cache")
+    confirm_clear_cache = st.checkbox("I confirm I want to clear all cached data", key="confirm_clear_cache", help="Check this to enable the Clear All Caches button.")
     if st.button(
         "🔄 Clear All Caches",
         disabled=not confirm_clear_cache,


### PR DESCRIPTION
This PR implements a micro-UX enhancement by adding `help` tooltips to `st.checkbox` components that function as safety interlocks across the dashboard. 

**What:** Added native tooltips explaining what checking the confirmation box will enable.
**Why:** Users need immediate context regarding what destructive actions they are authorizing (e.g., EMERGENCY HALT, Cancel All Orders, Clear State).
**Accessibility:** Improves screen reader and visual context by utilizing Streamlit's native `help` attribute on boolean inputs.

---
*PR created automatically by Jules for task [12102969257878773232](https://jules.google.com/task/12102969257878773232) started by @rozavala*