### PR TITLE
Widen drawdown circuit breaker thresholds for multi-commodity portfolio

### DIFF
--- a/config.json
+++ b/config.json
@@ -82,10 +82,10 @@
   },
   "drawdown_circuit_breaker": {
     "enabled": true,
-    "warning_pct": 2.0,
-    "halt_pct": 4.0,
-    "panic_pct": 6.0,
-    "recovery_pct": 3.0,
+    "warning_pct": 3.0,
+    "halt_pct": 6.0,
+    "panic_pct": 9.0,
+    "recovery_pct": 3.5,
     "recovery_hold_minutes": 30
   },
   "notifications": {

--- a/trading_bot/drawdown_circuit_breaker.py
+++ b/trading_bot/drawdown_circuit_breaker.py
@@ -5,9 +5,9 @@ Protects against aggregate portfolio losses that individual position stops miss.
 Halts trading for the day if intraday P&L drops below configurable thresholds.
 
 Thresholds (default):
-- WARNING: -2.0% intraday -> Pushover alert
-- HALT:    -4.0% intraday -> Block new trades
-- PANIC:   -6.0% intraday -> Close ALL positions
+- WARNING: -3.0% intraday -> Pushover alert
+- HALT:    -6.0% intraday -> Block new trades
+- PANIC:   -9.0% intraday -> Close ALL positions
 """
 
 import csv
@@ -56,10 +56,10 @@ class DrawdownGuard:
         self.config = config.get('drawdown_circuit_breaker', {})
         self.notification_config = config.get('notifications', {})
         self.enabled = self.config.get('enabled', False)
-        self.warning_pct = self.config.get('warning_pct', 2.0)
-        self.halt_pct = self.config.get('halt_pct', 4.0)
-        self.panic_pct = self.config.get('panic_pct', 6.0)
-        self.recovery_pct = self.config.get('recovery_pct', 3.0)
+        self.warning_pct = self.config.get('warning_pct', 3.0)
+        self.halt_pct = self.config.get('halt_pct', 6.0)
+        self.panic_pct = self.config.get('panic_pct', 9.0)
+        self.recovery_pct = self.config.get('recovery_pct', 3.5)
         self.recovery_hold_minutes = self.config.get('recovery_hold_minutes', 30)
         self._recovery_start = None
         self._panic_is_live = False  # Only True after update_pnl() freshly evaluates PANIC


### PR DESCRIPTION
## Summary
- Widen drawdown thresholds: WARNING 2→3%, HALT 4→6%, PANIC 6→9%, recovery 3→3.5%
- Old 4% halt was compensating for execution bugs (orphaned legs) now fixed by atomic BAG closes (PR #1263)
- With KC/NG/CC books, options bid-ask widening during low-liquidity windows can produce 4-5% phantom drawdowns that don't represent actual losses
- New thresholds sized for market risk, not implementation risk

## Test plan
- [x] Drawdown tests pass (pre-existing import issue unrelated to this change)
- [x] Tests use inline config values, unaffected by default changes
- [ ] Monitor Pushover notifications post-deploy — WARNING should trigger less frequently
- [ ] Verify no spurious HALTs during overnight NG sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)