### PR TITLE
🎨 Palette: Add tooltips to safety interlock checkboxes

### DIFF
--- a/pages/1_Cockpit.py
+++ b/pages/1_Cockpit.py
@@ -29,7 +29,6 @@ from dashboard_utils import (
     calculate_rolling_win_rate,
     get_active_theses,
     get_current_market_regime,
-    get_commodity_profile,
     load_task_schedule_status,
     load_deduplicator_metrics,
     _resolve_data_path,
@@ -1129,7 +1128,7 @@ with ctrl_cols[0]:
     st.caption("No active cooldown")
 
 with ctrl_cols[1]:
-    confirm_halt = st.checkbox("I confirm I want to HALT all orders", key="confirm_halt")
+    confirm_halt = st.checkbox("I confirm I want to HALT all orders", key="confirm_halt", help="Check this to enable the 'EMERGENCY HALT' button, which immediately cancels all unfilled orders across all positions.")
     if st.button(
         "🛑 EMERGENCY HALT",
         type="primary",
@@ -1162,7 +1161,7 @@ with ctrl_cols[1]:
             st.error("Config not loaded")
 
 with ctrl_cols[2]:
-    confirm_refresh = st.checkbox("I confirm I want to reload all data", key="confirm_refresh")
+    confirm_refresh = st.checkbox("I confirm I want to reload all data", key="confirm_refresh", help="Check this to enable the 'Refresh All Data' button, which clears application cache and forces a full data reload from external sources.")
     if st.button(
         "🔄 Refresh All Data",
         width="stretch",

--- a/pages/5_Utilities.py
+++ b/pages/5_Utilities.py
@@ -53,7 +53,7 @@ Collect and archive logs to the centralized logs branch for analysis and debuggi
 This captures orchestrator logs, dashboard logs, state files, and trading data.
 """)
 
-confirm_collect = st.checkbox("I confirm I want to collect logs", key="confirm_collect")
+confirm_collect = st.checkbox("I confirm I want to collect logs", key="confirm_collect", help="Check this to enable the 'Collect Logs' button, which archives orchestrator logs, dashboard logs, state files, and trading data for analysis.")
 if st.button(
     "🚀 Collect Logs",
     type="primary",
@@ -216,7 +216,7 @@ with manual_cols[0]:
     st.caption("Runs full order generation cycle: data pull → Council deliberation → signals → order placement")
 
     # Safety Interlock
-    confirm_exec = st.checkbox("I confirm I want to execute live trades", key="confirm_exec_orders")
+    confirm_exec = st.checkbox("I confirm I want to execute live trades", key="confirm_exec_orders", help="Check this to enable the 'Force Generate & Execute Orders' button, which immediately triggers a full data pull, analysis, and order placement cycle.")
     confirm_text = st.text_input("Type 'EXECUTE' to confirm:", key="confirm_text_orders")
 
     is_authorized = confirm_exec and confirm_text == "EXECUTE"
@@ -310,7 +310,7 @@ with manual_cols[1]:
     st.warning("⚠️ **Cancel All Open Orders**")
     st.caption("Immediately cancels all unfilled DAY orders in IB")
 
-    confirm_cancel_all = st.checkbox("I confirm I want to CANCEL all open orders", key="confirm_cancel_all")
+    confirm_cancel_all = st.checkbox("I confirm I want to CANCEL all open orders", key="confirm_cancel_all", help="Check this to enable the 'Cancel All Open Orders' button, which immediately cancels all unfilled DAY orders in Interactive Brokers.")
     if st.button(
         "🛑 Cancel All Open Orders",
         disabled=not confirm_cancel_all,
@@ -346,7 +346,7 @@ with manual_cols2[0]:
     st.warning("⚠️ **Close Stale Positions**")
     st.caption("Closes positions held longer than max_holding_days")
 
-    confirm_close_stale = st.checkbox("I confirm I want to CLOSE stale positions", key="confirm_close_stale")
+    confirm_close_stale = st.checkbox("I confirm I want to CLOSE stale positions", key="confirm_close_stale", help="Check this to enable the 'Force Close Stale Positions' button, which immediately attempts to close any open positions that have exceeded their maximum configured holding period.")
     if st.button(
         "🔄 Force Close Stale Positions",
         disabled=not confirm_close_stale,
@@ -380,7 +380,7 @@ with manual_cols2[1]:
     st.info("ℹ️ **Sync Equity Data**")
     st.caption("Forces fresh equity sync from IB Flex Query")
 
-    confirm_sync = st.checkbox("I confirm I want to force equity sync", key="confirm_sync")
+    confirm_sync = st.checkbox("I confirm I want to force equity sync", key="confirm_sync", help="Check this to enable the 'Force Equity Sync' button, which triggers a fresh data pull from Interactive Brokers Flex Query reports to update equity balances.")
     if st.button(
         "💰 Force Equity Sync",
         disabled=not confirm_sync,
@@ -665,7 +665,7 @@ with state_cols[1]:
 
     # Use a form with confirmation checkbox to prevent accidental clicks
     with st.form("clear_state_form"):
-        confirm_clear = st.checkbox("I understand this will clear all state data")
+        confirm_clear = st.checkbox("I understand this will clear all state data", help="Check this to enable the 'Clear State File' button, which completely deletes all application state (sentinels, triggers, deduplicators) and forces a fresh rebuild on next run.")
         submit_clear = st.form_submit_button("🗑️ Clear State File")
 
         if submit_clear:
@@ -704,12 +704,12 @@ This validates the entire architecture from sentinels to council to order execut
 validation_cols = st.columns([2, 1])
 
 with validation_cols[0]:
-    confirm_val = st.checkbox("I confirm I want to run system validation", key="confirm_val")
+    confirm_val = st.checkbox("I confirm I want to run system validation", key="confirm_val", help="Check this to enable the 'Run System Validation' button, which executes comprehensive preflight diagnostic checks on infrastructure and trading components.")
     run_validation = st.button("🚀 Run System Validation", type="primary", width='stretch', disabled=not confirm_val, help="Run preflight checks on all system components (~30s in quick mode, ~2min full).")
 
 with validation_cols[1]:
-    json_output = st.checkbox("JSON Output", value=False)
-    quick_mode = st.checkbox("Quick Mode (Skip slow tests)", value=True)
+    json_output = st.checkbox("JSON Output", value=False, help="Outputs the validation results in raw JSON format rather than human-readable text.")
+    quick_mode = st.checkbox("Quick Mode (Skip slow tests)", value=True, help="Skips slow external API checks (like LLM endpoint validation) to return results faster.")
 
 if run_validation:
     with st.spinner("Running comprehensive system validation..."):
@@ -1143,7 +1143,7 @@ st.markdown("Clear cached data to force fresh data loads from sources.")
 cache_cols = st.columns(2)
 
 with cache_cols[0]:
-    confirm_clear_cache = st.checkbox("I confirm I want to clear all cached data", key="confirm_clear_cache")
+    confirm_clear_cache = st.checkbox("I confirm I want to clear all cached data", key="confirm_clear_cache", help="Check this to enable the 'Clear All Caches' button, which purges all loaded data from memory, forcing fresh fetches on the next page load.")
     if st.button(
         "🔄 Clear All Caches",
         disabled=not confirm_clear_cache,

--- a/tests/test_ui_ux.py
+++ b/tests/test_ui_ux.py
@@ -349,6 +349,37 @@ class TestPortfolioUX(unittest.TestCase):
 
 
 class TestUtilitiesUX(unittest.TestCase):
+    def test_utilities_checkbox_tooltips(self):
+        """Verify that all checkboxes in pages/5_Utilities.py have help tooltips."""
+        file_path = os.path.join(
+            os.path.dirname(__file__), "..", "pages", "5_Utilities.py"
+        )
+        with open(file_path, "r") as f:
+            tree = ast.parse(f.read())
+
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "checkbox"
+            ):
+                if not node.args:
+                    continue
+
+                label = None
+                if isinstance(node.args[0], ast.Constant):
+                    label = node.args[0].value
+                elif isinstance(node.args[0], ast.JoinedStr):
+                    # Handle f-strings if any
+                    label = "f-string"
+
+                if label:
+                    has_help = any(kw.arg == "help" for kw in node.keywords)
+                    self.assertTrue(
+                        has_help,
+                        f"Checkbox '{label}' in Utilities is missing 'help' tooltip",
+                    )
+
     def test_utilities_safety_interlocks(self):
         """Verify that high-impact buttons in pages/5_Utilities.py have safety interlocks."""
         file_path = os.path.join(


### PR DESCRIPTION
### 💡 What:
Added `help` parameters (tooltips) to the `st.checkbox` components that serve as safety interlocks on the `Utilities` and `Cockpit` pages. Also added a unit test to enforce this pattern moving forward.

### 🎯 Why:
The dashboard utilizes a great "Safety Interlock" pattern for high-impact or destructive actions (e.g., canceling orders, clearing cache), requiring the user to explicitly check a box before the action button is enabled. However, the checkboxes themselves lacked tooltips detailing the *consequence* of checking them. Adding tooltips reduces cognitive load and operational risk by providing immediate context.

### ♿ Accessibility:
The `help` tooltips provide native Streamlit "just-in-time" documentation on hover, aiding user comprehension without cluttering the UI.

---
*PR created automatically by Jules for task [17621848494173673836](https://jules.google.com/task/17621848494173673836) started by @rozavala*