### PR TITLE
fix: filter weekly close verification by commodity — prevent cross-engine closes

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -3928,6 +3928,13 @@ async def run_emergency_cycle(trigger: SentinelTrigger, config: dict, ib: IB, pa
                     if affected_theses and live_positions is not None:
                         trade_ledger = get_trade_ledger_df()
 
+                        # Filter to this commodity only — IB returns ALL positions
+                        active_ticker = config.get('commodity', {}).get('ticker', config.get('symbol', 'KC'))
+                        commodity_positions = [
+                            p for p in live_positions
+                            if p.position != 0 and p.contract.symbol == active_ticker
+                        ]
+
                         for thesis in affected_theses:
                           try:
                             # Check if this trigger invalidates the thesis
@@ -3946,9 +3953,7 @@ async def run_emergency_cycle(trigger: SentinelTrigger, config: dict, ib: IB, pa
 
                                 # Collect ALL legs for this thesis (spreads have multiple legs)
                                 thesis_legs = []
-                                for pos in live_positions:
-                                    if pos.position == 0:
-                                        continue
+                                for pos in commodity_positions:
                                     pos_id = _find_position_id_for_contract(pos, trade_ledger)
                                     if pos_id == thesis_id:
                                         thesis_legs.append(pos)

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -3406,13 +3406,18 @@ async def close_stale_positions(config: dict, connection_purpose: str = "orchest
 
             try:
                 verify_positions = await asyncio.wait_for(ib.reqPositionsAsync(), timeout=30)
-                remaining = [p for p in (verify_positions or []) if p.position != 0]
+                # Filter to this commodity only — IB returns ALL positions across commodities.
+                # Without this filter, KC engine would try to close NG/CC positions.
+                remaining = [
+                    p for p in (verify_positions or [])
+                    if p.position != 0 and p.contract.symbol == commodity_symbol
+                ]
 
                 if remaining:
                     remaining_symbols = [p.contract.localSymbol for p in remaining]
                     logger.critical(
                         f"⚠️ POST-CLOSE VERIFICATION FAILED: "
-                        f"{len(remaining)} positions still open: {remaining_symbols}"
+                        f"{len(remaining)} {commodity_symbol} positions still open: {remaining_symbols}"
                     )
 
                     # RETRY: Attempt individual market orders for each remaining leg
@@ -3441,10 +3446,13 @@ async def close_stale_positions(config: dict, connection_purpose: str = "orchest
                                 f"{pos.contract.localSymbol} (RETRY FAILED: {retry_e})"
                             )
 
-                    # Re-verify after retries
+                    # Re-verify after retries (filtered to this commodity)
                     await asyncio.sleep(5)
                     final_check = await asyncio.wait_for(ib.reqPositionsAsync(), timeout=30)
-                    final_remaining = [p for p in (final_check or []) if p.position != 0]
+                    final_remaining = [
+                        p for p in (final_check or [])
+                        if p.position != 0 and p.contract.symbol == commodity_symbol
+                    ]
 
                     if final_remaining:
                         final_symbols = [p.contract.localSymbol for p in final_remaining]


### PR DESCRIPTION
## Summary
**CRITICAL safety fix.** The weekly close post-verification path called `reqPositionsAsync()` without filtering by commodity symbol. Since IB returns positions for ALL commodities on the account, the KC engine was seeing NG positions (LNEM6, LN4H6) as "still open" and sending MARKET orders to close them — closing another engine's positions.

**Root cause:** Same cross-commodity pollution pattern as PR #1274 (dashboard) but in the execution path — much more dangerous since it places real orders.

**What happened (2026-03-13):**
1. KC weekly close completed its own positions successfully
2. Post-close verification fetched ALL IB positions (unfiltered)
3. Saw 4 NG positions (LNEM6 P3250, LNEM6 P3300, LN4H6 P3150, LN4H6 C3150)
4. Attempted MARKET order closes on all 4 → triggered `WEEKLY CLOSE FAILED` alert
5. User had to manually close the NG positions

**Fix:** Add `p.contract.symbol == commodity_symbol` filter to 3 unfiltered paths:
- `order_manager.py`: post-close verification (~line 3403)
- `order_manager.py`: second verification retry (~line 3441)
- `orchestrator.py`: sentinel invalidation defense check (~line 3915)

The initial position fetch already had this filter (line 2929).

## Test plan
- [ ] Verify syntax passes CI
- [ ] Next weekly close (Monday or next Friday) should only see positions for the active commodity
- [ ] Grep for unfiltered `reqPositionsAsync` — confirm no remaining paths iterate all positions without commodity filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)