### PR TITLE
fix: dedup ORDER_CANCELLED events in backfill script

### DIFF
--- a/scripts/backfill_execution_funnel.py
+++ b/scripts/backfill_execution_funnel.py
@@ -137,7 +137,8 @@ def backfill_commodity(ticker: str, data_root: str) -> int:
     if os.path.exists(oe_path):
         print(f"  [{ticker}] Reading order_events.csv...")
         oe = pd.read_csv(oe_path, on_bad_lines='warn')
-        _seen_placed = set()  # Dedup: only first Submitted per order_id → ORDER_PLACED
+        _seen_placed = set()     # Dedup: only first Submitted per order_id → ORDER_PLACED
+        _seen_cancelled = set()  # Dedup: only first Cancelled per order_id → ORDER_CANCELLED
         for _, r in oe.iterrows():
             ts = r.get('timestamp', '')
             status = str(r.get('status', '')).lower()
@@ -174,6 +175,9 @@ def backfill_commodity(ticker: str, data_root: str) -> int:
                     'source': 'BACKFILL',
                 })
             elif 'cancelled' in status or 'timedout' in status:
+                if order_id in _seen_cancelled:
+                    continue  # IB re-emits Cancelled repeatedly near timeout — skip dupes
+                _seen_cancelled.add(order_id)
                 rows.append({
                     'timestamp': ts,
                     'cycle_id': f"ORDER-{order_id}",


### PR DESCRIPTION
## Summary
- Same root cause as #1290: IB re-emits `Cancelled` status repeatedly near timeout
- KC ORDER_CANCELLED: 326 → 42 after dedup (284 duplicates removed)
- KC backfill already re-run on production data

## Test plan
- [x] KC backfill re-run: 42 unique ORDER_CANCELLED (was 326)
- [x] Total KC rows: 3267 → 2983

🤖 Generated with [Claude Code](https://claude.com/claude-code)