### PR TITLE
feat: add migration verification to deploy pipeline

### DIFF
--- a/scripts/run_migrations.py
+++ b/scripts/run_migrations.py
@@ -110,14 +110,44 @@ def run_migration(script_path: str, data_dirs: list, dry_run: bool) -> bool:
         return False
 
 
+def verify_migrations(migrations_dir: str, marker_path: str) -> bool:
+    """Check that all known migrations have been applied. Returns True if all OK."""
+    migrations = discover_migrations(migrations_dir)
+    if not migrations:
+        print("No migration scripts found.")
+        return True
+
+    applied = load_applied(marker_path)
+    pending = []
+    for script_path in migrations:
+        name = os.path.basename(script_path)
+        if name not in applied:
+            pending.append(name)
+
+    if pending:
+        print(f"PENDING migrations ({len(pending)}):")
+        for name in pending:
+            print(f"  - {name}")
+        return False
+    else:
+        print(f"All {len(migrations)} migrations applied.")
+        return True
+
+
 def main():
     parser = argparse.ArgumentParser(description='Run pending data migrations')
     parser.add_argument('--dry-run', action='store_true', help='Preview changes without applying')
+    parser.add_argument('--verify', action='store_true',
+                        help='Check migration status without running (exit 1 if pending)')
     args = parser.parse_args()
 
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     migrations_dir = os.path.join(repo_root, 'scripts', 'migrations')
     marker_path = os.path.join(repo_root, 'data', '.migrations_applied')
+
+    if args.verify:
+        ok = verify_migrations(migrations_dir, marker_path)
+        sys.exit(0 if ok else 1)
 
     data_dirs = discover_data_dirs(repo_root)
     migrations = discover_migrations(migrations_dir)

--- a/scripts/verify_deploy.sh
+++ b/scripts/verify_deploy.sh
@@ -35,7 +35,7 @@ fi
 
 ERRORS=0
 
-echo "  [1/7] Checking required directories..."
+echo "  [1/8] Checking required directories..."
 REQUIRED_DIRS=(
     "config"
     "config/profiles"
@@ -60,7 +60,7 @@ for dir in "${REQUIRED_DIRS[@]}"; do
     fi
 done
 
-echo "  [2/7] Checking required files..."
+echo "  [2/8] Checking required files..."
 REQUIRED_FILES=(
     # New packages (__init__.py)
     "config/__init__.py"
@@ -90,7 +90,7 @@ for file in "${REQUIRED_FILES[@]}"; do
     fi
 done
 
-echo "  [3/7] Checking Python imports..."
+echo "  [3/8] Checking Python imports..."
 # Each import block tests one phase of the HRO guide.
 # We test them individually so failures are pinpointed.
 
@@ -153,7 +153,7 @@ if [ $? -ne 0 ]; then
     ERRORS=$((ERRORS + 1))
 fi
 
-echo "  [4/7] Validating config files..."
+echo "  [4/8] Validating config files..."
 python -c "
 import json, sys
 configs = ['config.json']
@@ -184,7 +184,7 @@ if [ $? -ne 0 ]; then
     ERRORS=$((ERRORS + 1))
 fi
 
-echo "  [5/7] Per-commodity data sanity..."
+echo "  [5/8] Per-commodity data sanity..."
 # Auto-detect all commodity tickers from data/ directories.
 # To add a new commodity: create data/{TICKER}/ and register a commodity profile.
 ALL_TICKERS=()
@@ -259,7 +259,33 @@ if [ $COMMODITY_WARNINGS -gt 0 ]; then
     echo "    ($COMMODITY_WARNINGS warnings — normal for new commodities)"
 fi
 
-echo "  [6/7] Running system readiness check..."
+echo "  [6/8] Verifying migrations applied..."
+MARKER_FILE="data/.migrations_applied"
+MIGRATIONS_DIR="scripts/migrations"
+if [ -d "$MIGRATIONS_DIR" ] && [ -f "$MARKER_FILE" ]; then
+    MIGRATION_WARNINGS=0
+    for _mig in "$MIGRATIONS_DIR"/*.py; do
+        [ -f "$_mig" ] || continue
+        _name=$(basename "$_mig")
+        [ "$_name" = "__init__.py" ] && continue
+        if ! grep -qFx "$_name" "$MARKER_FILE" 2>/dev/null; then
+            echo "    ⚠️  Migration not applied: $_name"
+            MIGRATION_WARNINGS=$((MIGRATION_WARNINGS + 1))
+        fi
+    done
+    if [ $MIGRATION_WARNINGS -eq 0 ]; then
+        APPLIED_COUNT=$(wc -l < "$MARKER_FILE" | tr -d ' ')
+        echo "    ✅ All migrations applied ($APPLIED_COUNT total)"
+    else
+        echo "    ⚠️  $MIGRATION_WARNINGS migration(s) not in marker file (non-blocking)"
+    fi
+elif [ -d "$MIGRATIONS_DIR" ] && [ ! -f "$MARKER_FILE" ]; then
+    echo "    ⚠️  Marker file missing — migrations may not have run"
+else
+    echo "    ⏭️  No migrations directory, skipping"
+fi
+
+echo "  [7/8] Running system readiness check..."
 if [ -f "verify_system_readiness.py" ]; then
     # Quick mode, skip IBKR (Gateway may not be ready during deploy)
     # CRITICAL: Use `if !` pattern so set -e doesn't abort on non-zero exit.
@@ -274,7 +300,7 @@ else
     echo "    ⏭️  verify_system_readiness.py not found, skipping"
 fi
 
-echo "  [7/7] Checking MasterOrchestrator mode..."
+echo "  [8/8] Checking MasterOrchestrator mode..."
 LEGACY_MODE="${LEGACY_MODE:-false}"
 if [ "$LEGACY_MODE" = "true" ]; then
     echo "    ℹ️  LEGACY_MODE=true — running per-commodity services"


### PR DESCRIPTION
## Summary
- Adds step [6/8] to `verify_deploy.sh` — cross-checks every `.py` in `scripts/migrations/` against `data/.migrations_applied` marker file
- Adds `--verify` flag to `run_migrations.py` for standalone status checks (`python scripts/run_migrations.py --verify`)
- Warnings are non-blocking — deploy continues even if migrations are pending, but the warning is visible in deploy logs

## How it works
The deploy pipeline now has three layers of migration safety:

1. **Step 6 (deploy.sh)**: Runs `run_migrations.py` — executes pending migrations
2. **Step 8 (verify_deploy.sh)**: Verifies all migrations are in the marker file — warns if any were missed
3. **Manual check**: `python scripts/run_migrations.py --verify` — exits 0 if all applied, 1 if pending

## Test plan
- [x] `python scripts/run_migrations.py --verify` correctly reports pending migrations (exit 1)
- [x] `python scripts/run_migrations.py --dry-run` still works
- [ ] verify_deploy.sh reports migration status during deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)