### PR TITLE
fix: create per-commodity surrogate_models dir in deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -245,7 +245,8 @@ mkdir -p trading_bot/prompts      # Templatized agent prompts
 mkdir -p backtesting              # Backtesting framework
 mkdir -p data/surrogate_models    # Surrogate model cache (runtime)
 for _t in "${ALL_TICKERS[@]}"; do
-    mkdir -p "data/$_t"           # Per-commodity data directory
+    mkdir -p "data/$_t"                    # Per-commodity data directory
+    mkdir -p "data/$_t/surrogate_models"   # Per-commodity surrogate model cache
 done
 echo "  Directories OK"
 


### PR DESCRIPTION
## Summary
- Deploy to production failed because `verify_deploy.sh` expects `data/KC/surrogate_models` but `deploy.sh` Step 5 only created `data/KC`
- Adds `mkdir -p data/$_t/surrogate_models` to the per-commodity scaffolding loop

## Root cause
Step 5 had `mkdir -p data/surrogate_models` (global) but the verification gate checks for `data/KC/surrogate_models` (per-commodity). The rollback was triggered by this single missing directory.

## Test plan
- [ ] Re-deploy to production after merging to `main` and then to `production`

🤖 Generated with [Claude Code](https://claude.com/claude-code)