### PR TITLE
🎨 Palette: Add tooltips to Funnel slippage metrics

### DIFF
--- a/pages/10_The_Funnel.py
+++ b/pages/10_The_Funnel.py
@@ -399,18 +399,18 @@ with tab_exec:
                     slip_stats = filled_clean['slippage_pct'].dropna()
                     if not slip_stats.empty:
                         ss1, ss2, ss3, ss4 = st.columns(4)
-                        ss1.metric("Mean", f"{slip_stats.mean():.1f}%")
-                        ss2.metric("Median", f"{slip_stats.median():.1f}%")
-                        ss3.metric("P75", f"{slip_stats.quantile(0.75):.1f}%")
-                        ss4.metric("Max", f"{slip_stats.max():.1f}%")
+                        ss1.metric("Mean", f"{slip_stats.mean():.1f}%", help="Mean slippage as % of credit/debit")
+                        ss2.metric("Median", f"{slip_stats.median():.1f}%", help="Median slippage as % of credit/debit")
+                        ss3.metric("P75", f"{slip_stats.quantile(0.75):.1f}%", help="75th percentile of slippage as % of credit/debit")
+                        ss4.metric("Max", f"{slip_stats.max():.1f}%", help="Maximum slippage as % of credit/debit")
 
                 with slip_col2:
                     st.markdown("**Absolute Slippage (cents/ticks)**")
                     abs_stats = filled_clean['slippage_abs'].dropna()
                     if not abs_stats.empty:
                         sa1, sa2, sa3, sa4 = st.columns(4)
-                        sa1.metric("Mean", f"{abs_stats.mean():.2f}")
-                        sa2.metric("Median", f"{abs_stats.median():.2f}")
+                        sa1.metric("Mean", f"{abs_stats.mean():.2f}", help="Mean absolute slippage in cents/ticks")
+                        sa2.metric("Median", f"{abs_stats.median():.2f}", help="Median absolute slippage in cents/ticks")
                         sa3.metric("Favorable", f"{(abs_stats < 0).sum()}", help="Fills better than initial limit")
                         sa4.metric("Adverse", f"{(abs_stats > 0).sum()}", help="Fills worse than initial limit")
 

--- a/tests/test_ui_ux.py
+++ b/tests/test_ui_ux.py
@@ -206,6 +206,28 @@ class TestCockpitUX(unittest.TestCase):
         self.assertTrue(found_config, "Task Schedule dataframe is missing 'column_config' with 'Task Description'")
 
 
+class TestFunnelUX(unittest.TestCase):
+    def test_funnel_metric_tooltips(self):
+        """Verify that key metrics in pages/10_The_Funnel.py have help tooltips."""
+        file_path = os.path.join(
+            os.path.dirname(__file__), "..", "pages", "10_The_Funnel.py"
+        )
+        with open(file_path, "r") as f:
+            tree = ast.parse(f.read())
+
+        found_config = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "metric":
+                has_help = False
+                for kw in node.keywords:
+                    if kw.arg == "help":
+                        has_help = True
+                        break
+                self.assertTrue(has_help, f"Metric missing tooltip help in {file_path}")
+                found_config = True
+        self.assertTrue(found_config, "No metrics found to check in The Funnel")
+
+
 class TestDashboardUX(unittest.TestCase):
     def test_dashboard_metric_tooltips(self):
         """Verify that key metrics in dashboard.py have help tooltips."""


### PR DESCRIPTION
💡 **What:** Added missing `help` tooltips to all `st.metric` calls in the Slippage Summary and Absolute Slippage sections of `pages/10_The_Funnel.py`. Also added `test_funnel_metric_tooltips` to `tests/test_ui_ux.py` to statically enforce this requirement.
🎯 **Why:** To improve contextual clarity and accessibility, ensuring users immediately understand what "Mean", "Median", "P75", and "Max" slippage values refer to without needing external documentation, aligning with Palette's micro-UX guidelines.
♿ **Accessibility:** Added native hover tooltips to previously bare metric cards.

---
*PR created automatically by Jules for task [2569485327176120992](https://jules.google.com/task/2569485327176120992) started by @rozavala*