### PR TITLE
fix: close contradicted positions before placing new orders

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -2134,6 +2134,43 @@ async def run_position_audit_cycle(config: dict, trigger_source: str = "Schedule
             f"{len(position_groups)} thesis groups"
         )
 
+        # 4.5 === SAFETY NET: Retry pending_close theses ===
+        # These are theses marked CONTRADICT where the immediate close in
+        # place_queued_orders failed (partial fill, timeout, IB disconnection).
+        # The pending_close flag in TMS metadata is the durable record of intent.
+        try:
+            pending = tms.get_pending_close_theses()
+            if pending:
+                logger.warning(
+                    f"Found {len(pending)} theses with pending_close flag — "
+                    f"retrying CONTRADICT close in audit cycle"
+                )
+                from trading_bot.order_manager import _close_contradicted_thesis
+                for item in pending:
+                    tid = item['trade_id']
+                    reason = item['pending_close']
+                    ts = item.get('pending_close_timestamp', '')
+                    logger.info(
+                        f"Retrying pending_close for {tid} "
+                        f"(reason={reason}, flagged_at={ts})")
+                    try:
+                        closed = await _close_contradicted_thesis(
+                            ib, tid, config, tms)
+                        if closed:
+                            logger.info(f"pending_close retry successful for {tid}")
+                            # Remove from position_groups so it's not double-processed
+                            position_groups.pop(tid, None)
+                        else:
+                            logger.warning(
+                                f"pending_close retry failed for {tid}. "
+                                f"Will retry on next audit cycle.")
+                    except Exception as e:
+                        logger.error(
+                            f"pending_close retry error for {tid}: {e}",
+                            exc_info=True)
+        except Exception as e:
+            logger.warning(f"Failed to process pending_close theses in audit: {e}")
+
         # 5. === NEW: Cache active futures (Issue 9 fix) ===
         active_futures_cache = {}
         try:

--- a/tests/test_thesis_coherence.py
+++ b/tests/test_thesis_coherence.py
@@ -313,16 +313,20 @@ class TestCheckThesisCoherence(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestDeferredInvalidation(unittest.IsolatedAsyncioTestCase):
-    """Tests for deferred invalidation + auto-close in fill handler."""
+    """Tests for fill handler behavior with supersedes_trade_ids.
+
+    CONTRADICT closures are now handled immediately in place_queued_orders()
+    before new orders are placed. The fill handler only logs a warning if
+    it receives supersedes_trade_ids (should no longer happen in normal flow).
+    """
 
     @patch('trading_bot.order_manager.record_entry_thesis_for_trade', new_callable=AsyncMock)
     @patch('trading_bot.order_manager.log_trade_to_ledger', new_callable=AsyncMock)
-    @patch('trading_bot.order_manager._auto_close_superseded', new_callable=AsyncMock)
     @patch('trading_bot.tms.TransactiveMemory')
-    async def test_deferred_invalidation_plus_auto_close(
-        self, mock_tms_cls, mock_auto_close, mock_log, mock_record
+    async def test_fill_handler_logs_warning_for_supersedes(
+        self, mock_tms_cls, mock_log, mock_record
     ):
-        """Mock fill callback → old thesis invalidated AND auto-close called."""
+        """Fill with supersedes_trade_ids → warning logged, NO invalidation or auto-close."""
         from trading_bot.order_manager import _handle_and_log_fill, _recorded_thesis_positions
 
         mock_tms = MagicMock()
@@ -356,32 +360,28 @@ class TestDeferredInvalidation(unittest.IsolatedAsyncioTestCase):
 
         _recorded_thesis_positions.discard('new-uuid-1')
 
-        await _handle_and_log_fill(ib, trade, fill, 456, 'new-uuid-1', decision_data, config)
+        with self.assertLogs('OrderManager', level='WARNING') as cm:
+            await _handle_and_log_fill(ib, trade, fill, 456, 'new-uuid-1', decision_data, config)
 
-        # Verify invalidation was called
-        mock_tms.invalidate_thesis.assert_called_once()
-        call_args = mock_tms.invalidate_thesis.call_args
-        self.assertEqual(call_args[0][0], 'old-bear-1')
-        self.assertIn('CONTRADICT', call_args[0][1])
+        # Verify warning was logged about legacy supersedes_trade_ids
+        warning_msgs = [m for m in cm.output if 'supersedes_trade_ids' in m]
+        self.assertTrue(warning_msgs, "Expected warning about supersedes_trade_ids")
 
-        # Verify auto-close was called
-        mock_auto_close.assert_called_once()
+        # NO invalidation or auto-close — handled by place_queued_orders now
+        mock_tms.invalidate_thesis.assert_not_called()
 
     @patch('trading_bot.order_manager.record_entry_thesis_for_trade', new_callable=AsyncMock)
     @patch('trading_bot.order_manager.log_trade_to_ledger', new_callable=AsyncMock)
-    @patch('trading_bot.order_manager._auto_close_superseded', new_callable=AsyncMock)
     @patch('trading_bot.tms.TransactiveMemory')
-    async def test_auto_close_failure_does_not_crash_fill_handler(
-        self, mock_tms_cls, mock_auto_close, mock_log, mock_record
+    async def test_fill_handler_completes_with_supersedes(
+        self, mock_tms_cls, mock_log, mock_record
     ):
-        """_auto_close_superseded raises → fill handler completes, thesis recorded."""
+        """Fill with supersedes_trade_ids still completes and records thesis."""
         from trading_bot.order_manager import _handle_and_log_fill, _recorded_thesis_positions
 
         mock_tms = MagicMock()
         mock_tms.collection = True
         mock_tms_cls.return_value = mock_tms
-
-        mock_auto_close.side_effect = Exception("IB timeout")
 
         ib = MagicMock()
         ib.isConnected.return_value = True
@@ -409,10 +409,9 @@ class TestDeferredInvalidation(unittest.IsolatedAsyncioTestCase):
         config = {'symbol': 'KC', 'exchange': 'NYBOT', 'notifications': {}}
         _recorded_thesis_positions.discard('new-uuid-2')
 
-        # Should not raise
         await _handle_and_log_fill(ib, trade, fill, 457, 'new-uuid-2', decision_data, config)
 
-        # Thesis was still recorded despite auto-close failure
+        # Thesis was still recorded
         mock_record.assert_called_once()
 
     @patch('trading_bot.order_manager.record_entry_thesis_for_trade', new_callable=AsyncMock)
@@ -459,8 +458,10 @@ class TestDeferredInvalidation(unittest.IsolatedAsyncioTestCase):
     @patch('trading_bot.order_manager.record_entry_thesis_for_trade', new_callable=AsyncMock)
     @patch('trading_bot.order_manager.log_trade_to_ledger', new_callable=AsyncMock)
     @patch('trading_bot.tms.TransactiveMemory')
-    async def test_auto_close_skipped_when_ib_disconnected(self, mock_tms_cls, mock_log, mock_record):
-        """ib.isConnected() returns False → auto-close skipped with warning."""
+    async def test_fill_handler_warning_only_when_ib_disconnected(
+        self, mock_tms_cls, mock_log, mock_record
+    ):
+        """ib.isConnected() False + supersedes_trade_ids → warning only, no invalidation."""
         from trading_bot.order_manager import _handle_and_log_fill, _recorded_thesis_positions
 
         mock_tms = MagicMock()
@@ -495,9 +496,8 @@ class TestDeferredInvalidation(unittest.IsolatedAsyncioTestCase):
 
         await _handle_and_log_fill(ib, trade, fill, 459, 'disconn-uuid', decision_data, config)
 
-        # Invalidation should still be called
-        mock_tms.invalidate_thesis.assert_called_once()
-        # But no auto-close attempt
+        # No invalidation — handled by pending_close flag + audit cycle
+        mock_tms.invalidate_thesis.assert_not_called()
 
 
 class TestAutoCloseSuperseded(unittest.IsolatedAsyncioTestCase):
@@ -574,20 +574,22 @@ class TestAutoCloseSuperseded(unittest.IsolatedAsyncioTestCase):
         ib.reqPositionsAsync.assert_not_called()
 
 
-class TestDedupPreventsSecondAutoClose(unittest.IsolatedAsyncioTestCase):
-    """Verify _processed_supersedes prevents duplicate deferred invalidation."""
+class TestFillHandlerNoLongerAutoCloses(unittest.IsolatedAsyncioTestCase):
+    """Verify fill handler does not perform CONTRADICT invalidation or auto-close.
+
+    CONTRADICT closures are now handled in place_queued_orders before order
+    placement. The fill handler should only log a warning if it receives
+    supersedes_trade_ids (legacy path).
+    """
 
     @patch('trading_bot.order_manager.record_entry_thesis_for_trade', new_callable=AsyncMock)
     @patch('trading_bot.order_manager.log_trade_to_ledger', new_callable=AsyncMock)
-    @patch('trading_bot.order_manager._auto_close_superseded', new_callable=AsyncMock)
     @patch('trading_bot.tms.TransactiveMemory')
-    async def test_second_fill_skips_invalidation(
-        self, mock_tms_cls, mock_auto_close, mock_log, mock_record
+    async def test_multiple_fills_no_invalidation(
+        self, mock_tms_cls, mock_log, mock_record
     ):
-        """Two leg fills with same supersedes_trade_ids → only one invalidation + auto-close."""
-        from trading_bot.order_manager import (
-            _handle_and_log_fill, _recorded_thesis_positions, _processed_supersedes
-        )
+        """Two leg fills with supersedes_trade_ids → warnings only, no invalidation."""
+        from trading_bot.order_manager import _handle_and_log_fill, _recorded_thesis_positions
 
         mock_tms = MagicMock()
         mock_tms.collection = True
@@ -620,32 +622,19 @@ class TestDedupPreventsSecondAutoClose(unittest.IsolatedAsyncioTestCase):
         fill1.execution.avgPrice = 2.00
 
         _recorded_thesis_positions.discard('dedup-uuid')
-        _processed_supersedes.discard('old-bear-dedup')
 
         await _handle_and_log_fill(ib, trade1, fill1, 500, 'dedup-uuid', decision_data, config)
 
-        self.assertEqual(mock_tms.invalidate_thesis.call_count, 1)
-        self.assertEqual(mock_auto_close.call_count, 1)
-
-        # --- Second leg fill (same decision_data ref) ---
-        trade2 = MagicMock()
-        trade2.order.orderId = 201
-        trade2.order.orderRef = 'dedup-uuid'
-        trade2.contract = MagicMock(spec=['comboLegs', 'localSymbol'])
-        trade2.contract.localSymbol = 'COMBO'
-
+        # --- Second leg fill ---
         fill2 = MagicMock()
         fill2.contract = MagicMock()
         fill2.contract.conId = 1002
         fill2.execution.avgPrice = 1.80
 
-        await _handle_and_log_fill(ib, trade2, fill2, 501, 'dedup-uuid', decision_data, config)
+        await _handle_and_log_fill(ib, trade1, fill2, 501, 'dedup-uuid', decision_data, config)
 
-        # Invalidation + auto-close should NOT have been called a second time
-        self.assertEqual(mock_tms.invalidate_thesis.call_count, 1,
-                         "invalidate_thesis called more than once — dedup failed")
-        self.assertEqual(mock_auto_close.call_count, 1,
-                         "_auto_close_superseded called more than once — dedup failed")
+        # No invalidation or auto-close in either fill
+        mock_tms.invalidate_thesis.assert_not_called()
 
 
 class TestCloseSpreadPositionUsesPosContract(unittest.IsolatedAsyncioTestCase):
@@ -739,6 +728,137 @@ class TestCloseSpreadPositionUsesPosContract(unittest.IsolatedAsyncioTestCase):
 
         # Exchange should have been filled from config
         self.assertEqual(leg.contract.exchange, 'NYBOT')
+
+
+class TestCloseContradictedThesis(unittest.IsolatedAsyncioTestCase):
+    """Tests for _close_contradicted_thesis() — the new immediate close path."""
+
+    @patch('trading_bot.order_manager.get_trade_ledger_df')
+    async def test_close_with_aggregated_positions(self, mock_ledger):
+        """IB shows qty=2 (aggregated) but thesis owns qty=1 → closes only thesis portion."""
+        from trading_bot.order_manager import _close_contradicted_thesis
+        import pandas as pd
+
+        ib = MagicMock()
+        ib.isConnected.return_value = True
+
+        # IB shows qty=2 (two theses share same strikes)
+        pos1 = MagicMock()
+        pos1.contract.localSymbol = 'KOK6 C2.95'
+        pos1.position = 2  # Aggregated: 2 long
+        pos2 = MagicMock()
+        pos2.contract.localSymbol = 'KOK6 C3'
+        pos2.position = -2  # Aggregated: 2 short
+        ib.reqPositionsAsync = AsyncMock(return_value=[pos1, pos2])
+
+        # Ledger: this thesis has qty=1 per leg
+        mock_ledger.return_value = pd.DataFrame({
+            'position_id': ['thesis-a', 'thesis-a'],
+            'local_symbol': ['KOK6 C2.95', 'KOK6 C3'],
+            'quantity': [1, 1],
+            'action': ['BUY', 'SELL'],
+        })
+
+        tms = MagicMock()
+        tms.retrieve_thesis.return_value = {'strategy_type': 'BULL_CALL_SPREAD'}
+        config = {'data_dir': '/tmp/test', 'exchange': 'NYBOT', 'notifications': {}}
+
+        with patch('orchestrator._close_spread_position',
+                   new_callable=AsyncMock) as mock_close:
+            mock_close.return_value = True
+
+            result = await _close_contradicted_thesis(ib, 'thesis-a', config, tms)
+
+            self.assertTrue(result)
+            # Verify adjusted legs were passed with thesis-specific quantities
+            call_args = mock_close.call_args
+            legs_passed = call_args[0][1]
+            self.assertEqual(len(legs_passed), 2)
+            # Should have capped quantities to thesis amounts (1, not 2)
+            for leg in legs_passed:
+                self.assertEqual(abs(leg.position), 1)
+
+            # Thesis should be invalidated and pending_close cleared
+            tms.invalidate_thesis.assert_called_once()
+            tms.clear_pending_close.assert_called_once_with('thesis-a')
+
+    @patch('trading_bot.order_manager.get_trade_ledger_df')
+    async def test_close_no_ib_positions_invalidates(self, mock_ledger):
+        """No matching IB positions → invalidate thesis (already closed externally)."""
+        from trading_bot.order_manager import _close_contradicted_thesis
+        import pandas as pd
+
+        ib = MagicMock()
+        ib.isConnected.return_value = True
+        ib.reqPositionsAsync = AsyncMock(return_value=[])
+
+        mock_ledger.return_value = pd.DataFrame({
+            'position_id': ['thesis-b'],
+            'local_symbol': ['KOK6 C2.95'],
+            'quantity': [1],
+            'action': ['BUY'],
+        })
+
+        tms = MagicMock()
+        config = {'data_dir': '/tmp/test'}
+
+        result = await _close_contradicted_thesis(ib, 'thesis-b', config, tms)
+
+        self.assertTrue(result)
+        tms.invalidate_thesis.assert_called_once()
+        tms.clear_pending_close.assert_called_once_with('thesis-b')
+
+    @patch('trading_bot.order_manager.get_trade_ledger_df')
+    async def test_close_failure_preserves_pending_flag(self, mock_ledger):
+        """Close fails → pending_close flag preserved for audit retry."""
+        from trading_bot.order_manager import _close_contradicted_thesis
+        import pandas as pd
+
+        ib = MagicMock()
+        ib.isConnected.return_value = True
+
+        pos = MagicMock()
+        pos.contract.localSymbol = 'KOK6 C2.95'
+        pos.position = 1
+        ib.reqPositionsAsync = AsyncMock(return_value=[pos])
+
+        mock_ledger.return_value = pd.DataFrame({
+            'position_id': ['thesis-c'],
+            'local_symbol': ['KOK6 C2.95'],
+            'quantity': [1],
+            'action': ['BUY'],
+        })
+
+        tms = MagicMock()
+        tms.retrieve_thesis.return_value = {'strategy_type': 'BULL_CALL_SPREAD'}
+        config = {'data_dir': '/tmp/test', 'exchange': 'NYBOT', 'notifications': {}}
+
+        with patch('orchestrator._close_spread_position',
+                   new_callable=AsyncMock) as mock_close:
+            mock_close.return_value = False  # Close failed
+
+            result = await _close_contradicted_thesis(ib, 'thesis-c', config, tms)
+
+            self.assertFalse(result)
+            # Thesis should NOT be invalidated
+            tms.invalidate_thesis.assert_not_called()
+            # pending_close flag should NOT be cleared
+            tms.clear_pending_close.assert_not_called()
+
+    async def test_close_skipped_when_ib_disconnected(self):
+        """IB not connected → returns False, flag preserved."""
+        from trading_bot.order_manager import _close_contradicted_thesis
+
+        ib = MagicMock()
+        ib.isConnected.return_value = False
+
+        tms = MagicMock()
+        config = {'data_dir': '/tmp/test'}
+
+        result = await _close_contradicted_thesis(ib, 'thesis-d', config, tms)
+
+        self.assertFalse(result)
+        ib.reqPositionsAsync.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -594,11 +594,6 @@ async def _log_catastrophe_fill_to_ledger(detected_fill: dict, position_id: str,
 # Module-level set for TMS thesis deduplication
 _recorded_thesis_positions = set()
 
-# Module-level set to prevent duplicate deferred invalidation + auto-close
-# when multiple leg fills trigger _handle_and_log_fill with the same
-# supersedes_trade_ids (same dict ref from decision_data).
-_processed_supersedes = set()
-
 # --- Logging Setup ---
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger("OrderManager")
@@ -1056,30 +1051,38 @@ async def generate_and_queue_orders(config: dict, connection_purpose: str = "orc
                     continue
 
                 if coherence_action == "CONTRADICT":
-                    # DEFERRED: attach to signal, auto-close happens in fill callback
-                    superseded_ids = [t.get('_metadata', {}).get('trade_id', '')
-                                      for t in conflicting
-                                      if t.get('_metadata', {}).get('trade_id')]
-                    signal['supersedes_trade_ids'] = superseded_ids
-                    signal['supersedes_reason'] = 'CONTRADICT'
-                    for thesis in conflicting:
-                        tid = thesis.get('_metadata', {}).get('trade_id', '')
-                        logger.warning(
-                            f"THESIS CONTRADICT: {tid} ({thesis.get('strategy_type')}) "
-                            f"will be invalidated + auto-closed after new {signal.get('direction')} "
-                            f"order fills on {signal.get('contract_month')}."
-                        )
+                    # IMMEDIATE CLOSE: Mark for closure before new orders are placed.
+                    # The pending_close flag in TMS is the durable record of intent.
+                    # place_queued_orders() will query TMS and close these positions
+                    # BEFORE placing any new orders (eliminates race conditions).
+                    superseded_ids = []
+                    try:
+                        from trading_bot.tms import TransactiveMemory
+                        tms_mark = TransactiveMemory()
+                        for thesis in conflicting:
+                            tid = thesis.get('_metadata', {}).get('trade_id', '')
+                            if tid:
+                                superseded_ids.append(tid)
+                                tms_mark.mark_pending_close(
+                                    tid, 'CONTRADICT', signal.get('direction', ''))
+                                logger.warning(
+                                    f"THESIS CONTRADICT: {tid} ({thesis.get('strategy_type')}) "
+                                    f"marked pending_close — will be closed before new "
+                                    f"{signal.get('direction')} order on {signal.get('contract_month')}."
+                                )
+                    except Exception as e:
+                        logger.error(f"Failed to mark pending_close on contradicted theses: {e}")
                     try:
                         send_pushover_notification(
                             config.get('notifications', {}),
                             "Contradictory Thesis Detected",
                             f"New {signal.get('direction')} on {signal.get('contract_month')} "
                             f"contradicts {', '.join(s[:8] for s in superseded_ids)}. "
-                            f"Old position will be auto-closed after new order fills."
+                            f"Old position will be closed immediately before new order."
                         )
                     except Exception:
                         pass
-                    # Proceed — old thesis stays active until fill
+                    # Proceed to generate new order — close happens in place_queued_orders
 
                 future = next((f for f in active_futures if f.lastTradeDateOrContractMonth.startswith(signal.get("contract_month", ""))), None)
                 if not future:
@@ -1462,65 +1465,20 @@ async def _handle_and_log_fill(ib: IB, trade: Trade, fill: Fill, combo_id: int, 
             else:
                 logger.debug(f"TMS: Thesis already recorded for {position_uuid}, skipping duplicate.")
 
-        # === DEFERRED THESIS INVALIDATION + AUTO-CLOSE ===
+        # === LEGACY: DEFERRED THESIS INVALIDATION (superseded by immediate close) ===
+        # CONTRADICT closures are now handled immediately in place_queued_orders()
+        # before new orders are placed. This block is retained as a defensive
+        # warning ONLY for any edge case where supersedes_trade_ids might still
+        # be attached (e.g., signals generated before this code change deployed).
         superseded_ids = (decision_data or {}).get('supersedes_trade_ids', [])
         if superseded_ids:
-            _sup_reason = (decision_data or {}).get('supersedes_reason', 'CONTRADICT')
-            _sup_month = (decision_data or {}).get('contract_month', '?')
-            _sup_direction = (decision_data or {}).get('direction', '?')
-            logger.info(
-                f"Fill handler received supersedes_trade_ids: {superseded_ids} "
-                f"(reason: {_sup_reason})")
-
-            try:
-                from trading_bot.tms import TransactiveMemory
-                tms_inv = TransactiveMemory()
-                if not tms_inv.collection:
-                    logger.warning(
-                        "TMS collection unavailable in fill handler — "
-                        "ContextVar may not have propagated. "
-                        "Deferred invalidation skipped; audit cycle will catch it.")
-                else:
-                    for old_tid in superseded_ids:
-                        # Dedup: each leg fill triggers this block independently.
-                        # Only process each superseded trade ID once.
-                        if old_tid in _processed_supersedes:
-                            logger.debug(
-                                f"TMS: Deferred invalidation of {old_tid} already "
-                                f"processed, skipping duplicate.")
-                            continue
-                        _processed_supersedes.add(old_tid)
-
-                        # 1. Invalidate thesis in TMS
-                        tms_inv.invalidate_thesis(
-                            old_tid,
-                            f"{_sup_reason}: replaced by {position_uuid} "
-                            f"({_sup_direction} on {_sup_month})")
-                        logger.info(
-                            f"TMS: Deferred invalidation of {old_tid} — "
-                            f"new thesis {position_uuid} filled.")
-
-                        # 2. Auto-close the old position (check connection first)
-                        try:
-                            if not ib.isConnected():
-                                logger.warning(
-                                    f"Auto-close {old_tid}: IB disconnected. "
-                                    f"Position audit will handle it.")
-                            else:
-                                await _auto_close_superseded(
-                                    ib, old_tid, _sup_reason, config or {}, tms_inv)
-                        except Exception as close_err:
-                            logger.error(
-                                f"Auto-close of {old_tid} failed: {close_err}. "
-                                f"Position audit cycle will retry.",
-                                exc_info=True)
-                            send_pushover_notification(
-                                (config or {}).get('notifications', {}),
-                                "Auto-Close Failed",
-                                f"Failed to close {old_tid[:8]}: {close_err}. "
-                                f"Manual review required.")
-            except Exception as e:
-                logger.error(f"Deferred invalidation failed: {e}", exc_info=True)
+            logger.warning(
+                f"Fill handler received supersedes_trade_ids={superseded_ids} — "
+                f"this should no longer happen. CONTRADICT closures are now "
+                f"handled before order placement. Logging only, NOT auto-closing. "
+                f"The pending_close flag in TMS (if set) will be handled by "
+                f"place_queued_orders or the position audit safety net."
+            )
 
     except Exception as e:
         logger.exception(f"Error processing and logging fill for order {trade.order.orderId}: {e}")
@@ -1607,6 +1565,121 @@ async def _auto_close_superseded(
         logger.info(f"Auto-close {old_trade_id}: successfully closed superseded position.")
 
 
+async def _close_contradicted_thesis(
+    ib: IB, trade_id: str, config: dict, tms: 'TransactiveMemory'
+) -> bool:
+    """Close IB positions for a contradicted thesis immediately.
+
+    Called from place_queued_orders() BEFORE placing new orders, and from
+    the position audit safety net for retry. Key differences from
+    _auto_close_superseded (legacy fill-handler path):
+
+    - Executes at detection time, not gated on a new order fill
+    - Uses thesis-specific quantities (handles IB aggregation correctly)
+    - Invalidates thesis ONLY on successful close (atomic)
+    - Preserves pending_close flag on failure for audit retry
+
+    Returns True if fully closed + invalidated, False otherwise.
+    """
+    if not ib.isConnected():
+        logger.warning(
+            f"CONTRADICT close {trade_id}: IB not connected. "
+            f"pending_close flag will be picked up by audit cycle.")
+        return False
+
+    # 1. Get current IB positions
+    try:
+        positions = await asyncio.wait_for(ib.reqPositionsAsync(), timeout=30)
+    except asyncio.TimeoutError:
+        logger.error(f"CONTRADICT close {trade_id}: reqPositionsAsync timed out")
+        return False
+
+    # 2. Get thesis legs from trade ledger
+    trade_ledger = get_trade_ledger_df(config.get('data_dir'))
+    if trade_ledger.empty or 'position_id' not in trade_ledger.columns:
+        logger.warning(f"CONTRADICT close {trade_id}: trade ledger empty/missing")
+        return False
+
+    old_rows = trade_ledger[trade_ledger['position_id'] == trade_id]
+    if old_rows.empty:
+        logger.warning(f"CONTRADICT close {trade_id}: no ledger entries found")
+        return False
+
+    old_symbols = set(old_rows['local_symbol'].unique())
+
+    # 3. Calculate expected quantity per symbol for THIS thesis only
+    expected_qty = {}
+    for _, row in old_rows.iterrows():
+        sym = row.get('local_symbol', '')
+        qty = row['quantity'] if row['action'] == 'BUY' else -row['quantity']
+        expected_qty[sym] = expected_qty.get(sym, 0) + qty
+
+    # 4. Match IB positions to thesis contracts
+    legs = [p for p in positions
+            if p.contract.localSymbol in old_symbols and p.position != 0]
+
+    if not legs:
+        # No IB positions — already closed (externally or by stale close).
+        # Safe to invalidate thesis and clear flag.
+        logger.info(
+            f"CONTRADICT close {trade_id}: no matching IB positions "
+            f"(may already be closed). Invalidating thesis.")
+        tms.invalidate_thesis(trade_id, "CONTRADICT: position already closed")
+        tms.clear_pending_close(trade_id)
+        return True
+
+    # 5. Handle aggregated positions: cap leg quantities to thesis-specific
+    # amounts. If IB shows qty=2 for a symbol but this thesis only owns
+    # qty=1, we create a lightweight wrapper with the thesis's quantity so
+    # _close_spread_position only closes what belongs to this thesis.
+    from types import SimpleNamespace
+    adjusted_legs = []
+    for leg in legs:
+        sym = leg.contract.localSymbol
+        thesis_qty = expected_qty.get(sym, 0)  # signed: +1 long, -1 short
+        ib_qty = leg.position                   # signed: +2 long, -2 short
+
+        if thesis_qty == 0:
+            continue  # This symbol isn't part of this thesis
+
+        # If IB qty exceeds thesis qty (aggregation), cap to thesis qty
+        if abs(ib_qty) > abs(thesis_qty):
+            logger.info(
+                f"CONTRADICT close {trade_id}: {sym} IB qty={ib_qty}, "
+                f"thesis qty={thesis_qty}. Closing thesis portion only.")
+            adjusted_leg = SimpleNamespace(
+                contract=leg.contract,
+                position=thesis_qty,
+            )
+            adjusted_legs.append(adjusted_leg)
+        else:
+            adjusted_legs.append(leg)
+
+    if not adjusted_legs:
+        logger.warning(f"CONTRADICT close {trade_id}: no legs after adjustment")
+        return False
+
+    # 6. Close via _close_spread_position
+    from orchestrator import _close_spread_position  # Lazy import (established pattern)
+
+    thesis = tms.retrieve_thesis(trade_id)
+    fully_closed = await _close_spread_position(
+        ib, adjusted_legs, trade_id,
+        f"CONTRADICT: direction reversal", config, thesis)
+
+    # 7. Invalidate ONLY on success (atomic with closure)
+    if fully_closed:
+        tms.invalidate_thesis(trade_id, "CONTRADICT: closed on direction reversal")
+        tms.clear_pending_close(trade_id)
+        logger.info(f"CONTRADICT close {trade_id}: fully closed and invalidated.")
+        return True
+    else:
+        logger.warning(
+            f"CONTRADICT close {trade_id}: partial/failed close. "
+            f"pending_close flag preserved for audit cycle retry.")
+        return False
+
+
 async def check_liquidity_conditions(ib: IB, contract, order_size: int, config: dict = None) -> tuple[bool, str]:
     """Check if liquidity conditions are safe for execution.
 
@@ -1676,7 +1749,6 @@ async def place_queued_orders(config: dict, orders_list: list = None, connection
     # Clear thesis tracking at START of run (not in finally) to avoid racing
     # with fire-and-forget _handle_and_log_fill tasks still inflight
     _recorded_thesis_positions.clear()
-    _processed_supersedes.clear()
 
     # === D3 FIX: Explicit sequential processing ===
     # Use pop_all to atomically get and clear, preventing any race
@@ -1707,6 +1779,44 @@ async def place_queued_orders(config: dict, orders_list: list = None, connection
         logger.critical(msg, exc_info=True)
         send_pushover_notification(config.get('notifications', {}), "Order Placement Connection Failed", f"{msg}\n{traceback.format_exc()}")
         return  # Fail closed - cannot place orders without connection
+
+    # === CONTRADICT IMMEDIATE CLOSE ===
+    # Close positions marked pending_close BEFORE placing any new orders.
+    # This ensures:
+    # 1. No IB qty aggregation with new orders (eliminates race condition)
+    # 2. Close is not gated on new order filling (eliminates timeout gap)
+    # 3. Thesis invalidation only on successful close (atomicity)
+    try:
+        from trading_bot.tms import TransactiveMemory
+        tms_close = TransactiveMemory()
+        pending = tms_close.get_pending_close_theses()
+        if pending:
+            logger.info(
+                f"Found {len(pending)} theses with pending_close — "
+                f"executing CONTRADICT closures before placing new orders"
+            )
+            for item in pending:
+                tid = item['trade_id']
+                reason = item['pending_close']
+                ts = item.get('pending_close_timestamp', '')
+                logger.info(
+                    f"CONTRADICT close: {tid} (reason={reason}, flagged_at={ts})")
+                try:
+                    closed = await _close_contradicted_thesis(
+                        ib, tid, config, tms_close)
+                    if closed:
+                        logger.info(f"CONTRADICT close successful: {tid[:8]}")
+                    else:
+                        logger.warning(
+                            f"CONTRADICT close failed/partial for {tid[:8]}. "
+                            f"pending_close flag preserved for audit cycle retry.")
+                except Exception as e:
+                    logger.error(
+                        f"CONTRADICT close error for {tid[:8]}: {e}. "
+                        f"pending_close flag preserved for audit cycle retry.",
+                        exc_info=True)
+    except Exception as e:
+        logger.error(f"Failed to process pending_close theses: {e}", exc_info=True)
 
     live_orders = {} # Dictionary to track order status by orderId
     _fill_tasks = []  # Collect fill handler tasks so we can await them before disconnect

--- a/trading_bot/tms.py
+++ b/trading_bot/tms.py
@@ -716,6 +716,87 @@ class TransactiveMemory:
         except Exception as e:
             logger.error(f"TMS invalidate_thesis failed: {e}")
 
+    def mark_pending_close(self, trade_id: str, reason: str, direction: str = ""):
+        """Mark thesis for deferred close. Survives process restarts.
+
+        Called when a CONTRADICT is detected but the close cannot execute
+        immediately (e.g., no IB connection yet). The pending_close flag is
+        the durable record of close intent, picked up by place_queued_orders
+        and the position audit safety net.
+        """
+        if not self.collection:
+            return
+
+        try:
+            doc_id = f"thesis_{trade_id}"
+            results = self.collection.get(ids=[doc_id], include=['metadatas'])
+            if results and results['metadatas']:
+                meta = results['metadatas'][0]
+                meta['pending_close'] = reason
+                meta['pending_close_timestamp'] = datetime.now(timezone.utc).isoformat()
+                if direction:
+                    meta['pending_close_direction'] = direction
+                self.collection.update(ids=[doc_id], metadatas=[meta])
+                logger.info(
+                    f"TMS: Marked thesis {trade_id} pending_close={reason}"
+                    + (f" (new direction: {direction})" if direction else "")
+                )
+        except Exception as e:
+            logger.error(f"TMS mark_pending_close failed for {trade_id}: {e}")
+
+    def clear_pending_close(self, trade_id: str):
+        """Remove pending_close flag after successful close."""
+        if not self.collection:
+            return
+
+        try:
+            doc_id = f"thesis_{trade_id}"
+            results = self.collection.get(ids=[doc_id], include=['metadatas'])
+            if results and results['metadatas']:
+                meta = results['metadatas'][0]
+                changed = False
+                for key in ('pending_close', 'pending_close_timestamp',
+                            'pending_close_direction'):
+                    if key in meta:
+                        del meta[key]
+                        changed = True
+                if changed:
+                    self.collection.update(ids=[doc_id], metadatas=[meta])
+                    logger.info(f"TMS: Cleared pending_close for {trade_id}")
+        except Exception as e:
+            logger.debug(f"TMS clear_pending_close failed for {trade_id}: {e}")
+
+    def get_pending_close_theses(self) -> list:
+        """Return all active theses with a pending_close flag.
+
+        ChromaDB doesn't support $exists queries, so we scan all active
+        theses and filter in Python. This is fine at our scale (< 50
+        active theses at any time).
+        """
+        if not self.collection:
+            return []
+
+        try:
+            all_active = self.collection.get(
+                where={"active": "true"},
+                include=['metadatas', 'documents']
+            )
+            results = []
+            for i, meta in enumerate(all_active.get('metadatas', [])):
+                if meta.get('pending_close'):
+                    trade_id = meta.get('trade_id', '')
+                    results.append({
+                        'trade_id': trade_id,
+                        'pending_close': meta['pending_close'],
+                        'pending_close_timestamp': meta.get('pending_close_timestamp', ''),
+                        'pending_close_direction': meta.get('pending_close_direction', ''),
+                        'metadata': meta,
+                    })
+            return results
+        except Exception as e:
+            logger.error(f"TMS get_pending_close_theses failed: {e}")
+            return []
+
     def get_all_theses(self) -> list:
         """Returns all theses (active + invalidated) from the TMS."""
         if not self.collection:


### PR DESCRIPTION
## Summary

- **Root cause**: CONTRADICT auto-close was coupled to the new replacement order's fill event, causing two failure modes observed on 2026-03-10:
  1. **Race condition** (81d08068): IB aggregated qty=2 across theses sharing same strikes → safety check bailed with no retry → thesis invalidated but IB position persisted
  2. **Failed trigger** (e7792fb9): New BEARISH order timed out after 40min → fill never fired → old BULLISH position never closed
- **Fix**: Move CONTRADICT handling from fill callback to order placement: close old positions **immediately before** placing new orders, using a durable `pending_close` TMS flag
- Thesis-specific quantity capping handles aggregated IB positions correctly (closes only this thesis's portion)
- Position audit safety net retries any `pending_close` theses where the immediate close failed
- Fill handler neutered to warning-only log (defensive fallback during rollout)

## Test plan

- [x] All 929 existing tests pass (0 failures)
- [x] 4 new tests for `_close_contradicted_thesis`: aggregated positions, no IB positions, close failure, IB disconnected
- [x] Updated 4 existing `TestDeferredInvalidation` tests for new fill handler behavior
- [ ] Deploy to DEV with `trading_off=true`, verify no import errors
- [ ] Trigger CONTRADICT scenario manually (BULLISH then BEARISH on same month)
- [ ] Verify `"CONTRADICT close successful"` log lines appear before new order placement
- [ ] Verify no `"Fill handler received supersedes_trade_ids"` warnings (should not appear)
- [ ] Monitor audit cycle for `"pending_close retry"` log lines (only if immediate close fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)