### PR TITLE
fix: align council_history log with post-gate execution outcome

### DIFF
--- a/trading_bot/signal_generator.py
+++ b/trading_bot/signal_generator.py
@@ -1031,6 +1031,23 @@ async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_ty
         vol_level = routed['vol_level']
         reason = routed['reason']
 
+        # Align council_history log with actual execution outcome.
+        # The log vars (prediction_type_log, strategy_type_log) were set from the
+        # Master's original direction BEFORE the conviction gate and route_strategy().
+        # Update them so the audit trail reflects what actually executed.
+        prediction_type_log = prediction_type
+        vol_level_log = vol_level
+        if prediction_type == 'VOLATILITY' and vol_level == 'LOW':
+            strategy_type_log = 'IRON_CONDOR'
+        elif prediction_type == 'VOLATILITY' and vol_level == 'HIGH':
+            strategy_type_log = 'LONG_STRADDLE'
+        elif routed['direction'] in ('BULLISH',):
+            strategy_type_log = 'BULL_CALL_SPREAD'
+        elif routed['direction'] in ('BEARISH',):
+            strategy_type_log = 'BEAR_PUT_SPREAD'
+        else:
+            strategy_type_log = 'NONE'
+
         logger.info(f"Router decision: {prediction_type}/{vol_level} for {contract.localSymbol}")
 
         # Construct final signal object


### PR DESCRIPTION
## Summary
- Council history logging captured `strategy_type` before the H6-A conviction gate and `route_strategy()` ran
- A suppressed BULLISH signal (score 0.14 < 0.20) would still log `BULL_CALL_SPREAD` in council_history even though no trade was placed
- Now updates `prediction_type_log`, `vol_level_log`, and `strategy_type_log` from the `routed` result after all gates have run
- Audit trail now matches actual execution: suppressed signals log as `NONE`, IC suppressions log correctly

## Test plan
- [x] All 1004 tests pass
- [ ] Verify next conviction-gated signal logs `strategy_type=NONE` in council_history

🤖 Generated with [Claude Code](https://claude.com/claude-code)