### PR TITLE
fix: disconnect guard clientId filter + reflexion error loop breaker

### DIFF
--- a/trading_bot/agents.py
+++ b/trading_bot/agents.py
@@ -39,11 +39,21 @@ def _is_error_report(report) -> bool:
     research_topic() wraps exceptions as:
       {'data': 'Error conducting research: ...', 'confidence': 0.0, 'sentiment': 'NEUTRAL'}
     These must not be passed to the council as legitimate agent reports (Issue #1167).
+
+    Also catches LLM-rephrased variants where reflexion previously fed the
+    error text back as "previous analysis" and the LLM re-phrased it (e.g.,
+    "[EVIDENCE]: The provided input was a system error message ('Error
+    conducting research: ...')"). Without this, poisoned state persists across
+    cycles even after the original API error resolves.
     """
-    if isinstance(report, dict) and isinstance(report.get('data'), str):
-        data_str = report['data']
-        if 'Error conducting research' in data_str or 'All providers exhausted' in data_str:
-            return True
+    if isinstance(report, dict):
+        data = report.get('data', '')
+        # Handle nested dicts (reflexion output wraps data in another dict)
+        if isinstance(data, dict):
+            data = data.get('data', '')
+        if isinstance(data, str):
+            if 'Error conducting research' in data or 'All providers exhausted' in data:
+                return True
     return False
 
 
@@ -1104,6 +1114,18 @@ OUTPUT FORMAT (JSON):
 
         # Step 1: Initial analysis
         initial_response_struct = await self.research_topic(persona_key, search_instruction, regime_context=regime_context, trace_collector=trace_collector)
+
+        # Short-circuit reflexion if the initial research failed.
+        # Feeding error text into the reflexion prompt creates a
+        # self-perpetuating loop where the LLM "analyzes" the error
+        # message as evidence, poisoning state for future cycles.
+        if _is_error_report(initial_response_struct):
+            logger.warning(
+                f"[{persona_key}] Skipping reflexion — initial research returned error. "
+                f"Returning error struct as-is to avoid poisoned-state loop."
+            )
+            return initial_response_struct
+
         initial_text = initial_response_struct.get('data', '')
 
         # Step 2: Reflexion prompt

--- a/trading_bot/connection_pool.py
+++ b/trading_bot/connection_pool.py
@@ -329,8 +329,15 @@ class IBConnectionPool:
         fill callbacks and corrupted local state.
         """
         try:
+            my_client_id = ib.client.clientId
             pending = []
             for trade in ib.openTrades():
+                # Only drain orders placed by THIS connection's clientId.
+                # IB Gateway returns trades from ALL client connections on the
+                # same account; attempting to cancel another engine's orders
+                # causes Error 10147 and 120s blocking stalls.
+                if trade.order.clientId != my_client_id:
+                    continue
                 status = trade.orderStatus.status
                 if status not in cls.TERMINAL_ORDER_STATES:
                     pending.append(trade)


### PR DESCRIPTION
## Summary
- **Disconnect guard cross-engine bleed**: `_drain_pending_orders` now filters `ib.openTrades()` by `trade.order.clientId` to only process orders placed by the current connection. IB Gateway returns trades from all client connections on the same account — without this filter, each engine tried to cancel other engines' orders, causing Error 10147, 120-second blocking stalls, and false CRITICAL alerts (#1276, #1277, #1278, all closed as false positives).
- **Reflexion error propagation**: `research_topic_with_reflexion` now short-circuits when the initial research returns an error, preventing the LLM from "analyzing" error text as evidence — which was creating a self-perpetuating poisoned state loop (CC geopolitical agent was non-functional for days).
- **`_is_error_report()` hardened**: Now handles nested dicts from reflexion output wrapping, catching re-phrased error patterns that previously slipped through.

## Production fixes applied alongside this PR
- Cleared poisoned `reports.geopolitical` key from `/data/CC/state.json`
- Paused CC trading (`ACTIVE_COMMODITIES=KC,NG`) — zero lifetime fills due to persistent 65-85 tick spreads exceeding the 55-tick liquidity threshold
- Closed false-positive issues #1276, #1277, #1278

## Test plan
- [ ] Verify no `range(15)` or unfiltered `openTrades()` loops remain
- [ ] Confirm disconnect guard logs show "No pending orders" on clean release (no cross-engine bleed)
- [ ] Confirm geopolitical agent research succeeds on next KC/NG cycle (no reflexion error loop)
- [ ] Monitor for 0 false CRITICAL disconnect guard alerts over next 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)