### PR TITLE
fix: lower NG emergency trigger threshold from 7% to 5%

### DIFF
--- a/config/profiles/ng.json
+++ b/config/profiles/ng.json
@@ -18,7 +18,7 @@
         "active": "09:00-14:30",
         "passive": ["18:00-09:00", "14:30-17:00"],
         "maintenance_breaks": ["17:00-18:00"],
-        "emergency_trigger_pct": 7.0,
+        "emergency_trigger_pct": 5.0,
         "emergency_cooldown_seconds": 1800,
         "emergency_council_timeout_seconds": 300,
         "passive_new_positions_only": true,


### PR DESCRIPTION
## Summary
- NG's `emergency_trigger_pct` was 7%, meaning overnight moves had to exceed 7% to trigger an immediate council decision during PASSIVE hours
- Only 1 out of 103 NG council decisions ever fired during PASSIVE — meaningful 3-5% overnight moves were all deferred to the next morning
- Lowered to 5% to allow the system to react to significant overnight moves while still filtering routine volatility

## Test plan
- [ ] Monitor NG overnight behavior for appropriate trigger frequency
- [ ] Verify deferred triggers still work for sub-5% moves
- [ ] Watch for excessive PASSIVE council invocations (adjust back up if too noisy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)