### PR TITLE
🎨 Palette: Fix metric delta colors for warning visibility

### DIFF
--- a/pages/1_Cockpit.py
+++ b/pages/1_Cockpit.py
@@ -1232,9 +1232,11 @@ try:
             )
 
         with router_cols[2]:
+            fallback_count = metrics.get('fallback_count', 0)
             st.metric(
                 "Fallback Count",
-                metrics.get('fallback_count', 0),
+                fallback_count,
+                delta=fallback_count if fallback_count > 0 else None,
                 delta_color="inverse",  # Lower is better
                 help="Number of times the router switched to backup providers"
             )

--- a/pages/5_Utilities.py
+++ b/pages/5_Utilities.py
@@ -766,7 +766,8 @@ if run_validation:
                     with metric_cols[2]:
                         st.metric("Warnings", summary.get('warnings', 0), delta=None, delta_color="off", help="Number of validation checks that returned a warning.")
                     with metric_cols[3]:
-                        st.metric("Failures", summary.get('failed', 0), delta=None, delta_color="inverse", help="Number of validation checks that failed.")
+                        fails = summary.get('failed', 0)
+                        st.metric("Failures", fails, delta=fails if fails > 0 else None, delta_color="inverse", help="Number of validation checks that failed.")
 
                     # Results table
                     if data.get('checks'):


### PR DESCRIPTION
💡 **What:** The UX enhancement fixes `st.metric()` displays for failure-prone metrics (like "Fallback Count" and "Failures") to correctly render in red when values are greater than zero.
🎯 **Why:** Previously, these metrics used `delta_color="inverse"` but did not pass a `delta` value. In Streamlit, `delta_color` does nothing without a `delta`. By explicitly setting the delta to the failure count, the system now provides immediate, attention-grabbing visual feedback when there's an issue or failure, improving dashboard intuitiveness.
♿ **Accessibility:** Enhances visual hierarchy by using color semantics properly for warning conditions, making it easier for users to spot system friction at a glance.

---
*PR created automatically by Jules for task [13147162936935213310](https://jules.google.com/task/13147162936935213310) started by @rozavala*