### PR TITLE
fix: penalize NEUTRAL on real moves + abstention ceilings

### DIFF
--- a/config.json
+++ b/config.json
@@ -567,7 +567,18 @@
     "max_bootstrapped_demos": 4,
     "max_labeled_demos": 2,
     "min_examples_per_agent": 30,
-    "min_examples_for_suggest": 100
+    "min_examples_for_suggest": 100,
+    "max_neutral_rate": {
+      "default": 0.60,
+      "technical": 0.40,
+      "sentiment": 0.40,
+      "volatility": 0.40,
+      "macro": 0.55,
+      "agronomist": 0.70,
+      "inventory": 0.70,
+      "supply_chain": 0.70,
+      "geopolitical": 0.75
+    }
   },
   "final_column_order": [
     "date",

--- a/tests/test_dspy_contribution.py
+++ b/tests/test_dspy_contribution.py
@@ -68,8 +68,8 @@ class TestComputeMetricScore:
         )
         assert score == 0.5
 
-    def test_zero_contribution_neutral_prediction(self):
-        """Zero contribution + NEUTRAL prediction → rewarded for abstention."""
+    def test_zero_contribution_neutral_on_noise(self):
+        """Zero contribution + NEUTRAL on NEUTRAL outcome → good abstention."""
         score = _compute_metric_score(
             pred_direction="NEUTRAL",
             pred_confidence=0.7,
@@ -79,8 +79,19 @@ class TestComputeMetricScore:
         )
         assert score == pytest.approx(0.4 + 0.2 * 0.7)
 
+    def test_zero_contribution_neutral_on_real_move(self):
+        """Zero contribution + NEUTRAL on directional outcome → missed signal."""
+        score = _compute_metric_score(
+            pred_direction="NEUTRAL",
+            pred_confidence=0.7,
+            actual="BULLISH",
+            contribution_score=0.0,
+            example_direction="NEUTRAL",
+        )
+        assert score == 0.15
+
     def test_zero_contribution_directional_prediction(self):
-        """Zero contribution + directional prediction → 0.3."""
+        """Zero contribution + directional prediction → 0.25."""
         score = _compute_metric_score(
             pred_direction="BULLISH",
             pred_confidence=0.8,
@@ -88,7 +99,7 @@ class TestComputeMetricScore:
             contribution_score=0.0,
             example_direction="NEUTRAL",
         )
-        assert score == 0.3
+        assert score == 0.25
 
     def test_no_contribution_neutral_fallback(self):
         """No contribution data + NEUTRAL → small credit."""
@@ -132,6 +143,28 @@ class TestComputeMetricScore:
             example_direction="BULLISH",
         )
         assert score == pytest.approx(0.7 + 0.3 * 1.0)
+
+    def test_always_neutral_is_suboptimal(self):
+        """Always-NEUTRAL strategy scores lower than selective commitment.
+
+        Given 40% NEUTRAL outcomes and 60% directional, an always-NEUTRAL
+        agent should score worse than one that commits selectively.
+        """
+        # Always-NEUTRAL agent: 0.4 * 0.5 + 0.6 * 0.15 = 0.29
+        always_neutral = (
+            0.4 * _compute_metric_score("NEUTRAL", 0.5, "NEUTRAL", 0.0, "NEUTRAL")
+            + 0.6 * _compute_metric_score("NEUTRAL", 0.5, "BULLISH", 0.0, "NEUTRAL")
+        )
+
+        # Selective agent: commits on directional, abstains on noise.
+        # Gets directional right 50% of the time.
+        selective = (
+            0.4 * _compute_metric_score("NEUTRAL", 0.5, "NEUTRAL", 0.0, "NEUTRAL")
+            + 0.3 * _compute_metric_score("BULLISH", 0.8, "BULLISH", 0.5, "BULLISH")
+            + 0.3 * _compute_metric_score("BULLISH", 0.8, "BEARISH", -0.5, "BULLISH")
+        )
+
+        assert selective > always_neutral
 
 
 # ---------------------------------------------------------------------------
@@ -440,3 +473,41 @@ class TestShouldSuggestEnableMetric:
         }
         suggest, explanation = should_suggest_enable(baseline, optimized, stats, min_for_suggest=100)
         assert suggest is True
+
+
+# ---------------------------------------------------------------------------
+# Abstention ceiling
+# ---------------------------------------------------------------------------
+
+
+class TestAbstentionCeiling:
+    """Test that abstention ceiling config values are respected."""
+
+    def test_ceiling_values_in_config(self):
+        """Config has per-agent max_neutral_rate entries."""
+        import json
+        from pathlib import Path
+        config_path = Path(__file__).resolve().parent.parent / "config.json"
+        with open(config_path) as f:
+            cfg = json.load(f)
+        rates = cfg.get("dspy", {}).get("max_neutral_rate", {})
+        assert rates.get("default") == 0.60
+        assert rates.get("technical") == 0.40
+        assert rates.get("sentiment") == 0.40
+        assert rates.get("volatility") == 0.40
+        assert rates.get("macro") == 0.55
+        assert rates.get("agronomist") == 0.70
+        assert rates.get("geopolitical") == 0.75
+
+    def test_episodic_agents_have_higher_ceiling(self):
+        """Episodic domain agents (agronomist, inventory) get looser ceilings."""
+        import json
+        from pathlib import Path
+        config_path = Path(__file__).resolve().parent.parent / "config.json"
+        with open(config_path) as f:
+            cfg = json.load(f)
+        rates = cfg.get("dspy", {}).get("max_neutral_rate", {})
+        # Episodic agents should have higher ceilings than daily-data agents
+        assert rates["agronomist"] > rates["technical"]
+        assert rates["inventory"] > rates["sentiment"]
+        assert rates["geopolitical"] > rates["macro"]

--- a/trading_bot/dspy_optimizer.py
+++ b/trading_bot/dspy_optimizer.py
@@ -407,9 +407,22 @@ def _compute_metric_score(
                 return 0.0
             return 0.5
         else:
+            # Zero contribution: actual was NEUTRAL, agent was NEUTRAL, or
+            # Master was NEUTRAL. Distinguish "correct abstention on noise"
+            # from "missed a real market move."
             if pred_direction == "NEUTRAL":
-                return 0.4 + 0.2 * pred_confidence
-            return 0.3
+                if actual == "NEUTRAL":
+                    # Market noise — correctly identified nothing was happening
+                    return 0.4 + 0.2 * pred_confidence
+                else:
+                    # Market moved significantly but agent had no opinion.
+                    # Better than being actively wrong (0.0) but worse than
+                    # committing correctly (0.7+) or identifying noise (0.4+).
+                    return 0.15
+            else:
+                # Agent forced a direction but contribution was still 0
+                # (e.g., aligned with Master but outcome was NEUTRAL)
+                return 0.25
 
     # Fallback: directional accuracy + calibration
     if pred_direction == "NEUTRAL":
@@ -694,6 +707,25 @@ def optimize_agent(
     val_accuracy = val_correct / val_directional if val_directional else 0.0
     val_abstention = 1.0 - (val_directional / len(valset)) if valset else 0.0
     val_metric = sum(val_metric_scores) / len(val_metric_scores) if val_metric_scores else 0.0
+
+    # Abstention ceiling: reject optimization if NEUTRAL rate exceeds
+    # per-agent ceiling. Different agents have different domain frequencies.
+    max_neutral_rates = dspy_cfg.get("max_neutral_rate", {})
+    default_ceiling = max_neutral_rates.get("default", 0.60)
+    agent_ceiling = max_neutral_rates.get(agent_name, default_ceiling)
+    if val_abstention > agent_ceiling:
+        logger.warning(
+            f"[{agent_name}] Abstention rate {val_abstention:.0%} exceeds "
+            f"ceiling {agent_ceiling:.0%} — rejecting optimization"
+        )
+        return {
+            "directional_accuracy": 0.0,
+            "avg_metric_score": 0.0,
+            "abstention_rate": val_abstention,
+            "n_demos": 0,
+            "skipped": True,
+            "reason": f"abstention {val_abstention:.0%} > ceiling {agent_ceiling:.0%}",
+        }
 
     # Extract optimized instruction and demos.
     # NEUTRAL demos are kept — they're valuable examples of correctly


### PR DESCRIPTION
## Summary
- **Layer 1**: Zero-contribution metric now distinguishes "correct abstention on noise" (actual=NEUTRAL → 0.4-0.6) from "missed a real market move" (actual=directional → 0.15). Breaks the perverse incentive where always-NEUTRAL guaranteed a ~0.4 floor — an always-NEUTRAL agent now scores ~0.29 vs ~0.41 for selective commitment.
- **Layer 2**: Per-agent `max_neutral_rate` ceilings in config.json. Optimizations exceeding domain-appropriate abstention rates are rejected (technical/sentiment/volatility: 40%, macro: 55%, agronomist/inventory/supply_chain: 70%, geopolitical: 75%).

## Context
First DSPy optimization run showed 3 agents converging to 100% NEUTRAL (inventory, geopolitical, agronomist) because the metric rewarded abstention equally regardless of whether the market actually moved.

## Test plan
- [x] 25 DSPy contribution tests pass (including new `test_always_neutral_is_suboptimal`)
- [x] 46 contribution scorer tests pass
- [x] Abstention ceiling config values verified in tests
- [x] Incentive math validated: selective commitment (0.41) > always-NEUTRAL (0.29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)