### PR TITLE
feat: enable contribution-based scoring

### DIFF
--- a/config.json
+++ b/config.json
@@ -458,7 +458,7 @@
     }
   },
   "scoring": {
-    "use_contribution_scoring": false,
+    "use_contribution_scoring": true,
     "confidence_compression": true
   },
   "brier_scoring": {


### PR DESCRIPTION
## Summary
- Flips `use_contribution_scoring` to `true` after successful migration
- Migration validated: 47 cycles scored across 8 agents from KC council_history
- Brier scoring continues for DSPy/reflexion but no longer drives reliability multipliers

## Multiplier results (post-migration)
| Agent | Multiplier | Status |
|-------|-----------|--------|
| agronomist | 1.93 | Trusted |
| volatility | 1.83 | Trusted |
| technical | 1.55 | Trusted |
| sentiment | 1.54 | Trusted |
| geopolitical | 1.45 | Trusted |
| supply_chain | 0.91 | Baseline |
| inventory | 0.40 | Distrusted |
| macro | 0.37 | Distrusted |

## Rollback
Set `use_contribution_scoring: false` in config.json → instant revert to Brier multipliers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)