### PR TITLE
fix: dedup ORDER_PLACED events in backfill script

### DIFF
--- a/scripts/backfill_execution_funnel.py
+++ b/scripts/backfill_execution_funnel.py
@@ -137,6 +137,7 @@ def backfill_commodity(ticker: str, data_root: str) -> int:
     if os.path.exists(oe_path):
         print(f"  [{ticker}] Reading order_events.csv...")
         oe = pd.read_csv(oe_path, on_bad_lines='warn')
+        _seen_placed = set()  # Dedup: only first Submitted per order_id → ORDER_PLACED
         for _, r in oe.iterrows():
             ts = r.get('timestamp', '')
             status = str(r.get('status', '')).lower()
@@ -148,6 +149,9 @@ def backfill_commodity(ticker: str, data_root: str) -> int:
             msg = str(r.get('message', ''))[:200]
 
             if 'submitted' in status or 'presubmitted' in status:
+                if order_id in _seen_placed:
+                    continue  # IB re-emits Submitted on price modifications — skip dupes
+                _seen_placed.add(order_id)
                 rows.append({
                     'timestamp': ts,
                     'cycle_id': f"ORDER-{order_id}",


### PR DESCRIPTION
## Summary
- IB re-emits `Submitted`/`PreSubmitted` on every `placeOrder()` call including adaptive walk price modifications
- Backfill was mapping all of these to `ORDER_PLACED`, inflating the count (KC: 533 → 71 after fix)
- Fix: track seen order IDs, only emit `ORDER_PLACED` for first submission per `order_id`
- KC backfill re-run: 3729 → 3267 rows (462 duplicate ORDER_PLACED removed)

## Test plan
- [x] KC backfill re-run produces correct counts (71 ORDER_PLACED vs 533 before)
- [x] No ORDER_PLACED duplicates per order_id in output
- [x] PRICE_WALK_STEP events unaffected (still captured via `status=updated`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)