### PR TITLE
fix: use profile-driven timeout for market order fallback in close path

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1858,7 +1858,12 @@ async def _close_single_leg_with_walk(
             trade = place_order(ib, contract, order)
             if trade is None:
                 return False
-            for _ in range(15):
+            try:
+                from config import get_active_profile
+                _mkt_timeout = get_active_profile(config).market_order_fallback_timeout_seconds
+            except Exception:
+                _mkt_timeout = 60
+            for _ in range(_mkt_timeout):
                 await asyncio.sleep(1)
                 if trade.orderStatus.status == 'Filled':
                     try:
@@ -1965,7 +1970,12 @@ async def _close_single_leg_with_walk(
             if market_trade is None:
                 return False
 
-            for _ in range(15):
+            try:
+                from config import get_active_profile
+                _mkt_timeout2 = get_active_profile(config).market_order_fallback_timeout_seconds
+            except Exception:
+                _mkt_timeout2 = 60
+            for _ in range(_mkt_timeout2):
                 await asyncio.sleep(1)
                 if market_trade.orderStatus.status == 'Filled':
                     logger.info(


### PR DESCRIPTION
## Summary
- Replace two hardcoded `range(15)` loops in `_close_single_leg_with_walk()` with profile-driven `market_order_fallback_timeout_seconds` (KC=90s, CC=120s, NG=60s)
- This is the orchestrator's fallback/emergency close path — it fires when `order_manager.py`'s primary close fails, so it needs the same commodity-aware timeout
- Matches the existing pattern in `order_manager.py` (line 3329) with 60s fallback default

## Test plan
- [ ] Verify syntax passes CI
- [ ] Confirm no remaining `range(15)` in orchestrator close paths
- [ ] Monitor next close-stale cycle to verify timeout behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)