### PR TITLE
fix: increase CC liquidity spread threshold to match market conditions

### DIFF
--- a/config.json
+++ b/config.json
@@ -681,7 +681,7 @@
       },
       "strategy_tuning": {
         "max_liquidity_spread_percentage": 0.75,
-        "max_liquidity_spread_ticks": 30,
+        "max_liquidity_spread_ticks": 55,
         "cap_timeout_seconds": 900,
         "monitoring_duration_seconds": 1800
       }


### PR DESCRIPTION
## Summary
- CC (Cocoa) has generated 174 council decisions since Feb 19 but **zero orders reached IBKR** because the liquidity filter rejected every contract
- Cocoa options have bid-ask spreads of 36–75 ticks, but `max_liquidity_spread_ticks` was set to 30 (compared to 80 for KC and NG)
- Increased threshold to 55 ticks — allows most contracts through while still filtering the widest, most illiquid strikes

## Test plan
- [ ] Verify CC generates orders on next trading session
- [ ] Monitor fill quality to ensure 55 ticks isn't too permissive (adjust if slippage is excessive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)