### PR TITLE
fix: contribution scoring review feedback

### DIFF
--- a/pages/7_Brier_Analysis.py
+++ b/pages/7_Brier_Analysis.py
@@ -319,7 +319,8 @@ except Exception as e:
 
 # === SECTION 5B: Contribution-Based Multipliers ===
 try:
-    from trading_bot.contribution_bridge import is_contribution_scoring_enabled, _get_tracker
+    from trading_bot.contribution_bridge import is_contribution_scoring_enabled
+    from trading_bot.contribution_scorer import ContributionTracker
     _is_contrib = is_contribution_scoring_enabled()
 
     st.markdown("---")
@@ -329,7 +330,8 @@ try:
     else:
         st.caption("**INACTIVE** — Contribution scores computed but Brier multipliers still in use.")
 
-    _contrib_tracker = _get_tracker()
+    _contrib_path = _resolve_data_path_for("contribution_scores.json", ticker)
+    _contrib_tracker = ContributionTracker(data_path=_contrib_path) if os.path.exists(_contrib_path) else None
     if _contrib_tracker:
         _summary = _contrib_tracker.get_summary()
         if _summary:

--- a/scripts/migrate_contribution_scores.py
+++ b/scripts/migrate_contribution_scores.py
@@ -77,9 +77,7 @@ def migrate_ticker(ticker: str, data_dir: str, dry_run: bool = False) -> dict:
     logger.info(f"{ticker}: Using materiality threshold {threshold:.4%}")
 
     # Create tracker (in-memory, not loading existing file)
-    tracker = ContributionTracker.__new__(ContributionTracker)
-    tracker.data_path = output_path
-    tracker.agent_scores = {}
+    tracker = ContributionTracker.create_empty(output_path)
 
     scored_cycles = 0
     skipped_cycles = 0
@@ -164,6 +162,25 @@ def migrate_ticker(ticker: str, data_dir: str, dry_run: bool = False) -> dict:
             if canonical_regime not in tracker.agent_scores[agent]:
                 tracker.agent_scores[agent][canonical_regime] = []
             tracker.agent_scores[agent][canonical_regime].append(score)
+
+        # Score Master as self-assessment (direction vs outcome)
+        if master_dir and master_dir != "NEUTRAL":
+            master_score = tracker._compute_score(
+                agent_name="master_decision",
+                agent_direction=master_dir,
+                agent_confidence=master_conf,
+                master_direction=master_dir,
+                actual_outcome=actual_outcome,
+                prediction_type=pred_type,
+                strategy_type=strat_type,
+                volatility_outcome=vol_outcome,
+                influence_weight=1.0,
+            )
+            if "master_decision" not in tracker.agent_scores:
+                tracker.agent_scores["master_decision"] = {}
+            if canonical_regime not in tracker.agent_scores["master_decision"]:
+                tracker.agent_scores["master_decision"][canonical_regime] = []
+            tracker.agent_scores["master_decision"][canonical_regime].append(master_score)
 
         scored_cycles += 1
 

--- a/trading_bot/contribution_bridge.py
+++ b/trading_bot/contribution_bridge.py
@@ -163,6 +163,25 @@ def record_cycle_contributions(
         )
         scores[agent] = score
 
+    # Record Master as self-assessment (not in vote_breakdown but useful
+    # for dashboard diagnostics: was the final decision correct?)
+    if master_direction:
+        master_score = tracker.record_contribution(
+            agent="master_decision",
+            agent_direction=master_direction,
+            agent_confidence=master_confidence,
+            master_direction=master_direction,
+            actual_outcome=actual_outcome,
+            prediction_type=prediction_type,
+            strategy_type=strategy_type,
+            volatility_outcome=volatility_outcome,
+            regime=regime,
+            influence_weight=1.0,
+            cycle_id=cycle_id,
+            contract=contract,
+        )
+        scores["master_decision"] = master_score
+
     return scores
 
 

--- a/trading_bot/contribution_scorer.py
+++ b/trading_bot/contribution_scorer.py
@@ -76,6 +76,14 @@ class ContributionTracker:
         self.agent_scores: Dict[str, Dict[str, List[float]]] = {}
         self._load()
 
+    @classmethod
+    def create_empty(cls, data_path: str) -> "ContributionTracker":
+        """Create an empty tracker without loading from disk (for migration)."""
+        instance = cls.__new__(cls)
+        instance.data_path = data_path
+        instance.agent_scores = {}
+        return instance
+
     def record_contribution(
         self,
         agent: str,

--- a/trading_bot/reconciliation.py
+++ b/trading_bot/reconciliation.py
@@ -566,7 +566,8 @@ async def _process_reconciliation(ib: IB, df: pd.DataFrame, config: dict, file_p
             # --- Record Contribution Scores ---
             try:
                 _scoring_cfg = config.get("scoring", {})
-                if _scoring_cfg.get("use_contribution_scoring", False):
+                if (_scoring_cfg.get("use_contribution_scoring", False)
+                        or _scoring_cfg.get("accumulate_contribution_scores", False)):
                     _cycle_id = row.get("cycle_id", "")
                     _vote_breakdown_raw = row.get("vote_breakdown", "")
                     _regime = row.get("entry_regime", "NORMAL")


### PR DESCRIPTION
## Summary
Addresses external review feedback on contribution scoring:

1. **Accumulate gate**: Reconciliation hook now also fires when `accumulate_contribution_scores: true`, enabling shadow data collection before cutover
2. **`create_empty()` classmethod**: Replaces `__new__()` hack in migration script
3. **Master self-assessment**: Records master_decision contribution score (direction vs outcome) for dashboard diagnostics
4. **Dashboard data path**: Uses `_resolve_data_path_for()` instead of bridge's global state, fixing commodity switching and working directory issues

## Test plan
- [x] 46 existing tests pass
- [x] Migration script verified with `create_empty()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)