### PR TITLE
fix: filter cockpit untracked positions by commodity prefix

### DIFF
--- a/dashboard_utils.py
+++ b/dashboard_utils.py
@@ -364,6 +364,14 @@ def find_untracked_ibkr_positions(live_data: dict, active_theses: list, ticker: 
     if not portfolio_items:
         return []
 
+    # Filter portfolio to this commodity's symbol prefixes
+    # Futures use ticker directly, options use exchange-specific prefixes
+    _IBKR_SYMBOL_PREFIXES = {
+        "KC": ("KC", "KO"), "CC": ("CC", "DC"),
+        "SB": ("SB", "SO"), "NG": ("NG", "LNE"),
+    }
+    prefixes = _IBKR_SYMBOL_PREFIXES.get(ticker, (ticker,)) if ticker else None
+
     # Collect position_ids from active theses
     thesis_pids = {t.get('position_id') for t in (active_theses or [])}
 
@@ -384,6 +392,9 @@ def find_untracked_ibkr_positions(live_data: dict, active_theses: list, ticker: 
             continue
         local_sym = getattr(item.contract, 'localSymbol', None)
         if not local_sym:
+            continue
+        # Skip positions belonging to other commodities
+        if prefixes and not local_sym.startswith(prefixes):
             continue
         pid = symbol_to_pid.get(local_sym)
         if pid and pid in thesis_pids:


### PR DESCRIPTION
## Summary
- **Bug**: The Cockpit dashboard's "untracked IBKR positions" section was showing positions from ALL commodities in each commodity's view (e.g., NG positions appearing as untracked in KC's cockpit and vice versa)
- **Root cause**: `find_untracked_ibkr_positions()` compared the full IB portfolio against only the current commodity's theses, without filtering by IBKR symbol prefix first
- **Fix**: Added IBKR symbol prefix filtering (`KC→KO`, `NG→LNE`, `CC→DC`, `SB→SO`) to skip positions belonging to other commodities before the thesis-matching check

## Test plan
- [x] All 29 UI/UX tests pass
- [x] Prefix filtering validated: KC view keeps `KON6 P2.8` / skips `LNEM6 P3300`, NG view keeps `LNEM6 P3300` / skips `KON6 P2.8`
- [ ] Verify in dashboard that KC cockpit only shows KC positions and NG cockpit only shows NG positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)