### PR TITLE
chore: bump webfactory/ssh-agent v0.5.2 → v0.9.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Set up SSH key
-        uses: webfactory/ssh-agent@v0.5.2
+        uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 


### PR DESCRIPTION
## Summary
- Bumps `webfactory/ssh-agent` from v0.5.2 to v0.9.0 in deploy workflow
- Fixes Node.js 20 deprecation warning (forced to Node 24 starting June 2, 2026)

## Test plan
- [ ] Verify deploy workflow still works (SSH key setup + deployment)
- [ ] Confirm Node.js deprecation warning is gone from annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)