### PR TITLE
🎨 Palette: Add tooltip to Override Delta metric

### DIFF
--- a/pages/2_The_Scorecard.py
+++ b/pages/2_The_Scorecard.py
@@ -1118,7 +1118,7 @@ try:
                         delta_color=delta_color,
                     )
                 else:
-                    st.metric("Override Delta", "N/A")
+                    st.metric("Override Delta", "N/A", help="Override win rate minus aligned win rate. Positive = overrides add value.")
 
             with kpi_cols[3]:
                 cal_note = cc.get("_calibration_note", "") if cc else ""


### PR DESCRIPTION
💡 What: Added the `help` parameter to the `st.metric` component for "Override Delta" when the value is "N/A" to provide a descriptive tooltip.
🎯 Why: To provide consistent contextual clarity for users. Previously, the metric only showed the explanatory tooltip when a calculated value was present, but dropped it when the system had insufficient data ("N/A"), leading to a confusing UI experience. This explicitly conforms to the `.jules/palette.md` learnings regarding contextual consistency.
📸 Before/After: Visual change verified via code static analysis (grep).
♿ Accessibility: Improves accessibility and clarity by providing immediate, on-hover documentation for a complex financial metric regardless of its current state.

---
*PR created automatically by Jules for task [16661211041782835555](https://jules.google.com/task/16661211041782835555) started by @rozavala*