### PR TITLE
fix: lower prediction market failure threshold to 10

### DIFF
--- a/config.json
+++ b/config.json
@@ -237,7 +237,7 @@
         "notify_on_change": true
       },
       "max_topic_age_hours": 240,
-      "max_consecutive_failures": 50,
+      "max_consecutive_failures": 10,
       "interest_areas": [
         {
           "name": "US Monetary Policy",


### PR DESCRIPTION
## Summary
- Reduces `max_consecutive_failures` from 50 to 10 in config.json
- 50 retries was excessive — if Polymarket doesn't have a matching market, it won't appear on attempt #50
- Also includes prior fixes to `scripts/check_market_data.py` (nan handling, front-month resolution)

## Test plan
- [ ] Verify prediction market topics with no matching market get disabled after 10 failures instead of 50

🤖 Generated with [Claude Code](https://claude.com/claude-code)