### PR TITLE
feat: add Execution Funnel — signal-to-P&L diagnostic pipeline

### DIFF
--- a/_commodity_selector.py
+++ b/_commodity_selector.py
@@ -86,6 +86,9 @@ def _reinit_data_dirs(ticker: str):
     from trading_bot.tms import set_data_dir as set_tms_dir
     set_tms_dir(data_dir)
 
+    from trading_bot.execution_funnel import set_data_dir as set_funnel_dir
+    set_funnel_dir(data_dir)
+
 
 def selected_commodity() -> str:
     """Render commodity selector in sidebar and return the active ticker.

--- a/dashboard.py
+++ b/dashboard.py
@@ -589,6 +589,8 @@ if hasattr(st, "page_link"):
                       help="API costs, budget utilization, provider health, latency", width="stretch")
         st.page_link("pages/9_Portfolio.py", label="Portfolio", icon="\U0001f4ca",
                       help="Account-wide risk status, cross-commodity positions, engine health", width="stretch")
+        st.page_link("pages/10_The_Funnel.py", label="The Funnel", icon="\U0001f52c",
+                      help="Where does alpha leak? Signal-to-trade conversion, execution efficiency, $ impact", width="stretch")
 else:
     st.markdown("""
     Use the sidebar to navigate between pages:

--- a/pages/10_The_Funnel.py
+++ b/pages/10_The_Funnel.py
@@ -1,0 +1,488 @@
+"""
+Page 10: The Funnel (Execution Diagnostics)
+
+Purpose: Visualize the signal-to-P&L pipeline, identify where alpha leaks,
+and quantify dollar impact. Bridges the intelligence layer (Scorecard) with
+the financial layer (Trade Analytics).
+
+Data source: data/{TICKER}/execution_funnel.csv
+"""
+
+import streamlit as st
+import pandas as pd
+import numpy as np
+import plotly.express as px
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from dashboard_utils import (
+    load_council_history,
+    get_config,
+    _resolve_data_path_for,
+)
+from _date_filter import date_range_filter
+
+# --- Page Config ---
+st.set_page_config(page_title="The Funnel", page_icon="🔬", layout="wide")
+st.title("🔬 The Funnel — Signal-to-P&L Diagnostic")
+st.caption("Where does alpha leak? Track every signal from council decision through execution to P&L.")
+
+
+# --- Data Loading ---
+@st.cache_data(ttl=60)
+def load_funnel_data(ticker: str) -> pd.DataFrame:
+    """Load execution funnel data for a commodity."""
+    path = _resolve_data_path_for(ticker, 'execution_funnel.csv')
+    if not os.path.exists(path):
+        return pd.DataFrame()
+    try:
+        df = pd.read_csv(path)
+        if 'timestamp' in df.columns:
+            df['timestamp'] = pd.to_datetime(df['timestamp'], utc=True, errors='coerce')
+        return df
+    except Exception:
+        return pd.DataFrame()
+
+
+@st.cache_data(ttl=60)
+def load_order_events(ticker: str) -> pd.DataFrame:
+    """Load order events for slippage analysis."""
+    path = _resolve_data_path_for(ticker, 'order_events.csv')
+    if not os.path.exists(path):
+        return pd.DataFrame()
+    try:
+        df = pd.read_csv(path)
+        if 'timestamp' in df.columns:
+            df['timestamp'] = pd.to_datetime(df['timestamp'], utc=True, errors='coerce')
+        return df
+    except Exception:
+        return pd.DataFrame()
+
+
+# --- Sidebar Filters ---
+from _commodity_selector import render_commodity_selector
+ticker = render_commodity_selector()
+
+funnel_df = load_funnel_data(ticker)
+council_df = load_council_history(ticker)
+
+if funnel_df.empty and council_df.empty:
+    st.warning(f"No funnel or council data for {ticker}. Run the backfill script or wait for real-time data to accumulate.")
+    st.code("python scripts/backfill_execution_funnel.py --all --data-dir /home/rodrigo/real_options/data")
+    st.stop()
+
+# Date filter
+combined_ts = pd.concat([
+    funnel_df['timestamp'] if not funnel_df.empty and 'timestamp' in funnel_df.columns else pd.Series(dtype='datetime64[ns, UTC]'),
+    council_df['timestamp'] if not council_df.empty and 'timestamp' in council_df.columns else pd.Series(dtype='datetime64[ns, UTC]'),
+])
+
+if not combined_ts.empty:
+    start_date, end_date = date_range_filter(combined_ts)
+    if not funnel_df.empty and 'timestamp' in funnel_df.columns:
+        funnel_df = funnel_df[(funnel_df['timestamp'] >= start_date) & (funnel_df['timestamp'] <= end_date)]
+    if not council_df.empty and 'timestamp' in council_df.columns:
+        council_df = council_df[(council_df['timestamp'] >= start_date) & (council_df['timestamp'] <= end_date)]
+
+# Source filter
+if not funnel_df.empty and 'source' in funnel_df.columns:
+    sources = ['ALL'] + sorted(funnel_df['source'].dropna().unique().tolist())
+    selected_source = st.sidebar.selectbox("Data Source", sources, index=0)
+    if selected_source != 'ALL':
+        funnel_df = funnel_df[funnel_df['source'] == selected_source]
+
+# Regime filter
+if not funnel_df.empty and 'regime' in funnel_df.columns:
+    regimes = ['ALL'] + sorted(funnel_df['regime'].dropna().unique().tolist())
+    selected_regime = st.sidebar.selectbox("Regime Filter", regimes, index=0)
+    if selected_regime != 'ALL':
+        funnel_df = funnel_df[funnel_df['regime'] == selected_regime]
+
+
+# ============================================================
+# ROW 1: KPI CARDS
+# ============================================================
+st.subheader("Key Metrics")
+
+# Calculate funnel metrics
+def calc_funnel_kpis(df: pd.DataFrame, ch: pd.DataFrame) -> dict:
+    """Calculate KPI metrics from funnel and council data."""
+    kpis = {}
+
+    if not df.empty and 'stage' in df.columns:
+        decisions = df[df['stage'] == 'COUNCIL_DECISION']
+        actionable = decisions[decisions['outcome'] == 'PASS']
+        filled = df[df['stage'] == 'ORDER_FILLED']
+        cancelled = df[df['stage'] == 'ORDER_CANCELLED']
+        placed = df[df['stage'] == 'ORDER_PLACED']
+
+        # Signal-to-Trade %
+        n_actionable = len(actionable)
+        n_filled = len(filled)
+        kpis['signal_to_trade_pct'] = (n_filled / n_actionable * 100) if n_actionable > 0 else 0
+
+        # Fill Rate (of placed orders)
+        n_placed = len(placed)
+        kpis['fill_rate_pct'] = (n_filled / n_placed * 100) if n_placed > 0 else 0
+
+        # Avg Slippage %
+        filled_with_prices = filled.dropna(subset=['fill_price', 'initial_limit'])
+        if not filled_with_prices.empty:
+            slippage = (filled_with_prices['fill_price'].astype(float) - filled_with_prices['initial_limit'].astype(float)).abs()
+            initial = filled_with_prices['initial_limit'].astype(float).abs()
+            slippage_pct = (slippage / initial.replace(0, np.nan) * 100).dropna()
+            kpis['avg_slippage_pct'] = slippage_pct.mean() if not slippage_pct.empty else 0
+        else:
+            kpis['avg_slippage_pct'] = 0
+
+        # Conviction gate block rate
+        conviction_blocks = df[(df['stage'] == 'CONVICTION_GATE') & (df['outcome'] == 'BLOCK')]
+        conviction_total = df[df['stage'] == 'CONVICTION_GATE']
+        kpis['conviction_block_pct'] = (len(conviction_blocks) / len(conviction_total) * 100) if len(conviction_total) > 0 else 0
+
+        # Walk steps (avg per order)
+        walk_steps = df[df['stage'] == 'PRICE_WALK_STEP']
+        kpis['avg_walk_steps'] = (len(walk_steps) * 3 / n_placed) if n_placed > 0 else 0  # *3 because we log every 3rd
+
+    else:
+        kpis['signal_to_trade_pct'] = 0
+        kpis['fill_rate_pct'] = 0
+        kpis['avg_slippage_pct'] = 0
+        kpis['conviction_block_pct'] = 0
+        kpis['avg_walk_steps'] = 0
+
+    # Signal win rate vs Trade win rate from council_history
+    if not ch.empty and 'pnl_realized' in ch.columns:
+        resolved = ch[ch['pnl_realized'].notna()]
+        kpis['signal_win_rate'] = (resolved['pnl_realized'] > 0).mean() * 100 if not resolved.empty else 0
+        kpis['n_resolved'] = len(resolved)
+    else:
+        kpis['signal_win_rate'] = 0
+        kpis['n_resolved'] = 0
+
+    return kpis
+
+
+kpis = calc_funnel_kpis(funnel_df, council_df)
+
+k1, k2, k3, k4, k5, k6 = st.columns(6)
+k1.metric("Signal-to-Trade", f"{kpis['signal_to_trade_pct']:.0f}%",
+          help="% of actionable council signals that resulted in filled orders")
+k2.metric("Fill Rate", f"{kpis['fill_rate_pct']:.0f}%",
+          help="% of placed orders that filled (vs timed out/cancelled)")
+k3.metric("Avg Slippage", f"{kpis['avg_slippage_pct']:.1f}%",
+          help="Average % difference between initial limit and fill price")
+k4.metric("Conviction Blocks", f"{kpis['conviction_block_pct']:.0f}%",
+          help="% of directional signals blocked by conviction gate")
+k5.metric("Avg Walk Steps", f"{kpis['avg_walk_steps']:.0f}",
+          help="Average adaptive walk steps per placed order (est.)")
+k6.metric("Signal Win Rate", f"{kpis['signal_win_rate']:.0f}%",
+          help=f"Directional accuracy of resolved signals (n={kpis['n_resolved']})")
+
+
+# ============================================================
+# ROW 2: FUNNEL WATERFALL
+# ============================================================
+st.subheader("Funnel Waterfall — Where Do Signals Die?")
+
+if not funnel_df.empty and 'stage' in funnel_df.columns:
+    # Define the funnel stages in order
+    STAGE_ORDER = [
+        'COUNCIL_DECISION', 'CONVICTION_GATE', 'COMPLIANCE_AUDIT',
+        'CONFIDENCE_THRESHOLD', 'THESIS_COHERENCE', 'CAPITAL_CHECK',
+        'ORDER_QUEUED', 'DRAWDOWN_GATE', 'LIQUIDITY_GATE',
+        'ORDER_PLACED', 'ORDER_FILLED',
+    ]
+
+    waterfall_data = []
+    for stage in STAGE_ORDER:
+        stage_df = funnel_df[funnel_df['stage'] == stage]
+        passed = len(stage_df[stage_df['outcome'] == 'PASS'])
+        blocked = len(stage_df[stage_df['outcome'] == 'BLOCK'])
+        total = passed + blocked
+        waterfall_data.append({
+            'Stage': stage.replace('_', ' ').title(),
+            'Passed': passed,
+            'Blocked': blocked,
+            'Total': total,
+        })
+
+    wf_df = pd.DataFrame(waterfall_data)
+    wf_df = wf_df[wf_df['Total'] > 0]  # Only show stages with data
+
+    if not wf_df.empty:
+        fig_waterfall = go.Figure()
+        fig_waterfall.add_trace(go.Bar(
+            x=wf_df['Stage'], y=wf_df['Passed'],
+            name='Passed', marker_color='#2ecc71',
+            text=wf_df['Passed'], textposition='auto',
+        ))
+        fig_waterfall.add_trace(go.Bar(
+            x=wf_df['Stage'], y=wf_df['Blocked'],
+            name='Blocked', marker_color='#e74c3c',
+            text=wf_df['Blocked'], textposition='auto',
+        ))
+        fig_waterfall.update_layout(
+            barmode='stack',
+            xaxis_tickangle=-45,
+            height=400,
+            margin=dict(t=20, b=80),
+            legend=dict(orientation="h", yanchor="bottom", y=1.02),
+        )
+        st.plotly_chart(fig_waterfall, use_container_width=True)
+
+        # Survival rate
+        first_stage = wf_df.iloc[0]['Total'] if len(wf_df) > 0 else 1
+        last_pass = wf_df.iloc[-1]['Passed'] if len(wf_df) > 0 else 0
+        st.caption(f"End-to-end survival: {last_pass}/{first_stage} ({last_pass/max(first_stage,1)*100:.0f}%)")
+    else:
+        st.info("No stage data available for waterfall chart.")
+else:
+    # Fallback: build from council_history
+    st.info("No real-time funnel data yet. Showing summary from council history.")
+    if not council_df.empty:
+        total_decisions = len(council_df)
+        actionable = len(council_df[council_df['master_decision'].isin(['BULLISH', 'BEARISH'])])
+        with_strategy = len(council_df[council_df['strategy_type'].notna() & (council_df['strategy_type'] != 'NONE')])
+        compliant = len(council_df[council_df['compliance_approved'] == True])
+
+        summary_data = {
+            'Stage': ['Council Decisions', 'Actionable (Bull/Bear)', 'Strategy Selected', 'Compliance Approved'],
+            'Count': [total_decisions, actionable, with_strategy, compliant],
+        }
+        st.bar_chart(pd.DataFrame(summary_data).set_index('Stage'))
+
+
+# ============================================================
+# ROW 3: SIGNAL vs OUTCOME MATRIX
+# ============================================================
+st.subheader("Signal vs Outcome — Skill or Luck?")
+
+if not council_df.empty and 'pnl_realized' in council_df.columns and 'weighted_score' in council_df.columns:
+    resolved = council_df[council_df['pnl_realized'].notna()].copy()
+    if not resolved.empty:
+        resolved['process_score'] = resolved['master_confidence'].fillna(0.5) * resolved['weighted_score'].abs().fillna(0)
+        resolved['pnl'] = resolved['pnl_realized'].astype(float)
+
+        # Classify quadrants
+        process_median = resolved['process_score'].median()
+        conditions = [
+            (resolved['process_score'] >= process_median) & (resolved['pnl'] > 0),
+            (resolved['process_score'] < process_median) & (resolved['pnl'] > 0),
+            (resolved['process_score'] >= process_median) & (resolved['pnl'] <= 0),
+            (resolved['process_score'] < process_median) & (resolved['pnl'] <= 0),
+        ]
+        labels = ['Skill', 'Lucky', 'Execution Leak', 'Bad Call']
+        resolved['quadrant'] = np.select(conditions, labels, default='Unknown')
+
+        fig_matrix = px.scatter(
+            resolved,
+            x='process_score',
+            y='pnl',
+            color='quadrant',
+            size=resolved['pnl'].abs().clip(lower=0.1),
+            hover_data=['cycle_id', 'contract', 'strategy_type', 'master_decision'],
+            color_discrete_map={
+                'Skill': '#2ecc71', 'Lucky': '#f39c12',
+                'Execution Leak': '#e74c3c', 'Bad Call': '#95a5a6',
+            },
+            labels={'process_score': 'Process Score (confidence x |weighted_score|)', 'pnl': 'P&L (cents)'},
+        )
+        fig_matrix.add_hline(y=0, line_dash="dash", line_color="gray", opacity=0.5)
+        fig_matrix.add_vline(x=process_median, line_dash="dash", line_color="gray", opacity=0.5)
+        fig_matrix.update_layout(height=450, margin=dict(t=20))
+        st.plotly_chart(fig_matrix, use_container_width=True)
+
+        # Quadrant summary
+        quad_counts = resolved['quadrant'].value_counts()
+        qc1, qc2, qc3, qc4 = st.columns(4)
+        qc1.metric("Skill", quad_counts.get('Skill', 0), help="Good process + positive P&L")
+        qc2.metric("Lucky", quad_counts.get('Lucky', 0), help="Weak process + positive P&L")
+        qc3.metric("Execution Leak", quad_counts.get('Execution Leak', 0), help="Good process + negative P&L")
+        qc4.metric("Bad Call", quad_counts.get('Bad Call', 0), help="Weak process + negative P&L")
+else:
+    st.info("Insufficient council history data for matrix analysis.")
+
+
+# ============================================================
+# ROW 4: EXECUTION EFFICIENCY + POSITION LIFECYCLE
+# ============================================================
+tab_exec, tab_lifecycle = st.tabs(["Execution Efficiency", "Position Lifecycle"])
+
+with tab_exec:
+    if not funnel_df.empty and 'stage' in funnel_df.columns:
+        # Slippage distribution
+        filled = funnel_df[funnel_df['stage'] == 'ORDER_FILLED'].copy()
+        if not filled.empty and 'fill_price' in filled.columns and 'initial_limit' in filled.columns:
+            filled_clean = filled.dropna(subset=['fill_price', 'initial_limit'])
+            if not filled_clean.empty:
+                filled_clean['slippage'] = (filled_clean['fill_price'].astype(float) - filled_clean['initial_limit'].astype(float))
+                filled_clean['slippage_pct'] = (filled_clean['slippage'].abs() / filled_clean['initial_limit'].astype(float).abs().replace(0, np.nan) * 100)
+
+                st.markdown("**Slippage Distribution (fill vs initial limit)**")
+                fig_slip = px.histogram(
+                    filled_clean, x='slippage_pct',
+                    nbins=20, color_discrete_sequence=['#3498db'],
+                    labels={'slippage_pct': 'Slippage %'},
+                )
+                fig_slip.update_layout(height=300, margin=dict(t=20))
+                st.plotly_chart(fig_slip, use_container_width=True)
+
+        # Top unfilled orders
+        cancelled = funnel_df[funnel_df['stage'] == 'ORDER_CANCELLED'].copy()
+        if not cancelled.empty:
+            st.markdown("**Recent Unfilled Orders**")
+            display_cols = ['timestamp', 'contract', 'detail', 'walk_away_price', 'initial_limit']
+            avail_cols = [c for c in display_cols if c in cancelled.columns]
+            st.dataframe(
+                cancelled[avail_cols].tail(10).sort_values('timestamp', ascending=False),
+                hide_index=True, use_container_width=True,
+            )
+    else:
+        st.info("No execution data yet. Funnel events will appear after the next trading cycle.")
+
+with tab_lifecycle:
+    if not funnel_df.empty and 'stage' in funnel_df.columns:
+        # Exit reason distribution
+        closed = funnel_df[funnel_df['stage'] == 'POSITION_CLOSED'].copy()
+        if not closed.empty and 'detail' in closed.columns:
+            # Extract exit reason from detail
+            closed['exit_reason'] = closed['detail'].str.extract(r'exit_reason=([^,]+)', expand=False).fillna('Unknown')
+            reason_counts = closed['exit_reason'].value_counts()
+
+            if not reason_counts.empty:
+                st.markdown("**Exit Reason Distribution**")
+                fig_exit = px.pie(
+                    values=reason_counts.values,
+                    names=reason_counts.index,
+                    color_discrete_sequence=px.colors.qualitative.Set2,
+                )
+                fig_exit.update_layout(height=350, margin=dict(t=20))
+                st.plotly_chart(fig_exit, use_container_width=True)
+        else:
+            st.info("No position close events recorded yet.")
+
+        # Risk triggers
+        risk_events = funnel_df[funnel_df['stage'] == 'RISK_TRIGGER']
+        if not risk_events.empty:
+            st.markdown("**Recent Risk Triggers**")
+            display_cols = ['timestamp', 'contract', 'detail']
+            avail_cols = [c for c in display_cols if c in risk_events.columns]
+            st.dataframe(
+                risk_events[avail_cols].tail(10).sort_values('timestamp', ascending=False),
+                hide_index=True, use_container_width=True,
+            )
+    else:
+        st.info("No lifecycle data yet.")
+
+
+# ============================================================
+# ROW 5: TOP LEAKS TABLE
+# ============================================================
+st.subheader("Top Alpha Leaks — Ranked by Impact")
+
+if not funnel_df.empty and 'stage' in funnel_df.columns:
+    leak_data = []
+
+    # Leak 1: Unfilled orders (opportunity cost)
+    n_cancelled = len(funnel_df[funnel_df['stage'] == 'ORDER_CANCELLED'])
+    n_placed = len(funnel_df[funnel_df['stage'] == 'ORDER_PLACED'])
+    if n_placed > 0:
+        leak_data.append({
+            'Leak Category': 'Unfilled Orders',
+            'Count': n_cancelled,
+            '% of Pipeline': f"{n_cancelled/max(n_placed,1)*100:.0f}%",
+            'Diagnosis': 'Adaptive walk exhausted without fill',
+            'Config Key': 'strategy.adaptive_walk.*',
+        })
+
+    # Leak 2: Conviction gate blocks
+    n_conv_block = len(funnel_df[(funnel_df['stage'] == 'CONVICTION_GATE') & (funnel_df['outcome'] == 'BLOCK')])
+    n_conv_total = len(funnel_df[funnel_df['stage'] == 'CONVICTION_GATE'])
+    if n_conv_total > 0:
+        leak_data.append({
+            'Leak Category': 'Conviction Gate',
+            'Count': n_conv_block,
+            '% of Pipeline': f"{n_conv_block/max(n_conv_total,1)*100:.0f}%",
+            'Diagnosis': 'Weighted score below threshold',
+            'Config Key': 'strategy.min_weighted_score_magnitude',
+        })
+
+    # Leak 3: Confidence threshold blocks
+    n_conf_block = len(funnel_df[(funnel_df['stage'] == 'CONFIDENCE_THRESHOLD') & (funnel_df['outcome'] == 'BLOCK')])
+    if n_conf_block > 0:
+        leak_data.append({
+            'Leak Category': 'Confidence Threshold',
+            'Count': n_conf_block,
+            '% of Pipeline': f"{n_conf_block/len(funnel_df)*100:.0f}%",
+            'Diagnosis': 'Signal confidence below min_confidence_threshold',
+            'Config Key': 'risk_management.min_confidence_threshold',
+        })
+
+    # Leak 4: Compliance blocks
+    n_compl_block = len(funnel_df[(funnel_df['stage'] == 'COMPLIANCE_AUDIT') & (funnel_df['outcome'] == 'BLOCK')])
+    if n_compl_block > 0:
+        leak_data.append({
+            'Leak Category': 'Compliance Veto',
+            'Count': n_compl_block,
+            '% of Pipeline': f"{n_compl_block/len(funnel_df)*100:.0f}%",
+            'Diagnosis': 'Hallucination check or risk limit breach',
+            'Config Key': 'compliance.*',
+        })
+
+    # Leak 5: Liquidity gate blocks
+    n_liq_block = len(funnel_df[(funnel_df['stage'] == 'LIQUIDITY_GATE') & (funnel_df['outcome'] == 'BLOCK')])
+    if n_liq_block > 0:
+        leak_data.append({
+            'Leak Category': 'Liquidity Gate',
+            'Count': n_liq_block,
+            '% of Pipeline': f"{n_liq_block/len(funnel_df)*100:.0f}%",
+            'Diagnosis': 'Bid-ask spread too wide or volume too low',
+            'Config Key': 'risk_management.max_spread_pct',
+        })
+
+    # Leak 6: Drawdown gate blocks
+    n_dd_block = len(funnel_df[(funnel_df['stage'] == 'DRAWDOWN_GATE') & (funnel_df['outcome'] == 'BLOCK')])
+    if n_dd_block > 0:
+        leak_data.append({
+            'Leak Category': 'Drawdown Circuit Breaker',
+            'Count': n_dd_block,
+            '% of Pipeline': f"{n_dd_block/len(funnel_df)*100:.0f}%",
+            'Diagnosis': 'Cumulative drawdown exceeded threshold',
+            'Config Key': 'drawdown_circuit_breaker.*',
+        })
+
+    if leak_data:
+        leak_df = pd.DataFrame(leak_data).sort_values('Count', ascending=False)
+        st.dataframe(leak_df, hide_index=True, use_container_width=True)
+    else:
+        st.success("No significant leaks detected in the current period.")
+else:
+    st.info("Leak analysis requires funnel event data. Will populate after trading cycles run with instrumentation.")
+
+
+# ============================================================
+# RAW DATA EXPLORER
+# ============================================================
+with st.expander("Raw Funnel Data", expanded=False):
+    if not funnel_df.empty:
+        # Stage filter
+        stages = ['ALL'] + sorted(funnel_df['stage'].dropna().unique().tolist())
+        sel_stage = st.selectbox("Filter by Stage", stages)
+        display_df = funnel_df if sel_stage == 'ALL' else funnel_df[funnel_df['stage'] == sel_stage]
+
+        st.dataframe(
+            display_df.sort_values('timestamp', ascending=False).head(200),
+            hide_index=True, use_container_width=True,
+        )
+        st.download_button(
+            "Download Funnel CSV",
+            display_df.to_csv(index=False).encode('utf-8'),
+            f"execution_funnel_{ticker}.csv",
+            "text/csv",
+        )
+    else:
+        st.info("No funnel data available.")

--- a/scripts/backfill_execution_funnel.py
+++ b/scripts/backfill_execution_funnel.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""
+Backfill execution_funnel.csv from existing council_history.csv,
+decision_signals.csv, trade_ledger archives, and order_events.csv.
+
+Produces endpoint events only (COUNCIL_DECISION, STRATEGY_SELECTION,
+COMPLIANCE_AUDIT, ORDER_PLACED, ORDER_FILLED, ORDER_CANCELLED, POSITION_CLOSED).
+Middle stages (CONVICTION_GATE, DRAWDOWN_GATE, etc.) are unrecoverable from
+historical data and will fill in via real-time instrumentation going forward.
+
+Usage:
+    python scripts/backfill_execution_funnel.py [--commodity KC] [--all] [--data-dir /path/to/data]
+"""
+
+import argparse
+import os
+import sys
+import glob
+import pandas as pd
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from trading_bot.execution_funnel import SCHEMA_COLUMNS, FunnelStage
+from trading_bot.exit_reasons import classify_exit_reason
+
+
+def _safe_float(val):
+    """Convert to float or return None."""
+    try:
+        f = float(val)
+        return f if not np.isnan(f) else None
+    except (ValueError, TypeError):
+        return None
+
+
+def backfill_commodity(ticker: str, data_root: str) -> int:
+    """Backfill funnel events for a single commodity. Returns row count."""
+    data_dir = os.path.join(data_root, ticker)
+    output_path = os.path.join(data_dir, 'execution_funnel.csv')
+
+    if not os.path.isdir(data_dir):
+        print(f"  [{ticker}] Data directory not found: {data_dir}. Skipping.")
+        return 0
+
+    if os.path.exists(output_path) and os.path.getsize(output_path) > 0:
+        existing = pd.read_csv(output_path)
+        backfill_count = (existing.get('source', pd.Series()) == 'BACKFILL').sum()
+        if backfill_count > 0:
+            print(f"  [{ticker}] Already has {backfill_count} backfill rows. Skipping.")
+            print(f"  [{ticker}] To re-run, delete {output_path} first.")
+            return 0
+
+    rows = []
+
+    # --- 1. Council History → COUNCIL_DECISION + COMPLIANCE_AUDIT ---
+    ch_path = os.path.join(data_dir, 'council_history.csv')
+    if os.path.exists(ch_path):
+        print(f"  [{ticker}] Reading council_history.csv...")
+        ch = pd.read_csv(ch_path, on_bad_lines='warn')
+        for _, r in ch.iterrows():
+            cycle_id = r.get('cycle_id', f"{ticker}-backfill-{_}")
+            contract = r.get('contract', 'unknown')
+            direction = r.get('master_decision', 'NEUTRAL')
+            confidence = _safe_float(r.get('master_confidence', 0.0))
+            regime = r.get('entry_regime', 'UNKNOWN')
+            ts = r.get('timestamp', '')
+            ws = _safe_float(r.get('weighted_score', 0.0))
+            thesis = r.get('thesis_strength', 'N/A')
+            conv_mult = _safe_float(r.get('conviction_multiplier', 1.0))
+
+            # COUNCIL_DECISION
+            rows.append({
+                'timestamp': ts,
+                'cycle_id': cycle_id,
+                'contract': contract,
+                'stage': FunnelStage.COUNCIL_DECISION.value,
+                'outcome': 'PASS' if direction not in ('NEUTRAL', 'N/A', None, '') else 'INFO',
+                'detail': f"direction={direction}, confidence={confidence}, thesis={thesis}, weighted_score={ws}, conviction_mult={conv_mult}",
+                'price_snapshot': _safe_float(r.get('entry_price')),
+                'regime': regime,
+                'source': 'BACKFILL',
+            })
+
+            # COMPLIANCE_AUDIT
+            compliance_val = r.get('compliance_approved')
+            if pd.notna(compliance_val):
+                approved = str(compliance_val).lower() in ('true', '1', 'yes')
+                compliance_reason = r.get('compliance_reason', 'N/A')
+                rows.append({
+                    'timestamp': ts,
+                    'cycle_id': cycle_id,
+                    'contract': contract,
+                    'stage': FunnelStage.COMPLIANCE_AUDIT.value,
+                    'outcome': 'PASS' if approved else 'BLOCK',
+                    'detail': 'Approved' if approved else str(compliance_reason)[:200],
+                    'price_snapshot': _safe_float(r.get('entry_price')),
+                    'regime': regime,
+                    'source': 'BACKFILL',
+                })
+
+            # STRATEGY_SELECTION (from council_history strategy_type)
+            strategy = r.get('strategy_type', 'NONE')
+            pred_type = r.get('prediction_type', 'DIRECTIONAL')
+            if pd.notna(strategy) and strategy not in ('NONE', '', 'N/A'):
+                rows.append({
+                    'timestamp': ts,
+                    'cycle_id': cycle_id,
+                    'contract': contract,
+                    'stage': FunnelStage.STRATEGY_SELECTION.value,
+                    'outcome': 'PASS',
+                    'detail': f"prediction_type={pred_type}, strategy={strategy}",
+                    'price_snapshot': _safe_float(r.get('entry_price')),
+                    'regime': regime,
+                    'source': 'BACKFILL',
+                })
+
+            # PNL_RECONCILED (from exit data in council_history)
+            pnl = _safe_float(r.get('pnl_realized'))
+            if pnl is not None:
+                rows.append({
+                    'timestamp': r.get('exit_timestamp', ts),
+                    'cycle_id': cycle_id,
+                    'contract': contract,
+                    'stage': FunnelStage.PNL_RECONCILED.value,
+                    'outcome': 'PASS' if pnl > 0 else 'FAIL',
+                    'detail': f"pnl={pnl:.2f}, trend={r.get('actual_trend_direction', 'N/A')}",
+                    'price_snapshot': _safe_float(r.get('exit_price')),
+                    'regime': regime,
+                    'source': 'BACKFILL',
+                })
+
+        print(f"  [{ticker}] Processed {len(ch)} council history rows.")
+
+    # --- 2. Order Events → ORDER_PLACED, ORDER_FILLED, ORDER_CANCELLED ---
+    oe_path = os.path.join(data_dir, 'order_events.csv')
+    if os.path.exists(oe_path):
+        print(f"  [{ticker}] Reading order_events.csv...")
+        oe = pd.read_csv(oe_path, on_bad_lines='warn')
+        for _, r in oe.iterrows():
+            ts = r.get('timestamp', '')
+            status = str(r.get('status', '')).lower()
+            order_id = r.get('orderId', 'unknown')
+            local_sym = r.get('local_symbol', 'unknown')
+            action = r.get('action', '')
+            qty = r.get('quantity', 0)
+            lmt_price = _safe_float(r.get('lmtPrice'))
+            msg = str(r.get('message', ''))[:200]
+
+            if 'submitted' in status or 'presubmitted' in status:
+                rows.append({
+                    'timestamp': ts,
+                    'cycle_id': f"ORDER-{order_id}",
+                    'contract': local_sym,
+                    'stage': FunnelStage.ORDER_PLACED.value,
+                    'outcome': 'PASS',
+                    'detail': f"action={action}, qty={qty}, order_id={order_id}",
+                    'initial_limit': lmt_price,
+                    'source': 'BACKFILL',
+                })
+            elif 'filled' in status:
+                rows.append({
+                    'timestamp': ts,
+                    'cycle_id': f"ORDER-{order_id}",
+                    'contract': local_sym,
+                    'stage': FunnelStage.ORDER_FILLED.value,
+                    'outcome': 'PASS',
+                    'detail': f"action={action}, qty={qty}, order_id={order_id}",
+                    'fill_price': lmt_price,
+                    'source': 'BACKFILL',
+                })
+            elif 'cancelled' in status or 'timedout' in status:
+                rows.append({
+                    'timestamp': ts,
+                    'cycle_id': f"ORDER-{order_id}",
+                    'contract': local_sym,
+                    'stage': FunnelStage.ORDER_CANCELLED.value,
+                    'outcome': 'BLOCK',
+                    'detail': f"action={action}, reason={msg}",
+                    'walk_away_price': lmt_price,
+                    'source': 'BACKFILL',
+                })
+            elif 'updated' in status and 'adaptive' in msg.lower():
+                rows.append({
+                    'timestamp': ts,
+                    'cycle_id': f"ORDER-{order_id}",
+                    'contract': local_sym,
+                    'stage': FunnelStage.PRICE_WALK_STEP.value,
+                    'outcome': 'INFO',
+                    'detail': msg,
+                    'source': 'BACKFILL',
+                })
+
+        print(f"  [{ticker}] Processed {len(oe)} order events.")
+
+    # --- 3. Trade Ledger (latest archive) → ORDER_FILLED / POSITION_CLOSED ---
+    ledger_dir = os.path.join(data_dir, 'archive_ledger')
+    if os.path.isdir(ledger_dir):
+        # Find the latest _v2 or regular ledger
+        v2_files = sorted(glob.glob(os.path.join(ledger_dir, '*_v2.csv')))
+        regular_files = sorted(glob.glob(os.path.join(ledger_dir, '*.csv')))
+        ledger_file = v2_files[-1] if v2_files else (regular_files[-1] if regular_files else None)
+
+        if ledger_file:
+            print(f"  [{ticker}] Reading trade ledger: {os.path.basename(ledger_file)}...")
+            tl = pd.read_csv(ledger_file, on_bad_lines='warn')
+            for _, r in tl.iterrows():
+                ts = r.get('timestamp', '')
+                position_id = r.get('position_id', 'unknown')
+                local_sym = r.get('local_symbol', 'unknown')
+                action = r.get('action', '')
+                qty = r.get('quantity', 0)
+                fill_price = _safe_float(r.get('avg_fill_price'))
+                reason = str(r.get('reason', 'Strategy Execution'))
+
+                # Determine if this is an entry or exit based on reason
+                exit_reason = classify_exit_reason(reason)
+
+                if reason == 'Strategy Execution':
+                    # Entry fill
+                    rows.append({
+                        'timestamp': ts,
+                        'cycle_id': position_id,
+                        'contract': local_sym,
+                        'stage': FunnelStage.ORDER_FILLED.value,
+                        'outcome': 'PASS',
+                        'detail': f"action={action}, qty={qty}, reason={reason}",
+                        'fill_price': fill_price,
+                        'source': 'BACKFILL',
+                    })
+                else:
+                    # Exit / close
+                    rows.append({
+                        'timestamp': ts,
+                        'cycle_id': position_id,
+                        'contract': local_sym,
+                        'stage': FunnelStage.POSITION_CLOSED.value,
+                        'outcome': 'PASS',
+                        'detail': f"action={action}, qty={qty}, exit_reason={exit_reason.value}",
+                        'fill_price': fill_price,
+                        'source': 'BACKFILL',
+                    })
+
+            print(f"  [{ticker}] Processed {len(tl)} trade ledger entries.")
+
+    # --- Write ---
+    if rows:
+        df = pd.DataFrame(rows)
+        # Ensure all schema columns exist
+        for col in SCHEMA_COLUMNS:
+            if col not in df.columns:
+                df[col] = None
+        df = df[SCHEMA_COLUMNS]
+
+        # Sort by timestamp
+        df['_ts_sort'] = pd.to_datetime(df['timestamp'], errors='coerce', utc=True)
+        df = df.sort_values('_ts_sort', na_position='last').drop(columns=['_ts_sort'])
+
+        df.to_csv(output_path, index=False)
+        print(f"  [{ticker}] Wrote {len(df)} backfill events to {output_path}")
+        return len(df)
+    else:
+        print(f"  [{ticker}] No data found to backfill.")
+        return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Backfill execution funnel from existing CSVs")
+    parser.add_argument('--commodity', type=str, help='Single commodity ticker (e.g., KC)')
+    parser.add_argument('--all', action='store_true', help='Backfill all commodities')
+    parser.add_argument('--data-dir', type=str, default=None,
+                        help='Root data directory (default: <project>/data)')
+    args = parser.parse_args()
+
+    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    data_root = args.data_dir or os.path.join(project_root, 'data')
+
+    if args.all:
+        tickers = [d for d in os.listdir(data_root)
+                    if os.path.isdir(os.path.join(data_root, d))
+                    and d not in ('__pycache__', 'tms', 'archive')]
+    elif args.commodity:
+        tickers = [args.commodity]
+    else:
+        tickers = ['KC', 'CC', 'NG']
+
+    print(f"Backfilling execution funnel from: {data_root}")
+    print(f"Commodities: {', '.join(sorted(tickers))}\n")
+
+    total = 0
+    for ticker in sorted(tickers):
+        print(f"--- {ticker} ---")
+        total += backfill_commodity(ticker, data_root)
+        print()
+
+    print(f"Backfill complete: {total} total events across {len(tickers)} commodities.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_execution_funnel.py
+++ b/tests/test_execution_funnel.py
@@ -1,0 +1,198 @@
+"""Tests for execution funnel logger, FunnelStage enum, and ExitReason enum."""
+import os
+import pytest
+import pandas as pd
+
+from trading_bot.execution_funnel import (
+    log_funnel_event, FunnelStage, SCHEMA_COLUMNS, set_data_dir, get_funnel_df
+)
+from trading_bot.exit_reasons import ExitReason, classify_exit_reason
+
+
+class TestFunnelStageEnum:
+    def test_all_stages_are_strings(self):
+        for stage in FunnelStage:
+            assert isinstance(stage.value, str)
+
+    def test_mece_no_duplicates(self):
+        values = [s.value for s in FunnelStage]
+        assert len(values) == len(set(values))
+
+    def test_stage_ordering_completeness(self):
+        """Verify all major pipeline stages are represented."""
+        stage_names = {s.value for s in FunnelStage}
+        required = {
+            'COUNCIL_DECISION', 'CONVICTION_GATE', 'COMPLIANCE_AUDIT',
+            'CONFIDENCE_THRESHOLD', 'ORDER_PLACED', 'ORDER_FILLED',
+            'ORDER_CANCELLED', 'POSITION_OPENED', 'POSITION_CLOSED',
+        }
+        assert required.issubset(stage_names), f"Missing stages: {required - stage_names}"
+
+
+class TestExitReasonEnum:
+    def test_all_reasons_are_strings(self):
+        for reason in ExitReason:
+            assert isinstance(reason.value, str)
+
+    def test_no_duplicate_values(self):
+        values = [r.value for r in ExitReason]
+        assert len(values) == len(set(values))
+
+    def test_options_specific_exits_exist(self):
+        assert ExitReason.EXPIRED_WORTHLESS
+        assert ExitReason.EXPIRED_ITM
+        assert ExitReason.ASSIGNED
+        assert ExitReason.EXERCISED
+
+    def test_emergency_exits_exist(self):
+        assert ExitReason.EMERGENCY_HARD_CLOSE
+        assert ExitReason.EMERGENCY_HARD_CLOSE_RETRY
+        assert ExitReason.CATASTROPHE_FILL
+
+
+class TestClassifyExitReason:
+    def test_exact_matches(self):
+        assert classify_exit_reason("Strategy Execution") == ExitReason.STRATEGY_EXECUTION
+        assert classify_exit_reason("Stale Position Close") == ExitReason.STALE_CLOSE
+        assert classify_exit_reason("Risk Management Closure") == ExitReason.RISK_MANAGEMENT
+
+    def test_stop_loss_dynamic(self):
+        result = classify_exit_reason("Stop-Loss (Hit 55.2% of Max Risk)")
+        assert result == ExitReason.STOP_LOSS
+
+    def test_take_profit_dynamic(self):
+        result = classify_exit_reason("Take-Profit (Captured 82.1% of Max Profit)")
+        assert result == ExitReason.TAKE_PROFIT
+
+    def test_emergency_variants(self):
+        assert classify_exit_reason("EMERGENCY_HARD_CLOSE") == ExitReason.EMERGENCY_HARD_CLOSE
+        assert classify_exit_reason("EMERGENCY_HARD_CLOSE_RETRY") == ExitReason.EMERGENCY_HARD_CLOSE_RETRY
+        assert classify_exit_reason("EMERGENCY_HARD_CLOSE_RETRY_PARTIAL") == ExitReason.EMERGENCY_HARD_CLOSE_RETRY_PARTIAL
+
+    def test_weekly_close_variants(self):
+        assert classify_exit_reason("Friday Weekly Close") == ExitReason.FRIDAY_WEEKLY_CLOSE
+        assert classify_exit_reason("Holiday Tomorrow (Weekly Close)") == ExitReason.HOLIDAY_WEEKLY_CLOSE
+
+    def test_contradict_variants(self):
+        assert classify_exit_reason("CONTRADICT: position already closed") == ExitReason.CONTRADICT_CLOSED
+        assert classify_exit_reason("CONTRADICT: closed on direction reversal") == ExitReason.CONTRADICT_REVERSAL
+
+    def test_reconciliation(self):
+        assert classify_exit_reason("RECONCILIATION_MISSING") == ExitReason.RECONCILIATION_MISSING
+        assert classify_exit_reason("PHANTOM_RECONCILIATION") == ExitReason.PHANTOM_RECONCILIATION
+
+    def test_spread_close(self):
+        assert classify_exit_reason("Spread Close: abc12345") == ExitReason.SPREAD_CLOSE
+
+    def test_empty_and_none(self):
+        assert classify_exit_reason("") == ExitReason.STRATEGY_EXECUTION
+        assert classify_exit_reason(None) == ExitReason.STRATEGY_EXECUTION
+
+    def test_unknown_fallback(self):
+        result = classify_exit_reason("some completely unknown reason xyz")
+        assert result == ExitReason.RISK_MANAGEMENT
+
+
+class TestLogFunnelEvent:
+    def test_creates_csv_with_header(self, tmp_path):
+        set_data_dir(str(tmp_path))
+        result = log_funnel_event(
+            cycle_id="KC-test1",
+            contract="KCK6 (202605)",
+            stage=FunnelStage.COUNCIL_DECISION,
+            outcome="PASS",
+            detail="test event",
+            regime="TRENDING",
+            source="BACKFILL",
+        )
+        assert result is True
+        csv_path = os.path.join(str(tmp_path), 'execution_funnel.csv')
+        assert os.path.exists(csv_path)
+        df = pd.read_csv(csv_path)
+        assert list(df.columns) == SCHEMA_COLUMNS
+        assert len(df) == 1
+        assert df.iloc[0]['stage'] == 'COUNCIL_DECISION'
+
+    def test_appends_without_duplicate_headers(self, tmp_path):
+        set_data_dir(str(tmp_path))
+        log_funnel_event(cycle_id="t1", contract="c1", stage=FunnelStage.COUNCIL_DECISION, source="BACKFILL")
+        log_funnel_event(cycle_id="t2", contract="c2", stage=FunnelStage.ORDER_FILLED, source="BACKFILL")
+        csv_path = os.path.join(str(tmp_path), 'execution_funnel.csv')
+        df = pd.read_csv(csv_path)
+        assert len(df) == 2
+        assert df.iloc[0]['cycle_id'] == 't1'
+        assert df.iloc[1]['cycle_id'] == 't2'
+
+    def test_never_raises(self):
+        # Even with impossible path, should return False not raise
+        set_data_dir("/nonexistent/path/that/cannot/exist")
+        result = log_funnel_event(
+            cycle_id="test", contract="test",
+            stage=FunnelStage.ORDER_PLACED,
+            source="BACKFILL",
+        )
+        assert isinstance(result, bool)
+
+    def test_detail_truncation(self, tmp_path):
+        set_data_dir(str(tmp_path))
+        long_detail = "x" * 1000
+        log_funnel_event(
+            cycle_id="t1", contract="c1",
+            stage=FunnelStage.COUNCIL_DECISION,
+            detail=long_detail,
+            source="BACKFILL",
+        )
+        csv_path = os.path.join(str(tmp_path), 'execution_funnel.csv')
+        df = pd.read_csv(csv_path)
+        assert len(df.iloc[0]['detail']) <= 500
+
+    def test_source_flag(self, tmp_path):
+        set_data_dir(str(tmp_path))
+        log_funnel_event(
+            cycle_id="bf1", contract="c1",
+            stage=FunnelStage.COUNCIL_DECISION, source="BACKFILL",
+        )
+        log_funnel_event(
+            cycle_id="rt1", contract="c2",
+            stage=FunnelStage.ORDER_PLACED, source="BACKFILL",
+        )
+        csv_path = os.path.join(str(tmp_path), 'execution_funnel.csv')
+        df = pd.read_csv(csv_path)
+        assert set(df['source']) == {'BACKFILL'}
+
+    def test_numeric_fields_rounded(self, tmp_path):
+        set_data_dir(str(tmp_path))
+        log_funnel_event(
+            cycle_id="t1", contract="c1",
+            stage=FunnelStage.ORDER_FILLED,
+            price_snapshot=123.456789,
+            bid=1.23456789,
+            ask=1.34567890,
+            fill_price=1.28901234,
+            source="BACKFILL",
+        )
+        csv_path = os.path.join(str(tmp_path), 'execution_funnel.csv')
+        df = pd.read_csv(csv_path)
+        assert df.iloc[0]['price_snapshot'] == 123.46
+        assert df.iloc[0]['bid'] == 1.2346
+        assert df.iloc[0]['fill_price'] == 1.289
+
+
+class TestGetFunnelDf:
+    def test_returns_empty_for_missing_file(self, tmp_path):
+        df = get_funnel_df(ticker="NONEXISTENT")
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 0
+        assert list(df.columns) == SCHEMA_COLUMNS
+
+    def test_loads_existing_data(self, tmp_path):
+        set_data_dir(str(tmp_path))
+        log_funnel_event(
+            cycle_id="t1", contract="c1",
+            stage=FunnelStage.ORDER_PLACED,
+            source="BACKFILL",
+        )
+        set_data_dir(str(tmp_path))
+        df = get_funnel_df()
+        assert len(df) == 1
+        assert df.iloc[0]['stage'] == 'ORDER_PLACED'

--- a/trading_bot/data_dir_context.py
+++ b/trading_bot/data_dir_context.py
@@ -159,6 +159,7 @@ def configure_legacy_modules(data_dir: str):
         ("trading_bot.router_metrics", None, "set_data_dir"),
         ("trading_bot.agents", None, "set_data_dir"),
         ("trading_bot.prompt_trace", None, "set_data_dir"),
+        ("trading_bot.execution_funnel", None, "set_data_dir"),
     ]
 
     os.makedirs(data_dir, exist_ok=True)

--- a/trading_bot/execution_funnel.py
+++ b/trading_bot/execution_funnel.py
@@ -1,0 +1,213 @@
+"""
+Execution Funnel Logger — Structured event log for the signal-to-P&L pipeline.
+
+WHY THIS EXISTS:
+council_history.csv captures the intelligence layer (what the council decided).
+trade_ledger.csv captures the financial layer (what actually traded).
+Nothing captures the middle: conviction gates, compliance, liquidity checks,
+adaptive walking, fills vs cancels. This module bridges that gap with an
+append-only event log enabling funnel analysis to pinpoint where alpha leaks.
+
+SCHEMA (execution_funnel.csv):
+    timestamp       — UTC ISO8601
+    cycle_id        — Links to council_history + decision_signals for drill-down
+    contract        — Contract identifier (e.g., "KCK6 (202605)")
+    stage           — FunnelStage enum value
+    outcome         — PASS / BLOCK / PARTIAL / FAIL / INFO
+    detail          — Context string (e.g., "score=0.34, threshold=0.10")
+    price_snapshot  — Underlying price at event time (nullable)
+    bid             — Combo bid at event time (nullable, ORDER_PLACED+ only)
+    ask             — Combo ask at event time (nullable, ORDER_PLACED+ only)
+    initial_limit   — First limit price set (nullable, ORDER_PLACED only)
+    fill_price      — Actual fill price (nullable, ORDER_FILLED only)
+    walk_away_price — Last limit before cancel (nullable, ORDER_CANCELLED only)
+    regime          — Market regime at decision time
+    source          — REALTIME or BACKFILL
+
+USAGE:
+    from trading_bot.execution_funnel import log_funnel_event, FunnelStage
+
+    log_funnel_event(
+        cycle_id="KC-abc123",
+        contract="KCK6 (202605)",
+        stage=FunnelStage.CONVICTION_GATE,
+        outcome="PASS",
+        detail=f"weighted_score={score:.4f}, threshold={threshold}",
+        price_snapshot=market_ctx.get('price'),
+        regime="TRENDING",
+    )
+"""
+
+import os
+import logging
+import pandas as pd
+from enum import Enum
+from typing import Optional
+from trading_bot.timestamps import format_ts, parse_ts_column
+
+logger = logging.getLogger(__name__)
+
+# --- Module-level path (legacy single-engine fallback) ---
+_BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FUNNEL_FILE_PATH = os.path.join(_BASE_DIR, 'data', 'execution_funnel.csv')
+
+
+def set_data_dir(data_dir: str):
+    """Configure funnel path for a commodity-specific data directory."""
+    global FUNNEL_FILE_PATH
+    FUNNEL_FILE_PATH = os.path.join(data_dir, 'execution_funnel.csv')
+    logger.info(f"ExecutionFunnel data_dir set to: {data_dir}")
+
+
+def _get_funnel_file_path() -> str:
+    """Resolve funnel file path via ContextVar (multi-engine) or module global."""
+    try:
+        from trading_bot.data_dir_context import get_engine_data_dir
+        return os.path.join(get_engine_data_dir(), 'execution_funnel.csv')
+    except LookupError:
+        return FUNNEL_FILE_PATH
+
+
+class FunnelStage(str, Enum):
+    """Every stage in the signal-to-P&L pipeline. Ordered by execution flow."""
+
+    # --- Intelligence Layer ---
+    COUNCIL_DECISION = "COUNCIL_DECISION"
+
+    # --- Decision Gates ---
+    CONVICTION_GATE = "CONVICTION_GATE"
+    COMPLIANCE_AUDIT = "COMPLIANCE_AUDIT"
+    DA_REVIEW = "DA_REVIEW"
+
+    # --- Order Generation ---
+    CONFIDENCE_THRESHOLD = "CONFIDENCE_THRESHOLD"
+    THESIS_COHERENCE = "THESIS_COHERENCE"
+    CAPITAL_CHECK = "CAPITAL_CHECK"
+    STRATEGY_SELECTION = "STRATEGY_SELECTION"
+    ORDER_QUEUED = "ORDER_QUEUED"
+
+    # --- Execution ---
+    DRAWDOWN_GATE = "DRAWDOWN_GATE"
+    LIQUIDITY_GATE = "LIQUIDITY_GATE"
+    ORDER_PLACED = "ORDER_PLACED"
+    PRICE_WALK_STEP = "PRICE_WALK_STEP"
+    ORDER_FILLED = "ORDER_FILLED"
+    ORDER_PARTIAL_FILL = "ORDER_PARTIAL_FILL"
+    ORDER_CANCELLED = "ORDER_CANCELLED"
+
+    # --- Position Management ---
+    POSITION_OPENED = "POSITION_OPENED"
+    RISK_TRIGGER = "RISK_TRIGGER"
+    POSITION_CLOSED = "POSITION_CLOSED"
+
+    # --- Reconciliation ---
+    PNL_RECONCILED = "PNL_RECONCILED"
+    TMS_ORPHAN_DETECTED = "TMS_ORPHAN_DETECTED"
+
+
+# Canonical column order — must match CSV header
+SCHEMA_COLUMNS = [
+    'timestamp', 'cycle_id', 'contract', 'stage', 'outcome', 'detail',
+    'price_snapshot', 'bid', 'ask', 'initial_limit', 'fill_price',
+    'walk_away_price', 'regime', 'source',
+]
+
+
+def log_funnel_event(
+    cycle_id: str,
+    contract: str,
+    stage: FunnelStage,
+    outcome: str = "INFO",
+    detail: str = "",
+    price_snapshot: Optional[float] = None,
+    bid: Optional[float] = None,
+    ask: Optional[float] = None,
+    initial_limit: Optional[float] = None,
+    fill_price: Optional[float] = None,
+    walk_away_price: Optional[float] = None,
+    regime: str = "UNKNOWN",
+    source: str = "REALTIME",
+) -> bool:
+    """
+    Append one event row to execution_funnel.csv.
+
+    Returns True on success, False on failure (never raises — non-critical path).
+    """
+    try:
+        # Guard: only log events inside a live orchestrator session (skip in tests/dashboard)
+        if source == "REALTIME":
+            try:
+                from trading_bot.data_dir_context import get_engine_runtime
+                if get_engine_runtime() is None:
+                    return True
+            except Exception:
+                pass
+
+        file_path = _get_funnel_file_path()
+        os.makedirs(os.path.dirname(file_path) or '.', exist_ok=True)
+
+        new_row = pd.DataFrame({
+            'timestamp': [format_ts()],
+            'cycle_id': [cycle_id],
+            'contract': [contract],
+            'stage': [stage.value if isinstance(stage, FunnelStage) else str(stage)],
+            'outcome': [outcome],
+            'detail': [str(detail)[:500]],
+            'price_snapshot': [round(float(price_snapshot), 2) if price_snapshot is not None else None],
+            'bid': [round(float(bid), 4) if bid is not None else None],
+            'ask': [round(float(ask), 4) if ask is not None else None],
+            'initial_limit': [round(float(initial_limit), 4) if initial_limit is not None else None],
+            'fill_price': [round(float(fill_price), 4) if fill_price is not None else None],
+            'walk_away_price': [round(float(walk_away_price), 4) if walk_away_price is not None else None],
+            'regime': [regime],
+            'source': [source],
+        })
+
+        if not os.path.exists(file_path) or os.path.getsize(file_path) == 0:
+            new_row.to_csv(file_path, index=False)
+        else:
+            try:
+                existing_header = pd.read_csv(file_path, nrows=0)
+                if list(existing_header.columns) != SCHEMA_COLUMNS:
+                    logger.info("Schema mismatch in execution_funnel.csv — migrating in-place.")
+                    full_df = pd.read_csv(file_path)
+                    for col in SCHEMA_COLUMNS:
+                        if col not in full_df.columns:
+                            full_df[col] = None
+                    full_df = full_df[SCHEMA_COLUMNS]
+                    combined = pd.concat([full_df, new_row], ignore_index=True)
+                    temp_path = file_path + ".tmp"
+                    combined.to_csv(temp_path, index=False)
+                    os.replace(temp_path, file_path)
+                else:
+                    new_row.to_csv(file_path, mode='a', header=False, index=False)
+            except pd.errors.EmptyDataError:
+                new_row.to_csv(file_path, index=False)
+
+        return True
+
+    except Exception as e:
+        logger.warning(f"Failed to log funnel event (non-fatal): {e}")
+        return False
+
+
+def get_funnel_df(ticker: str = None) -> pd.DataFrame:
+    """Load execution funnel data for dashboard consumption."""
+    try:
+        if ticker:
+            base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            path = os.path.join(base, 'data', ticker, 'execution_funnel.csv')
+        else:
+            path = _get_funnel_file_path()
+
+        if not os.path.exists(path):
+            return pd.DataFrame(columns=SCHEMA_COLUMNS)
+
+        df = pd.read_csv(path)
+        if 'timestamp' in df.columns:
+            df['timestamp'] = parse_ts_column(df['timestamp'])
+        return df
+
+    except Exception as e:
+        logger.warning(f"Failed to load funnel data: {e}")
+        return pd.DataFrame(columns=SCHEMA_COLUMNS)

--- a/trading_bot/exit_reasons.py
+++ b/trading_bot/exit_reasons.py
@@ -1,0 +1,145 @@
+"""
+Canonical exit/close reasons for position lifecycle events.
+
+Every position close event MUST use one of these values. No free-text exit
+reasons allowed in trade_ledger.csv, TMS metadata, or funnel events.
+
+Usage:
+    from trading_bot.exit_reasons import ExitReason
+    reason = ExitReason.STOP_LOSS
+    log_funnel_event(..., detail=reason.value)
+"""
+
+from enum import Enum
+
+
+class ExitReason(str, Enum):
+    """Why a position was closed. Exhaustive — add new values here, not inline."""
+
+    # === Entry (not an exit, but tracked for ledger symmetry) ===
+    STRATEGY_EXECUTION = "Strategy Execution"
+
+    # === Active risk management ===
+    STOP_LOSS = "STOP_LOSS"
+    TAKE_PROFIT = "TAKE_PROFIT"
+    RISK_MANAGEMENT = "Risk Management Closure"
+    POSITION_MISALIGNED = "Position Misaligned"
+
+    # === Time-based ===
+    STALE_CLOSE = "Stale Position Close"
+    FRIDAY_WEEKLY_CLOSE = "Friday Weekly Close"
+    HOLIDAY_WEEKLY_CLOSE = "Holiday Tomorrow (Weekly Close)"
+    POST_CLOSE_SWEEP = "POST_CLOSE_SWEEP"
+    DTE_FORCE_CLOSE = "DTE_FORCE_CLOSE"
+
+    # === Thesis lifecycle ===
+    CONTRADICT_CLOSED = "CONTRADICT: position already closed"
+    CONTRADICT_REVERSAL = "CONTRADICT: closed on direction reversal"
+    MANUAL = "MANUAL"
+
+    # === Options-specific terminal states ===
+    EXPIRED_WORTHLESS = "EXPIRED_WORTHLESS"
+    EXPIRED_ITM = "EXPIRED_ITM"
+    ASSIGNED = "ASSIGNED"
+    EXERCISED = "EXERCISED"
+
+    # === Emergency ===
+    EMERGENCY_HARD_CLOSE = "EMERGENCY_HARD_CLOSE"
+    EMERGENCY_HARD_CLOSE_RETRY = "EMERGENCY_HARD_CLOSE_RETRY"
+    EMERGENCY_HARD_CLOSE_RETRY_PARTIAL = "EMERGENCY_HARD_CLOSE_RETRY_PARTIAL"
+    CATASTROPHE_FILL = "CATASTROPHE_FILL (auto-detected)"
+
+    # === Spread close (normal exit flow) ===
+    SPREAD_CLOSE = "SPREAD_CLOSE"
+    SPREAD_CLOSE_NO_MKT_DATA = "SPREAD_CLOSE_NO_MKT_DATA"
+    SPREAD_CLOSE_MARKET_FALLBACK = "SPREAD_CLOSE_MARKET_FALLBACK"
+
+    # === Reconciliation / maintenance ===
+    RECONCILIATION_MISSING = "RECONCILIATION_MISSING"
+    PHANTOM_RECONCILIATION = "PHANTOM_RECONCILIATION"
+    ORPHAN_CLEANUP = "ORPHAN_CLEANUP"
+
+    # === Thesis invalidation (TMS, not trade ledger) ===
+    REGIME_BREACH = "REGIME BREACH"
+    PRICE_BREACH = "PRICE BREACH"
+    NARRATIVE_INVALIDATION = "NARRATIVE INVALIDATION"
+
+    # === Future (not instrumented yet) ===
+    ROLLED = "ROLLED"
+
+
+def classify_exit_reason(reason_text: str) -> ExitReason:
+    """
+    Best-effort classification of a free-text reason string into an ExitReason.
+
+    Used by the backfill script to map historical reason strings to enum values.
+    Returns the closest match, or RISK_MANAGEMENT as fallback.
+    """
+    if not reason_text:
+        return ExitReason.STRATEGY_EXECUTION
+
+    text = str(reason_text)
+
+    # Exact matches first
+    for member in ExitReason:
+        if text == member.value:
+            return member
+
+    # Prefix / substring matches
+    lower = text.lower()
+    if 'stop-loss' in lower or 'stop_loss' in lower:
+        return ExitReason.STOP_LOSS
+    if 'take-profit' in lower or 'take_profit' in lower:
+        return ExitReason.TAKE_PROFIT
+    if 'stale position close' in lower:
+        return ExitReason.STALE_CLOSE
+    if lower.startswith('stale position'):
+        return ExitReason.STALE_CLOSE
+    if 'friday weekly' in lower:
+        return ExitReason.FRIDAY_WEEKLY_CLOSE
+    if 'holiday tomorrow' in lower:
+        return ExitReason.HOLIDAY_WEEKLY_CLOSE
+    if 'post-close sweep' in lower:
+        return ExitReason.POST_CLOSE_SWEEP
+    if 'contradict' in lower and 'reversal' in lower:
+        return ExitReason.CONTRADICT_REVERSAL
+    if 'contradict' in lower and 'closed' in lower:
+        return ExitReason.CONTRADICT_CLOSED
+    if 'contradict' in lower:
+        return ExitReason.CONTRADICT_REVERSAL
+    if 'emergency_hard_close_retry_partial' in lower:
+        return ExitReason.EMERGENCY_HARD_CLOSE_RETRY_PARTIAL
+    if 'emergency_hard_close_retry' in lower:
+        return ExitReason.EMERGENCY_HARD_CLOSE_RETRY
+    if 'emergency_hard_close' in lower:
+        return ExitReason.EMERGENCY_HARD_CLOSE
+    if 'catastrophe' in lower:
+        return ExitReason.CATASTROPHE_FILL
+    if 'dte force close' in lower or 'dte_force_close' in lower:
+        return ExitReason.DTE_FORCE_CLOSE
+    if 'spread close' in lower and 'no mkt' in lower:
+        return ExitReason.SPREAD_CLOSE_NO_MKT_DATA
+    if 'spread close' in lower and 'market fallback' in lower:
+        return ExitReason.SPREAD_CLOSE_MARKET_FALLBACK
+    if 'spread close' in lower:
+        return ExitReason.SPREAD_CLOSE
+    if 'reconciliation_missing' in lower:
+        return ExitReason.RECONCILIATION_MISSING
+    if 'phantom' in lower:
+        return ExitReason.PHANTOM_RECONCILIATION
+    if 'orphan' in lower:
+        return ExitReason.ORPHAN_CLEANUP
+    if 'position misaligned' in lower:
+        return ExitReason.POSITION_MISALIGNED
+    if 'regime breach' in lower:
+        return ExitReason.REGIME_BREACH
+    if 'price breach' in lower:
+        return ExitReason.PRICE_BREACH
+    if 'narrative' in lower:
+        return ExitReason.NARRATIVE_INVALIDATION
+    if lower == 'strategy execution' or lower == 'daily strategy fill':
+        return ExitReason.STRATEGY_EXECUTION
+    if 'risk management' in lower:
+        return ExitReason.RISK_MANAGEMENT
+
+    return ExitReason.RISK_MANAGEMENT

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -37,6 +37,7 @@ from trading_bot.connection_pool import IBConnectionPool
 from trading_bot.position_sizer import DynamicPositionSizer
 from trading_bot.drawdown_circuit_breaker import DrawdownGuard
 from trading_bot.order_queue import OrderQueueManager
+from trading_bot.execution_funnel import log_funnel_event, FunnelStage
 
 # --- Module-level storage for orders ---
 # Structure: [(contract, order, decision_data), ...]
@@ -1025,6 +1026,15 @@ async def generate_and_queue_orders(config: dict, connection_purpose: str = "orc
                 # === F.4.1: Confidence gate (before NEUTRAL skip so low-confidence gets logged) ===
                 sig_confidence = signal.get('confidence', 0.0)
                 if sig_confidence < min_confidence:
+                    log_funnel_event(
+                        cycle_id=signal.get('_cycle_id', 'unknown'),
+                        contract=signal.get('contract_month', 'unknown'),
+                        stage=FunnelStage.CONFIDENCE_THRESHOLD,
+                        outcome="BLOCK",
+                        detail=f"confidence={sig_confidence:.2f}, threshold={min_confidence:.2f}, direction={signal.get('direction', 'N/A')}",
+                        price_snapshot=signal.get('price'),
+                        regime=signal.get('regime', 'UNKNOWN'),
+                    )
                     logger.info(
                         f"BLOCKED BY CONFIDENCE: {signal.get('contract_month', 'N/A')} — "
                         f"confidence {sig_confidence:.2f} < threshold {min_confidence:.2f}. "
@@ -1055,6 +1065,15 @@ async def generate_and_queue_orders(config: dict, connection_purpose: str = "orc
                     signal, config, approved_in_this_cycle)
 
                 if coherence_action == "BLOCK_INTRA_CYCLE":
+                    log_funnel_event(
+                        cycle_id=signal.get('_cycle_id', 'unknown'),
+                        contract=signal.get('contract_month', 'unknown'),
+                        stage=FunnelStage.THESIS_COHERENCE,
+                        outcome="BLOCK",
+                        detail=f"action=BLOCK_INTRA_CYCLE, direction={signal.get('direction')}",
+                        price_snapshot=signal.get('price'),
+                        regime=signal.get('regime', 'UNKNOWN'),
+                    )
                     logger.info(
                         f"BLOCKED (intra-cycle duplicate): {signal.get('contract_month')} "
                         f"{signal.get('direction')} — already approved in this batch. Skipping."
@@ -1062,6 +1081,15 @@ async def generate_and_queue_orders(config: dict, connection_purpose: str = "orc
                     continue
 
                 if coherence_action == "CONTRADICT":
+                    log_funnel_event(
+                        cycle_id=signal.get('_cycle_id', 'unknown'),
+                        contract=signal.get('contract_month', 'unknown'),
+                        stage=FunnelStage.THESIS_COHERENCE,
+                        outcome="INFO",
+                        detail=f"action=CONTRADICT, direction={signal.get('direction')}",
+                        price_snapshot=signal.get('price'),
+                        regime=signal.get('regime', 'UNKNOWN'),
+                    )
                     # IMMEDIATE CLOSE: Mark for closure before new orders are placed.
                     # The pending_close flag in TMS is the durable record of intent.
                     # place_queued_orders() will query TMS and close these positions
@@ -1218,6 +1246,15 @@ async def generate_and_queue_orders(config: dict, connection_purpose: str = "orc
 
                             # Issue #4: Early abort if capital exhausted
                             if committed_capital > account_value:
+                                log_funnel_event(
+                                    cycle_id=signal.get('_cycle_id', 'unknown'),
+                                    contract=signal.get('contract_month', 'unknown'),
+                                    stage=FunnelStage.CAPITAL_CHECK,
+                                    outcome="BLOCK",
+                                    detail=f"committed={committed_capital:,.2f}, account={account_value:,.2f}, this_order={estimated_risk:,.2f}",
+                                    price_snapshot=signal.get('price'),
+                                    regime=signal.get('regime', 'UNKNOWN'),
+                                )
                                 logger.warning(f"Capital exhausted (${committed_capital:,.2f} committed vs ${account_value:,.2f} available). Stopping order generation.")
                                 break
 
@@ -1231,6 +1268,16 @@ async def generate_and_queue_orders(config: dict, connection_purpose: str = "orc
                             signal['strategy_def'] = strategy_def
                             await ORDER_QUEUE.add((contract, order, signal))
                             approved_in_this_cycle.append(signal)
+                            _strategy_name = strategy_def.get('strategy_name', 'unknown') if isinstance(strategy_def, dict) else 'unknown'
+                            log_funnel_event(
+                                cycle_id=signal.get('_cycle_id', 'unknown'),
+                                contract=signal.get('contract_month', 'unknown'),
+                                stage=FunnelStage.ORDER_QUEUED,
+                                outcome="PASS",
+                                detail=f"strategy={_strategy_name}, qty={strategy_def.get('quantity', 0) if isinstance(strategy_def, dict) else 0}, risk=${estimated_risk:,.2f}",
+                                price_snapshot=signal.get('price'),
+                                regime=signal.get('regime', 'UNKNOWN'),
+                            )
                             logger.info(f"Successfully queued order for {future.localSymbol}.")
         except Exception as e:
             logger.error(f"Error in order generation block: {e}")
@@ -1408,6 +1455,16 @@ async def _handle_and_log_fill(ib: IB, trade: Trade, fill: Fill, combo_id: int, 
                         pass
         if _ledger_logged:
             logger.info(f"Successfully logged fill for {detailed_contract.localSymbol} (Order ID: {trade.order.orderId}, Position ID: {position_uuid})")
+
+            # --- Funnel: POSITION_OPENED ---
+            log_funnel_event(
+                cycle_id=decision_data.get('_cycle_id', 'unknown') if isinstance(decision_data, dict) else 'unknown',
+                contract=detailed_contract.localSymbol,
+                stage=FunnelStage.POSITION_OPENED,
+                outcome="PASS",
+                detail=f"position_id={position_uuid}, order_id={trade.order.orderId}",
+                fill_price=fill.execution.avgPrice if fill.execution else None,
+            )
 
         # --- NEW: Record Trade Thesis to TMS (DEDUPLICATED) ---
         if decision_data and position_uuid:
@@ -2011,14 +2068,38 @@ async def place_queued_orders(config: dict, orders_list: list = None, connection
                     # Maybe check once before the loop?
                     # Yes, but let's check strict status here.
                     if not drawdown_guard.is_entry_allowed():
+                        _dd_cycle_id = decision_data.get('_cycle_id', 'unknown') if isinstance(decision_data, dict) else 'unknown'
+                        log_funnel_event(
+                            cycle_id=_dd_cycle_id,
+                            contract=display_name,
+                            stage=FunnelStage.DRAWDOWN_GATE,
+                            outcome="BLOCK",
+                            detail="Circuit breaker active",
+                        )
                         logger.warning(f"DRAWDOWN GATE BLOCKED {display_name}: Circuit Breaker Active")
                         continue
 
                 # 0b. Liquidity Gate (Fail Closed)
                 liq_ok, liq_msg = await check_liquidity_conditions(ib, contract, order.totalQuantity)
+                _liq_cycle_id = decision_data.get('_cycle_id', 'unknown') if isinstance(decision_data, dict) else 'unknown'
                 if not liq_ok:
+                    log_funnel_event(
+                        cycle_id=_liq_cycle_id,
+                        contract=display_name,
+                        stage=FunnelStage.LIQUIDITY_GATE,
+                        outcome="BLOCK",
+                        detail=liq_msg,
+                    )
                     logger.warning(f"LIQUIDITY GATE BLOCKED {contract.localSymbol}: {liq_msg}. Skipping order.")
                     continue
+                else:
+                    log_funnel_event(
+                        cycle_id=_liq_cycle_id,
+                        contract=display_name,
+                        stage=FunnelStage.LIQUIDITY_GATE,
+                        outcome="PASS",
+                        detail=liq_msg,
+                    )
 
                 # 1. Fetch Market Context (Spread & Trend)
 
@@ -2365,7 +2446,23 @@ async def place_queued_orders(config: dict, orders_list: list = None, connection
                 'max_modification_errors': 3,
                 # Catastrophe stop trade (if any) — must be cancelled if spread times out
                 'catastrophe_stop_trade': _catastrophe_stop_trade,
+                # Funnel: initial limit for slippage tracking
+                'initial_limit': order.lmtPrice if order.orderType == "LMT" else None,
+                '_walk_log_counter': 0,
             }
+
+            # --- Funnel: ORDER_PLACED ---
+            _op_cycle_id = decision_data.get('_cycle_id', 'unknown') if isinstance(decision_data, dict) else 'unknown'
+            log_funnel_event(
+                cycle_id=_op_cycle_id,
+                contract=display_name,
+                stage=FunnelStage.ORDER_PLACED,
+                outcome="PASS",
+                detail=f"action={order.action}, qty={int(order.totalQuantity)}, type={order.orderType}",
+                initial_limit=order.lmtPrice if order.orderType == "LMT" else None,
+                bid=ticker.bid if not util.isNan(ticker.bid) else None,
+                ask=ticker.ask if not util.isNan(ticker.ask) else None,
+            )
 
             # --- 5. Build Notification String (ENHANCED FOR ALL DATA) ---
             price_info_notify = f"LMT: {order.lmtPrice:.{_price_decimals}f}" if order.orderType == "LMT" else "MKT"
@@ -2495,6 +2592,19 @@ async def place_queued_orders(config: dict, orders_list: list = None, connection
                                 details['last_known_good_price'] = new_price  # Track for rollback
                                 details['modification_error_count'] = 0  # Reset on attempt
                                 log_order_event(trade, "Updated", f"Adaptive Walk: Price updated to {new_price}")
+
+                                # Funnel: PRICE_WALK_STEP (every 3rd step to limit CSV bloat)
+                                details['_walk_log_counter'] = details.get('_walk_log_counter', 0) + 1
+                                if details['_walk_log_counter'] % 3 == 0:
+                                    _wk_cycle_id = details.get('decision_data', {}).get('_cycle_id', 'unknown') if isinstance(details.get('decision_data'), dict) else 'unknown'
+                                    log_funnel_event(
+                                        cycle_id=_wk_cycle_id,
+                                        contract=stored_display_name,
+                                        stage=FunnelStage.PRICE_WALK_STEP,
+                                        outcome="INFO",
+                                        detail=f"step={details['_walk_log_counter']}, old={current_limit}, new={new_price}, cap={ceiling}",
+                                        initial_limit=details.get('initial_limit'),
+                                    )
                             else:
                                 # Price at or very near cap/floor - log once then stop checking
                                 if not details.get('cap_reached_logged', False):
@@ -2593,6 +2703,18 @@ async def place_queued_orders(config: dict, orders_list: list = None, connection
                     f"    Filled @ {avg_fill_price:.2f} (qty {int(trade.order.totalQuantity)})"
                 )
                 filled_orders.append(fill_line)
+
+                # --- Funnel: ORDER_FILLED ---
+                _fill_cycle_id = dd.get('_cycle_id', 'unknown')
+                log_funnel_event(
+                    cycle_id=_fill_cycle_id,
+                    contract=stored_display_name,
+                    stage=FunnelStage.ORDER_FILLED,
+                    outcome="PASS",
+                    detail=f"action={trade.order.action}, qty={int(trade.orderStatus.filled)}, direction={fill_direction}",
+                    fill_price=avg_fill_price,
+                    initial_limit=details.get('initial_limit'),
+                )
 
                 # Cancel companion catastrophe stop — spread filled, stop is no longer needed
                 cat_stop = details.get('catastrophe_stop_trade')
@@ -2694,6 +2816,19 @@ async def place_queued_orders(config: dict, orders_list: list = None, connection
                     f"    {price_info_notify} — Unfilled, cancelled"
                 )
                 cancelled_orders.append(cancel_line)
+
+                # --- Funnel: ORDER_CANCELLED ---
+                _cancel_cycle_id = dd.get('_cycle_id', 'unknown')
+                log_funnel_event(
+                    cycle_id=_cancel_cycle_id,
+                    contract=stored_display_name,
+                    stage=FunnelStage.ORDER_CANCELLED,
+                    outcome="BLOCK",
+                    detail=f"direction={cancel_direction}, reason=monitoring_timeout",
+                    walk_away_price=trade.order.lmtPrice,
+                    initial_limit=details.get('initial_limit'),
+                )
+
                 await asyncio.sleep(0.2)
 
         # Build and send the final summary notification

--- a/trading_bot/risk_management.py
+++ b/trading_bot/risk_management.py
@@ -24,6 +24,7 @@ from trading_bot.order_manager import get_trade_ledger_df
 from trading_bot.ib_interface import place_order, get_active_futures
 from notifications import send_pushover_notification
 from trading_bot.tms import TransactiveMemory
+from trading_bot.execution_funnel import log_funnel_event, FunnelStage
 
 
 async def check_iron_condor_theses(ib: IB, config: dict):
@@ -484,7 +485,24 @@ async def _check_risk_once(ib: IB, config: dict, closed_ids: set, stop_loss_pct:
         reason = _determine_risk_action(metrics, config, position_open_dates, grace_period_seconds, combo_legs)
 
         if reason:
+            # --- Funnel: RISK_TRIGGER ---
+            _risk_contract = combo_legs[0].contract.localSymbol if combo_legs else "unknown"
+            log_funnel_event(
+                cycle_id="RISK",
+                contract=_risk_contract,
+                stage=FunnelStage.RISK_TRIGGER,
+                outcome="INFO",
+                detail=f"reason={reason}, pnl={metrics['pnl']:.2f}, risk_pct={metrics['risk_pct']:.2%}, capture_pct={metrics['capture_pct']:.2%}",
+            )
             await _execute_risk_closure(ib, config, combo_legs, reason, metrics['pnl'], closed_ids, account)
+            # --- Funnel: POSITION_CLOSED ---
+            log_funnel_event(
+                cycle_id="RISK",
+                contract=_risk_contract,
+                stage=FunnelStage.POSITION_CLOSED,
+                outcome="PASS",
+                detail=f"exit_reason={reason}, pnl={metrics['pnl']:.2f}",
+            )
 
 
 # --- Order Fill Monitoring ---

--- a/trading_bot/signal_generator.py
+++ b/trading_bot/signal_generator.py
@@ -30,6 +30,7 @@ from trading_bot.strategy_router import (
     detect_imminent_catalyst,
 )
 from trading_bot.prompt_trace import PromptTraceCollector, PromptTraceRecord, hash_persona
+from trading_bot.execution_funnel import log_funnel_event, FunnelStage
 
 logger = logging.getLogger(__name__)
 
@@ -568,6 +569,22 @@ async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_ty
                     f"multiplier={conviction_multiplier}, adj_confidence={decision['confidence']}"
                 )
 
+                # --- Funnel: COUNCIL_DECISION ---
+                log_funnel_event(
+                    cycle_id=cycle_id,
+                    contract=contract_name,
+                    stage=FunnelStage.COUNCIL_DECISION,
+                    outcome="PASS" if master_dir != "NEUTRAL" else "INFO",
+                    detail=(
+                        f"direction={master_dir}, confidence={decision['confidence']:.2f}, "
+                        f"conviction_mult={conviction_multiplier}, vote={vote_dir}, "
+                        f"thesis={decision.get('thesis_strength', 'N/A')}, "
+                        f"weighted_score={weighted_result.get('weighted_score', 0):.4f}"
+                    ),
+                    price_snapshot=market_ctx.get('price'),
+                    regime=regime_for_voting or 'UNKNOWN',
+                )
+
                 # === Devil's Advocate Check (Emergency Only — v7.0) ===
                 # DA is skipped for scheduled cycles to prevent excessive vetoing.
                 # Scheduled cycles already have: 7 agents + debate + compliance.
@@ -591,6 +608,17 @@ async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_ty
                         decision['reasoning'] += f" [DA VETO: {da_review.get('risks', ['Unknown'])[0]}]"
                     else:
                         logger.info("DA CHECK PASSED for emergency cycle.")
+
+                    # --- Funnel: DA_REVIEW ---
+                    log_funnel_event(
+                        cycle_id=cycle_id,
+                        contract=contract_name,
+                        stage=FunnelStage.DA_REVIEW,
+                        outcome="BLOCK" if not da_review.get('proceed', True) else "PASS",
+                        detail=da_review.get('recommendation', '')[:200],
+                        price_snapshot=market_ctx.get('price'),
+                        regime=regime_for_voting or 'UNKNOWN',
+                    )
 
                     # --- R3: Propagate Bypass Flag ---
                     if da_review.get('da_bypassed'):
@@ -656,6 +684,17 @@ async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_ty
                             "Compliance Veto Triggered",
                             f"Trade for {contract_name} blocked.\nReason: {compliance_reason}"
                         )
+
+                    # --- Funnel: COMPLIANCE_AUDIT ---
+                    log_funnel_event(
+                        cycle_id=cycle_id,
+                        contract=contract_name,
+                        stage=FunnelStage.COMPLIANCE_AUDIT,
+                        outcome="BLOCK" if not audit.get('approved', True) else "PASS",
+                        detail=compliance_reason if not audit.get('approved', True) else "Approved",
+                        price_snapshot=market_ctx.get('price'),
+                        regime=regime_for_voting or 'UNKNOWN',
+                    )
 
                 # --- E.2: PRICE SANITY CHECK (The "Fat Finger" Guardrail) ---
                 # Robust extraction of price
@@ -945,6 +984,16 @@ async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_ty
         _min_score = config.get('strategy', {}).get('min_weighted_score_magnitude', 0.20)
         _ws = weighted_result.get('weighted_score', 0.0)
         if final_direction in ('BULLISH', 'BEARISH') and abs(_ws) < _min_score:
+            # --- Funnel: CONVICTION_GATE (BLOCK) ---
+            log_funnel_event(
+                cycle_id=cycle_id,
+                contract=contract_name,
+                stage=FunnelStage.CONVICTION_GATE,
+                outcome="BLOCK",
+                detail=f"weighted_score={abs(_ws):.4f}, threshold={_min_score}, direction={final_direction}",
+                price_snapshot=market_ctx.get('price'),
+                regime=regime_for_voting or 'UNKNOWN',
+            )
             logger.warning(
                 f"CONVICTION GATE: Suppressing {final_direction} signal for {contract_name}. "
                 f"|weighted_score|={abs(_ws):.4f} < threshold={_min_score}. "
@@ -953,6 +1002,17 @@ async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_ty
             final_direction = 'NEUTRAL'
             final_data["action"] = 'NEUTRAL'
             final_data["reason"] += f" [CONVICTION GATE: |score|={abs(_ws):.4f} < {_min_score}]"
+        elif final_direction in ('BULLISH', 'BEARISH'):
+            # --- Funnel: CONVICTION_GATE (PASS) ---
+            log_funnel_event(
+                cycle_id=cycle_id,
+                contract=contract_name,
+                stage=FunnelStage.CONVICTION_GATE,
+                outcome="PASS",
+                detail=f"weighted_score={abs(_ws):.4f}, threshold={_min_score}, direction={final_direction}",
+                price_snapshot=market_ctx.get('price'),
+                regime=regime_for_voting or 'UNKNOWN',
+            )
 
         # v7.0 SAFETY: Default to BEARISH (expensive) when vol data is missing.
         # Rationale: On a $50K account, assume worst-case (expensive options)
@@ -1050,6 +1110,17 @@ async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_ty
 
         logger.info(f"Router decision: {prediction_type}/{vol_level} for {contract.localSymbol}")
 
+        # --- Funnel: STRATEGY_SELECTION ---
+        log_funnel_event(
+            cycle_id=cycle_id,
+            contract=contract_name,
+            stage=FunnelStage.STRATEGY_SELECTION,
+            outcome="PASS" if strategy_type_log != 'NONE' else "INFO",
+            detail=f"prediction_type={prediction_type_log}, strategy={strategy_type_log}, vol_level={vol_level_log}",
+            price_snapshot=market_ctx.get('price'),
+            regime=regime_log if 'regime_log' in dir() else regime,
+        )
+
         # Construct final signal object
         if prediction_type == "VOLATILITY":
             return {
@@ -1068,7 +1139,8 @@ async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_ty
                 # v7.0: Carry forward for Phase 5 position sizing
                 "thesis_strength": decision.get('thesis_strength', 'SPECULATIVE') if 'decision' in dir() else 'SPECULATIVE',
                 "conviction_multiplier": decision.get('conviction_multiplier', 1.0) if 'decision' in dir() else 1.0,
-                "_agent_reports": reports
+                "_agent_reports": reports,
+                "_cycle_id": cycle_id,
             }
         else:
             return {
@@ -1086,7 +1158,8 @@ async def generate_signals(ib: IB, config: dict, shutdown_check=None, trigger_ty
                 # v7.0: Carry forward for Phase 5 position sizing
                 "thesis_strength": decision.get('thesis_strength', 'SPECULATIVE') if 'decision' in dir() else 'SPECULATIVE',
                 "conviction_multiplier": decision.get('conviction_multiplier', 1.0) if 'decision' in dir() else 1.0,
-                "_agent_reports": reports
+                "_agent_reports": reports,
+                "_cycle_id": cycle_id,
             }
 
     # 5. Execute for all contracts


### PR DESCRIPTION
## Summary

- Adds structured event logging across the entire trading pipeline (16 instrumentation points) to identify where alpha leaks between correct council signals and realized P&L
- Creates `ExitReason` enum (32 canonical exit reasons) and `FunnelStage` enum (22 pipeline stages) as single sources of truth
- Includes backfill script that migrated 5,283 historical events from existing CSVs (KC: 3,728, NG: 674, CC: 881)
- New dashboard page "The Funnel" with waterfall chart, signal vs outcome 2x2 matrix, execution efficiency analysis, and top leak ranking

## Key Findings (from backfill data)
- KC: 533 orders placed → only 27 filled (**5% fill rate**) — confirms adaptive walk timeout as primary alpha leak
- NG: 26 placed → 13 filled (50% fill rate) — significantly better execution
- CC: 5 placed (mostly paused period)

## Safety
- All `log_funnel_event()` calls are fire-and-forget (never raise, never block trading)
- Engine runtime guard prevents logging in test/dashboard contexts
- Append-only CSV — no existing data modified
- 25 new tests + 1,030 existing tests pass with 0 regressions

## Test plan
- [x] 25 new tests pass (enums, logger, classifier, truncation, source flags)
- [x] Full test suite: 1,030 passed, 0 failures
- [x] Backfill script tested against production data (5,283 events)
- [ ] Verify dashboard page loads with backfilled data
- [ ] Monitor first live trading cycle for real-time funnel events

🤖 Generated with [Claude Code](https://claude.com/claude-code)