### PR TITLE
fix: contribution-aware DSPy evaluation and enablement

### DIFF
--- a/scripts/optimize_prompts.py
+++ b/scripts/optimize_prompts.py
@@ -70,15 +70,27 @@ def print_eval_table(stats: dict, readiness: dict, min_examples: int):
               f"{total_neutral/total_all:.0%} NEUTRAL")
     print()
 
-    # Header
-    fmt = "{:<20} {:>8} {:>10} {:>11} {:>7}  {}"
-    print(fmt.format("Agent", "Examples", "Dir. Acc.", "Abstention", "Brier", "Ready?"))
-    print("-" * 85)
+    # Check if contribution metrics are available
+    has_metric = any(
+        info.get("avg_metric_score") is not None
+        for info in agents_info.values()
+    )
 
-    # Sort by directional accuracy ascending (worst first)
+    # Header
+    if has_metric:
+        fmt = "{:<20} {:>8} {:>10} {:>8} {:>11} {:>7}  {}"
+        print(fmt.format("Agent", "Examples", "Dir. Acc.", "Metric", "Abstention", "Brier", "Ready?"))
+        print("-" * 95)
+    else:
+        fmt = "{:<20} {:>8} {:>10} {:>11} {:>7}  {}"
+        print(fmt.format("Agent", "Examples", "Dir. Acc.", "Abstention", "Brier", "Ready?"))
+        print("-" * 85)
+
+    # Sort by metric score (or directional accuracy) ascending (worst first)
+    sort_key = "avg_metric_score" if has_metric else "directional_accuracy"
     sorted_agents = sorted(
         agents_info.items(),
-        key=lambda x: x[1].get("directional_accuracy", 0),
+        key=lambda x: x[1].get(sort_key, 0),
     )
 
     for agent, info in sorted_agents:
@@ -90,14 +102,25 @@ def print_eval_table(stats: dict, readiness: dict, min_examples: int):
         if info["directional_accuracy"] < 0.30:
             flag = " <-- worst"
 
-        print(fmt.format(
-            agent,
-            f"{dir_total}/{info['total']}",
-            f"{info['directional_accuracy']:.1%}",
-            f"{info['abstention_rate']:.1%}",
-            f"{info['brier_score']:.2f}",
-            f"{ready_str} ({reason}){flag}",
-        ))
+        if has_metric:
+            print(fmt.format(
+                agent,
+                f"{dir_total}/{info['total']}",
+                f"{info['directional_accuracy']:.1%}",
+                f"{info.get('avg_metric_score', 0):.3f}",
+                f"{info['abstention_rate']:.1%}",
+                f"{info['brier_score']:.2f}",
+                f"{ready_str} ({reason}){flag}",
+            ))
+        else:
+            print(fmt.format(
+                agent,
+                f"{dir_total}/{info['total']}",
+                f"{info['directional_accuracy']:.1%}",
+                f"{info['abstention_rate']:.1%}",
+                f"{info['brier_score']:.2f}",
+                f"{ready_str} ({reason}){flag}",
+            ))
 
     print()
     print("Run with --optimize to generate improved prompts.")
@@ -112,13 +135,26 @@ def print_optimization_results(
     min_for_suggest: int,
 ):
     """Print before/after comparison and recommendation."""
-    print(f"\n{'='*56}")
+    print(f"\n{'='*70}")
     print(f"  Optimization Results ({ticker})")
-    print(f"{'='*56}\n")
+    print(f"{'='*70}\n")
 
-    fmt = "{:<20} {:>8} {:>8} {:>10} {:>11}  {:>5}"
-    print(fmt.format("Agent", "Before", "After", "Delta", "Abstention", "Demos"))
-    print("-" * 75)
+    # Check if contribution metrics are available
+    has_metric = any(
+        opt.get("avg_metric_score") is not None
+        for opt in optimized_results.values()
+        if not opt.get("skipped")
+    )
+
+    if has_metric:
+        fmt = "{:<20} {:>8} {:>8} {:>7} {:>8} {:>8} {:>7} {:>5}"
+        print(fmt.format("Agent", "Dir.Bef", "Dir.Aft", "D.Delt",
+                          "Met.Bef", "Met.Aft", "M.Delt", "Demos"))
+        print("-" * 85)
+    else:
+        fmt = "{:<20} {:>8} {:>8} {:>10} {:>11}  {:>5}"
+        print(fmt.format("Agent", "Before", "After", "Delta", "Abstention", "Demos"))
+        print("-" * 75)
 
     for agent in sorted(optimized_results.keys()):
         opt = optimized_results[agent]
@@ -129,17 +165,25 @@ def print_optimization_results(
         base_acc = baseline.get(agent, {}).get("directional_accuracy", 0)
         opt_acc = opt.get("directional_accuracy", 0)
         delta = opt_acc - base_acc
-        delta_str = f"{delta:+.1%}"
-        abstention = opt.get("abstention_rate", 0)
 
-        print(fmt.format(
-            agent,
-            f"{base_acc:.1%}",
-            f"{opt_acc:.1%}",
-            delta_str,
-            f"{abstention:.1%}",
-            opt.get("n_demos", 0),
-        ))
+        if has_metric:
+            base_met = baseline.get(agent, {}).get("avg_metric_score") or 0
+            opt_met = opt.get("avg_metric_score") or 0
+            met_delta = opt_met - base_met
+            print(fmt.format(
+                agent,
+                f"{base_acc:.1%}", f"{opt_acc:.1%}", f"{delta:+.1%}",
+                f"{base_met:.3f}", f"{opt_met:.3f}", f"{met_delta:+.3f}",
+                opt.get("n_demos", 0),
+            ))
+        else:
+            abstention = opt.get("abstention_rate", 0)
+            print(fmt.format(
+                agent,
+                f"{base_acc:.1%}", f"{opt_acc:.1%}", f"{delta:+.1%}",
+                f"{abstention:.1%}",
+                opt.get("n_demos", 0),
+            ))
 
     print(f"\nOptimized prompts saved to {output_dir}/{ticker}/")
 

--- a/tests/test_dspy_contribution.py
+++ b/tests/test_dspy_contribution.py
@@ -1,0 +1,442 @@
+"""Tests for DSPy contribution-aware scoring and data pipeline."""
+
+import csv
+import json
+import os
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from trading_bot.dspy_optimizer import (
+    CouncilDataset,
+    _compute_metric_score,
+    _safe_float,
+    evaluate_baseline,
+    should_suggest_enable,
+)
+
+
+# ---------------------------------------------------------------------------
+# _compute_metric_score
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMetricScore:
+    """Test the standalone metric function used by optimizer + eval."""
+
+    def test_positive_contribution_matching_direction(self):
+        """Positive contribution + matching direction → high score."""
+        score = _compute_metric_score(
+            pred_direction="BULLISH",
+            pred_confidence=0.8,
+            actual="BULLISH",
+            contribution_score=0.6,
+            example_direction="BULLISH",
+        )
+        assert score == pytest.approx(0.7 + 0.3 * 0.6)
+
+    def test_positive_contribution_different_direction(self):
+        """Positive contribution but prediction differs from example → 0.2."""
+        score = _compute_metric_score(
+            pred_direction="BEARISH",
+            pred_confidence=0.8,
+            actual="BULLISH",
+            contribution_score=0.6,
+            example_direction="BULLISH",
+        )
+        assert score == 0.2
+
+    def test_negative_contribution_matching_direction(self):
+        """Negative contribution + matching direction → 0.0 (reproducing bad call)."""
+        score = _compute_metric_score(
+            pred_direction="BULLISH",
+            pred_confidence=0.8,
+            actual="BEARISH",
+            contribution_score=-0.5,
+            example_direction="BULLISH",
+        )
+        assert score == 0.0
+
+    def test_negative_contribution_different_direction(self):
+        """Negative contribution + different direction → 0.5 (avoided mistake)."""
+        score = _compute_metric_score(
+            pred_direction="BEARISH",
+            pred_confidence=0.8,
+            actual="BEARISH",
+            contribution_score=-0.5,
+            example_direction="BULLISH",
+        )
+        assert score == 0.5
+
+    def test_zero_contribution_neutral_prediction(self):
+        """Zero contribution + NEUTRAL prediction → rewarded for abstention."""
+        score = _compute_metric_score(
+            pred_direction="NEUTRAL",
+            pred_confidence=0.7,
+            actual="NEUTRAL",
+            contribution_score=0.0,
+            example_direction="NEUTRAL",
+        )
+        assert score == pytest.approx(0.4 + 0.2 * 0.7)
+
+    def test_zero_contribution_directional_prediction(self):
+        """Zero contribution + directional prediction → 0.3."""
+        score = _compute_metric_score(
+            pred_direction="BULLISH",
+            pred_confidence=0.8,
+            actual="NEUTRAL",
+            contribution_score=0.0,
+            example_direction="NEUTRAL",
+        )
+        assert score == 0.3
+
+    def test_no_contribution_neutral_fallback(self):
+        """No contribution data + NEUTRAL → small credit."""
+        score = _compute_metric_score(
+            pred_direction="NEUTRAL",
+            pred_confidence=0.5,
+            actual="BULLISH",
+            contribution_score=None,
+        )
+        assert score == 0.15
+
+    def test_no_contribution_correct_direction(self):
+        """No contribution data + correct direction → high score."""
+        score = _compute_metric_score(
+            pred_direction="BULLISH",
+            pred_confidence=0.9,
+            actual="BULLISH",
+            contribution_score=None,
+        )
+        # direction_match=1.0, calibration=1-|0.9-1.0|=0.9
+        assert score == pytest.approx(0.7 + 0.3 * 0.9)
+
+    def test_no_contribution_wrong_direction(self):
+        """No contribution data + wrong direction → low score."""
+        score = _compute_metric_score(
+            pred_direction="BEARISH",
+            pred_confidence=0.9,
+            actual="BULLISH",
+            contribution_score=None,
+        )
+        # direction_match=0, calibration=1-|0.9-0.0|=0.1
+        assert score == pytest.approx(0.0 + 0.3 * 0.1)
+
+    def test_positive_contribution_clamped_at_1(self):
+        """Large positive contribution clamped at 1.0 in abs()."""
+        score = _compute_metric_score(
+            pred_direction="BULLISH",
+            pred_confidence=0.9,
+            actual="BULLISH",
+            contribution_score=2.5,
+            example_direction="BULLISH",
+        )
+        assert score == pytest.approx(0.7 + 0.3 * 1.0)
+
+
+# ---------------------------------------------------------------------------
+# _build_contribution_lookup
+# ---------------------------------------------------------------------------
+
+
+class TestBuildContributionLookup:
+    """Test the data pipeline from council_history to contribution scores."""
+
+    def _make_dataset(self, tmp_path, council_rows, brier_preds):
+        """Create a CouncilDataset with minimal fixtures."""
+        data_dir = tmp_path / "KC"
+        data_dir.mkdir()
+
+        # Write enhanced_brier.json
+        brier_path = data_dir / "enhanced_brier.json"
+        brier_path.write_text(json.dumps({"predictions": brier_preds}))
+
+        # Write council_history.csv
+        if council_rows:
+            csv_path = data_dir / "council_history.csv"
+            fieldnames = list(council_rows[0].keys())
+            with open(csv_path, "w", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                writer.writeheader()
+                for row in council_rows:
+                    writer.writerow(row)
+
+        return CouncilDataset(str(data_dir))
+
+    def test_basic_lookup(self, tmp_path):
+        """Lookup is built from vote_breakdown + actual outcome."""
+        council_rows = [{
+            "cycle_id": "KC-001",
+            "contract": "KCN6",
+            "entry_price": "100.0",
+            "exit_price": "110.0",
+            "trigger_type": "scheduled",
+            "thesis_strength": "HIGH",
+            "master_decision": "BULLISH",
+            "prediction_type": "DIRECTIONAL",
+            "strategy_type": "",
+            "volatility_outcome": "",
+            "actual_trend_direction": "BULLISH",
+            "vote_breakdown": json.dumps([
+                {"agent": "macro", "direction": "BULLISH", "confidence": 0.8, "final_weight": 1.0},
+                {"agent": "technical", "direction": "BEARISH", "confidence": 0.6, "final_weight": 1.0},
+            ]),
+        }]
+        brier_preds = [
+            {"cycle_id": "KC-001", "agent": "macro", "actual_outcome": "BULLISH",
+             "prob_bullish": 0.8, "prob_neutral": 0.1, "prob_bearish": 0.1, "timestamp": "2026-01-01"},
+            {"cycle_id": "KC-001", "agent": "technical", "actual_outcome": "BULLISH",
+             "prob_bullish": 0.2, "prob_neutral": 0.2, "prob_bearish": 0.6, "timestamp": "2026-01-01"},
+        ]
+
+        ds = self._make_dataset(tmp_path, council_rows, brier_preds)
+        predictions = ds.load()
+
+        # macro said BULLISH, outcome BULLISH → positive contribution
+        macro_score = predictions["macro"][0].get("contribution_score")
+        assert macro_score is not None
+        assert macro_score > 0
+
+        # technical said BEARISH, outcome BULLISH → negative contribution
+        tech_score = predictions["technical"][0].get("contribution_score")
+        assert tech_score is not None
+        assert tech_score < 0
+
+    def test_materiality_threshold_makes_neutral(self, tmp_path):
+        """Small price moves are reclassified as NEUTRAL via materiality threshold."""
+        council_rows = [{
+            "cycle_id": "KC-002",
+            "contract": "KCN6",
+            "entry_price": "100.0",
+            "exit_price": "100.3",  # 0.3% < KC threshold of 0.6%
+            "trigger_type": "scheduled",
+            "thesis_strength": "MODERATE",
+            "master_decision": "BULLISH",
+            "prediction_type": "DIRECTIONAL",
+            "strategy_type": "",
+            "volatility_outcome": "",
+            "actual_trend_direction": "BULLISH",
+            "vote_breakdown": json.dumps([
+                {"agent": "macro", "direction": "BULLISH", "confidence": 0.7, "final_weight": 1.0},
+            ]),
+        }]
+        brier_preds = [
+            {"cycle_id": "KC-002", "agent": "macro", "actual_outcome": "BULLISH",
+             "prob_bullish": 0.7, "prob_neutral": 0.2, "prob_bearish": 0.1, "timestamp": "2026-01-01"},
+        ]
+
+        ds = self._make_dataset(tmp_path, council_rows, brier_preds)
+        predictions = ds.load()
+
+        # Actual outcome reclassified as NEUTRAL due to small move (0.3% < 0.6% threshold)
+        # When actual_outcome is NEUTRAL, _compute_score PATH 1 returns 0.0
+        # (market didn't move enough — nobody credited or blamed)
+        score = predictions["macro"][0].get("contribution_score")
+        assert score is not None
+        assert score == 0.0
+
+    def test_empty_vote_breakdown_skipped(self, tmp_path):
+        """Rows with empty vote_breakdown produce no lookup entries."""
+        council_rows = [{
+            "cycle_id": "KC-003",
+            "contract": "KCN6",
+            "entry_price": "100.0",
+            "exit_price": "110.0",
+            "trigger_type": "scheduled",
+            "thesis_strength": "HIGH",
+            "master_decision": "BULLISH",
+            "prediction_type": "DIRECTIONAL",
+            "strategy_type": "",
+            "volatility_outcome": "",
+            "actual_trend_direction": "BULLISH",
+            "vote_breakdown": "",
+        }]
+        brier_preds = [
+            {"cycle_id": "KC-003", "agent": "macro", "actual_outcome": "BULLISH",
+             "prob_bullish": 0.8, "prob_neutral": 0.1, "prob_bearish": 0.1, "timestamp": "2026-01-01"},
+        ]
+
+        ds = self._make_dataset(tmp_path, council_rows, brier_preds)
+        predictions = ds.load()
+
+        # No contribution score because vote_breakdown was empty
+        assert predictions["macro"][0].get("contribution_score") is None
+
+    def test_unresolved_cycle_skipped(self, tmp_path):
+        """Rows with NaN actual_trend_direction are skipped."""
+        council_rows = [{
+            "cycle_id": "KC-004",
+            "contract": "KCN6",
+            "entry_price": "100.0",
+            "exit_price": "",
+            "trigger_type": "scheduled",
+            "thesis_strength": "HIGH",
+            "master_decision": "BULLISH",
+            "prediction_type": "DIRECTIONAL",
+            "strategy_type": "",
+            "volatility_outcome": "",
+            "actual_trend_direction": "NaN",
+            "vote_breakdown": json.dumps([
+                {"agent": "macro", "direction": "BULLISH", "confidence": 0.8, "final_weight": 1.0},
+            ]),
+        }]
+        brier_preds = [
+            {"cycle_id": "KC-004", "agent": "macro", "actual_outcome": "BULLISH",
+             "prob_bullish": 0.8, "prob_neutral": 0.1, "prob_bearish": 0.1, "timestamp": "2026-01-01"},
+        ]
+
+        ds = self._make_dataset(tmp_path, council_rows, brier_preds)
+        predictions = ds.load()
+
+        assert predictions["macro"][0].get("contribution_score") is None
+
+    def test_malformed_json_vote_breakdown_skipped(self, tmp_path):
+        """Rows with invalid JSON vote_breakdown don't crash, just skip."""
+        council_rows = [{
+            "cycle_id": "KC-005",
+            "contract": "KCN6",
+            "entry_price": "100.0",
+            "exit_price": "110.0",
+            "trigger_type": "scheduled",
+            "thesis_strength": "HIGH",
+            "master_decision": "BULLISH",
+            "prediction_type": "DIRECTIONAL",
+            "strategy_type": "",
+            "volatility_outcome": "",
+            "actual_trend_direction": "BULLISH",
+            "vote_breakdown": "not valid json{{{",
+        }]
+        brier_preds = [
+            {"cycle_id": "KC-005", "agent": "macro", "actual_outcome": "BULLISH",
+             "prob_bullish": 0.8, "prob_neutral": 0.1, "prob_bearish": 0.1, "timestamp": "2026-01-01"},
+        ]
+
+        ds = self._make_dataset(tmp_path, council_rows, brier_preds)
+        predictions = ds.load()  # Should not raise
+
+        assert predictions["macro"][0].get("contribution_score") is None
+
+    def test_no_council_history(self, tmp_path):
+        """Dataset works fine without council_history.csv — no enrichment."""
+        data_dir = tmp_path / "KC"
+        data_dir.mkdir()
+        brier_path = data_dir / "enhanced_brier.json"
+        brier_path.write_text(json.dumps({"predictions": [
+            {"cycle_id": "KC-001", "agent": "macro", "actual_outcome": "BULLISH",
+             "prob_bullish": 0.8, "prob_neutral": 0.1, "prob_bearish": 0.1, "timestamp": "2026-01-01"},
+        ]}))
+
+        ds = CouncilDataset(str(data_dir))
+        predictions = ds.load()
+
+        assert predictions["macro"][0].get("contribution_score") is None
+        assert predictions["macro"][0].get("market_context") is not None
+
+
+# ---------------------------------------------------------------------------
+# Stats and evaluation with contribution metrics
+# ---------------------------------------------------------------------------
+
+
+class TestStatsWithMetric:
+    """Test that stats() and evaluate_baseline() include metric scores."""
+
+    def _make_dataset(self, tmp_path, examples):
+        """Create a dataset from pre-built prediction dicts."""
+        data_dir = tmp_path / "KC"
+        data_dir.mkdir()
+        brier_preds = []
+        for ex in examples:
+            brier_preds.append({
+                "cycle_id": ex.get("cycle_id", "KC-001"),
+                "agent": ex["agent"],
+                "actual_outcome": ex["actual"],
+                "prob_bullish": ex.get("prob_bullish", 0.5),
+                "prob_neutral": ex.get("prob_neutral", 0.3),
+                "prob_bearish": ex.get("prob_bearish", 0.2),
+                "timestamp": "2026-01-01",
+            })
+        brier_path = data_dir / "enhanced_brier.json"
+        brier_path.write_text(json.dumps({"predictions": brier_preds}))
+        return CouncilDataset(str(data_dir))
+
+    def test_stats_includes_avg_metric_score(self, tmp_path):
+        """stats() returns avg_metric_score per agent."""
+        examples = [
+            {"agent": "macro", "actual": "BULLISH", "prob_bullish": 0.8,
+             "prob_neutral": 0.1, "prob_bearish": 0.1, "cycle_id": "KC-001"},
+            {"agent": "macro", "actual": "BEARISH", "prob_bullish": 0.2,
+             "prob_neutral": 0.1, "prob_bearish": 0.7, "cycle_id": "KC-002"},
+        ]
+        ds = self._make_dataset(tmp_path, examples)
+        stats = ds.stats()
+        assert "avg_metric_score" in stats["agents"]["macro"]
+        assert isinstance(stats["agents"]["macro"]["avg_metric_score"], float)
+
+    def test_stats_includes_contribution_coverage(self, tmp_path):
+        """stats() reports what fraction of examples have contribution scores."""
+        examples = [
+            {"agent": "macro", "actual": "BULLISH", "prob_bullish": 0.8,
+             "prob_neutral": 0.1, "prob_bearish": 0.1, "cycle_id": "KC-001"},
+        ]
+        ds = self._make_dataset(tmp_path, examples)
+        stats = ds.stats()
+        # Without council_history, no contribution scores → coverage = 0
+        assert stats["agents"]["macro"]["contribution_coverage"] == 0.0
+
+    def test_evaluate_baseline_includes_metric(self, tmp_path):
+        """evaluate_baseline() propagates avg_metric_score from stats."""
+        examples = [
+            {"agent": "macro", "actual": "BULLISH", "prob_bullish": 0.8,
+             "prob_neutral": 0.1, "prob_bearish": 0.1, "cycle_id": "KC-001"},
+        ]
+        ds = self._make_dataset(tmp_path, examples)
+        stats = ds.stats()
+        baseline = evaluate_baseline(stats)
+        assert "avg_metric_score" in baseline["macro"]
+
+
+# ---------------------------------------------------------------------------
+# should_suggest_enable with metric
+# ---------------------------------------------------------------------------
+
+
+class TestShouldSuggestEnableMetric:
+    """Test that should_suggest_enable uses metric scores when available."""
+
+    def test_uses_metric_over_directional(self):
+        """When avg_metric_score is available, uses it for comparison."""
+        baseline = {
+            "macro": {"directional_accuracy": 0.50, "avg_metric_score": 0.40},
+            "technical": {"directional_accuracy": 0.50, "avg_metric_score": 0.40},
+        }
+        # Metric improved a lot, directional stayed same
+        optimized = {
+            "macro": {"directional_accuracy": 0.50, "avg_metric_score": 0.60},
+            "technical": {"directional_accuracy": 0.50, "avg_metric_score": 0.55},
+        }
+        stats = {
+            "agents": {
+                "macro": {"total": 200, "class_balance": 0.45},
+                "technical": {"total": 200, "class_balance": 0.45},
+            }
+        }
+        suggest, explanation = should_suggest_enable(baseline, optimized, stats, min_for_suggest=100)
+        # avg metric improvement is ~17.5%, should recommend
+        assert suggest is True
+
+    def test_falls_back_to_directional_without_metric(self):
+        """Without avg_metric_score, uses directional_accuracy."""
+        baseline = {
+            "macro": {"directional_accuracy": 0.40},
+        }
+        optimized = {
+            "macro": {"directional_accuracy": 0.55},
+        }
+        stats = {
+            "agents": {
+                "macro": {"total": 200, "class_balance": 0.45},
+            }
+        }
+        suggest, explanation = should_suggest_enable(baseline, optimized, stats, min_for_suggest=100)
+        assert suggest is True

--- a/trading_bot/dspy_optimizer.py
+++ b/trading_bot/dspy_optimizer.py
@@ -292,6 +292,20 @@ class CouncilDataset:
             dates = [ex["timestamp"][:10] for ex in examples if ex["timestamp"]]
             all_dates.extend(dates)
 
+            # Contribution-aware metric score (baseline = historical predictions)
+            metric_scores = [
+                _compute_metric_score(
+                    pred_direction=ex["direction"],
+                    pred_confidence=ex.get("confidence", 0.5),
+                    actual=ex["actual"],
+                    contribution_score=ex.get("contribution_score"),
+                    example_direction=ex["direction"],
+                )
+                for ex in examples
+            ]
+            avg_metric = sum(metric_scores) / len(metric_scores) if metric_scores else 0.0
+            contrib_count = sum(1 for ex in examples if ex.get("contribution_score") is not None)
+
             result[agent] = {
                 "total": total,
                 "directional_total": len(directional),
@@ -299,6 +313,8 @@ class CouncilDataset:
                 "directional_accuracy": directional_accuracy,
                 "abstention_rate": abstention_rate,
                 "brier_score": brier,
+                "avg_metric_score": avg_metric,
+                "contribution_coverage": contrib_count / total if total > 0 else 0.0,
                 "bullish": bullish,
                 "bearish": bearish,
                 "neutral": neutral,
@@ -360,6 +376,48 @@ def _class_balance(directions: list[str]) -> float:
     total = sum(primary.values())
     min_count = min(primary.values())
     return min_count / total
+
+
+def _compute_metric_score(
+    pred_direction: str,
+    pred_confidence: float,
+    actual: str,
+    contribution_score: float | None = None,
+    example_direction: str = "",
+) -> float:
+    """Contribution-aware metric score for a single prediction.
+
+    Used by the DSPy optimizer metric, baseline evaluation, and validation.
+
+    Args:
+        pred_direction: Predicted direction (BULLISH/BEARISH/NEUTRAL).
+        pred_confidence: Predicted confidence (0.0-1.0).
+        actual: Actual outcome (BULLISH/BEARISH/NEUTRAL).
+        contribution_score: From contribution scorer (None if unavailable).
+        example_direction: Historical direction from training example
+            (used to check if prediction matches the known-good/bad call).
+    """
+    if contribution_score is not None:
+        if contribution_score > 0:
+            if pred_direction == example_direction:
+                return 0.7 + 0.3 * min(1.0, abs(contribution_score))
+            return 0.2
+        elif contribution_score < 0:
+            if pred_direction == example_direction:
+                return 0.0
+            return 0.5
+        else:
+            if pred_direction == "NEUTRAL":
+                return 0.4 + 0.2 * pred_confidence
+            return 0.3
+
+    # Fallback: directional accuracy + calibration
+    if pred_direction == "NEUTRAL":
+        return 0.15
+    direction_match = 1.0 if pred_direction == actual else 0.0
+    actual_hit = 1.0 if pred_direction == actual else 0.0
+    calibration = 1.0 - abs(pred_confidence - actual_hit)
+    return direction_match * 0.7 + calibration * 0.3
 
 
 # ---------------------------------------------------------------------------
@@ -426,23 +484,32 @@ def should_suggest_enable(
             f"Need >= {min_for_suggest} examples/agent. Short: {', '.join(insufficient)}"
         )
 
-    # 2 & 4. Improvement checks
+    # 2 & 4. Improvement checks (prefer contribution metric, fall back to directional)
     avg_improvement = 0.0
     pct_improved = 0.0
     improvements = []
+    using_metric = False
     common_agents = set(baseline.keys()) & set(optimized.keys())
     for agent in common_agents:
-        base_acc = baseline[agent].get("directional_accuracy", 0)
-        opt_acc = optimized[agent].get("directional_accuracy", 0)
-        improvements.append(opt_acc - base_acc)
+        # Use contribution-aware metric when available on both sides
+        base_metric = baseline[agent].get("avg_metric_score")
+        opt_metric = optimized[agent].get("avg_metric_score")
+        if base_metric is not None and opt_metric is not None:
+            improvements.append(opt_metric - base_metric)
+            using_metric = True
+        else:
+            base_acc = baseline[agent].get("directional_accuracy", 0)
+            opt_acc = optimized[agent].get("directional_accuracy", 0)
+            improvements.append(opt_acc - base_acc)
 
     if improvements:
         avg_improvement = sum(improvements) / len(improvements) * 100
         pct_improved = sum(1 for d in improvements if d > 0) / len(improvements)
+        metric_label = "metric" if using_metric else "directional"
 
         if avg_improvement < MIN_IMPROVEMENT_PCT:
             reasons.append(
-                f"Average improvement {avg_improvement:.1f}% < {MIN_IMPROVEMENT_PCT}% threshold"
+                f"Average {metric_label} improvement {avg_improvement:.1f}% < {MIN_IMPROVEMENT_PCT}% threshold"
             )
         if pct_improved < MIN_AGENTS_IMPROVED_RATIO:
             reasons.append(
@@ -529,6 +596,19 @@ def optimize_agent(
     baseline_correct = sum(1 for ex in directional_examples if ex["direction"] == ex["actual"])
     baseline_accuracy = baseline_correct / len(directional_examples) if directional_examples else 0.0
 
+    # Compute baseline contribution metric from raw examples
+    baseline_metric_scores = [
+        _compute_metric_score(
+            pred_direction=ex["direction"],
+            pred_confidence=ex.get("confidence", 0.5),
+            actual=ex["actual"],
+            contribution_score=ex.get("contribution_score"),
+            example_direction=ex["direction"],
+        )
+        for ex in examples
+    ]
+    baseline_metric = sum(baseline_metric_scores) / len(baseline_metric_scores) if baseline_metric_scores else 0.0
+
     # Build dspy.Example list
     trainset, valset = _build_splits(examples)
 
@@ -558,45 +638,20 @@ def optimize_agent(
                 task=f"Analyze as {agent_name}",
             )
 
-    # Metric: contribution-aware scoring with Brier fallback.
-    # When contribution scores are available, rewards agents for outputs
-    # that helped the council (positive contribution) and penalizes outputs
-    # that hurt it. NEUTRAL is a valid output when the domain isn't relevant.
-    # Falls back to directional accuracy when contribution data is missing.
+    # Metric: contribution-aware scoring with directional fallback.
+    # Delegates to _compute_metric_score (shared with baseline eval).
     def metric(example, prediction, trace=None):
-        pred_dir = prediction.direction
         try:
             pred_conf = float(prediction.confidence)
         except (ValueError, TypeError, AttributeError):
             pred_conf = 0.5
-
-        contribution = getattr(example, "contribution_score", None)
-
-        # Contribution-based metric (preferred when data available)
-        if contribution is not None:
-            if contribution > 0:
-                # Helpful output: reward reproducing similar behavior
-                if pred_dir == example.direction:
-                    return 0.7 + 0.3 * min(1.0, abs(contribution))
-                return 0.2  # Right idea, different execution
-            elif contribution < 0:
-                # Harmful output: penalize reproducing it
-                if pred_dir == example.direction:
-                    return 0.0  # Reproducing the bad call
-                return 0.5  # At least not repeating the mistake
-            else:
-                # Zero contribution (NEUTRAL agent or NEUTRAL outcome)
-                if pred_dir == "NEUTRAL":
-                    return 0.4 + 0.2 * pred_conf  # Reward correct abstention
-                return 0.3  # Forced a direction when it didn't matter
-
-        # Fallback: directional accuracy + calibration (no contribution data)
-        if pred_dir == "NEUTRAL":
-            return 0.15  # Small credit for honest abstention
-        direction_match = 1.0 if pred_dir == example.actual else 0.0
-        actual_hit = 1.0 if pred_dir == example.actual else 0.0
-        calibration = 1.0 - abs(pred_conf - actual_hit)
-        return direction_match * 0.7 + calibration * 0.3
+        return _compute_metric_score(
+            pred_direction=prediction.direction,
+            pred_confidence=pred_conf,
+            actual=example.actual,
+            contribution_score=getattr(example, "contribution_score", None),
+            example_direction=example.direction,
+        )
 
     # Run BootstrapFewShot (demo counts configurable via config.dspy)
     dspy_cfg = config.get("dspy", {})
@@ -611,12 +666,24 @@ def optimize_agent(
     module = AgentPredictor()
     compiled = optimizer.compile(module, trainset=trainset)
 
-    # Evaluate on validation set (directional accuracy only)
+    # Evaluate on validation set (contribution metric + directional accuracy)
     val_directional = 0
     val_correct = 0
+    val_metric_scores = []
     for ex in valset:
         try:
             pred = compiled(market_context=ex.market_context)
+            try:
+                pred_conf = float(pred.confidence)
+            except (ValueError, TypeError, AttributeError):
+                pred_conf = 0.5
+            val_metric_scores.append(_compute_metric_score(
+                pred_direction=pred.direction,
+                pred_confidence=pred_conf,
+                actual=ex.actual,
+                contribution_score=getattr(ex, "contribution_score", None),
+                example_direction=ex.direction,
+            ))
             if pred.direction != "NEUTRAL":
                 val_directional += 1
                 if pred.direction == ex.actual:
@@ -626,6 +693,7 @@ def optimize_agent(
 
     val_accuracy = val_correct / val_directional if val_directional else 0.0
     val_abstention = 1.0 - (val_directional / len(valset)) if valset else 0.0
+    val_metric = sum(val_metric_scores) / len(val_metric_scores) if val_metric_scores else 0.0
 
     # Extract optimized instruction and demos.
     # NEUTRAL demos are kept — they're valuable examples of correctly
@@ -649,7 +717,9 @@ def optimize_agent(
     # Save
     result = {
         "baseline_directional_accuracy": baseline_accuracy,
+        "baseline_metric": baseline_metric,
         "directional_accuracy": val_accuracy,
+        "avg_metric_score": val_metric,
         "abstention_rate": val_abstention,
         "n_demos": len(demos),
         "instruction": instruction,
@@ -720,7 +790,9 @@ def export_optimized_prompt(
         "optimized_at": datetime.now(timezone.utc).isoformat(),
         "n_training_examples": result.get("n_demos", 0),
         "baseline_directional_accuracy": result.get("baseline_directional_accuracy", None),
+        "baseline_metric": result.get("baseline_metric", None),
         "optimized_directional_accuracy": result.get("directional_accuracy", None),
+        "optimized_metric": result.get("avg_metric_score", None),
         "optimized_abstention_rate": result.get("abstention_rate", None),
         "instruction": instruction,
         "demos": result.get("demos", []),
@@ -780,6 +852,7 @@ def evaluate_baseline(stats: dict) -> dict[str, dict]:
     for agent, info in stats.get("agents", {}).items():
         result[agent] = {
             "directional_accuracy": info["directional_accuracy"],
+            "avg_metric_score": info.get("avg_metric_score"),
             "abstention_rate": info["abstention_rate"],
             "brier_score": info["brier_score"],
             "n_examples": info["total"],


### PR DESCRIPTION
## Summary
- Extracts `_compute_metric_score()` as a shared standalone function used consistently across optimizer training, baseline stats, validation loop, and enablement recommendation
- Adds `avg_metric_score` and `contribution_coverage` to `stats()` output so baseline evaluation includes contribution-aware scoring
- Updates `should_suggest_enable()` to prefer contribution metric over directional accuracy when available
- Updates `print_optimization_results()` and `print_eval_table()` to display metric scores alongside directional accuracy
- Adds 21 tests covering `_compute_metric_score`, `_build_contribution_lookup` data pipeline, stats/baseline integration, and `should_suggest_enable` metric preference

Addresses feedback points:
- **#2**: DSPy validation evaluation now computes contribution metric, not just directional accuracy
- **#3**: `_build_contribution_lookup` now has dedicated tests (JSON parsing, materiality threshold, NaN handling, missing data)
- **#4**: `should_suggest_enable()` uses contribution metric when available for improvement comparison

## Test plan
- [x] 21 new tests in `test_dspy_contribution.py` all pass
- [x] 46 existing `test_contribution_scorer.py` tests pass (no regressions)
- [x] 88 total related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)