### PR TITLE
🎨 Palette: Add tooltips to download buttons in Signal Overlay and Funnel pages

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -69,3 +69,6 @@ This journal records CRITICAL UX/accessibility learnings.
 ## 2026-03-10 - Visual Anchors in Data Tables
 **Learning:** Data tables often feel "heavy" and purely technical. Prepending semantic emojis to `st.column_config` headers (e.g., 🕒 Time, 📜 Decision) provides visual anchors that make the table more approachable and scan-friendly, especially when mixed with other metric cards that use icons.
 **Action:** Consistently use emojis in `column_config` titles for high-impact dashboards to maintain the visual language of the application.
+## 2024-05-23 - Add Tooltips to `st.download_button`
+**Learning:** Streamlit UI components like `st.download_button` can lack sufficient context, reducing accessibility and clarity. Adding the built-in `help` parameter provides native, descriptive tooltips that explain button functionality.
+**Action:** Consistently enforce `help` tooltips on `st.download_button` components (and others like `st.metric` or `st.checkbox`) across the dashboard to improve micro-UX and accessibility. Use `ast` unit tests to statically verify their presence.

--- a/pages/10_The_Funnel.py
+++ b/pages/10_The_Funnel.py
@@ -598,6 +598,7 @@ with st.expander("Raw Funnel Data", expanded=False):
             display_df.to_csv(index=False).encode('utf-8'),
             f"execution_funnel_{ticker}.csv",
             "text/csv",
+            help="Download the complete execution funnel data as a CSV file for detailed analysis."
         )
     else:
         st.info("No funnel data available.")

--- a/pages/6_Signal_Overlay.py
+++ b/pages/6_Signal_Overlay.py
@@ -1429,6 +1429,7 @@ if price_df is not None and not price_df.empty:
             data=csv,
             file_name=f"{profile.contract.symbol.lower()}_data_{lookback_days}d_{datetime.now().strftime('%Y%m%d_%H%M')}.csv",
             mime='text/csv',
+            help="Download the displayed market data and overlaid signals as a CSV file for external analysis."
         )
 
     # === RAW SIGNAL LOG ===

--- a/tests/test_ui_ux.py
+++ b/tests/test_ui_ux.py
@@ -227,6 +227,26 @@ class TestFunnelUX(unittest.TestCase):
                 found_config = True
         self.assertTrue(found_config, "No metrics found to check in The Funnel")
 
+    def test_funnel_download_button_tooltip(self):
+        """Verify that the download button in pages/10_The_Funnel.py has a help tooltip."""
+        file_path = os.path.join(
+            os.path.dirname(__file__), "..", "pages", "10_The_Funnel.py"
+        )
+        with open(file_path, "r") as f:
+            tree = ast.parse(f.read())
+
+        found_button = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "download_button":
+                has_help = False
+                for kw in node.keywords:
+                    if kw.arg == "help":
+                        has_help = True
+                        break
+                self.assertTrue(has_help, f"download_button missing tooltip help in {file_path}")
+                found_button = True
+        self.assertTrue(found_button, "No download_button found to check in The Funnel")
+
 
 class TestDashboardUX(unittest.TestCase):
     def test_dashboard_metric_tooltips(self):
@@ -551,6 +571,26 @@ class TestSignalOverlayUX(unittest.TestCase):
             self.assertTrue(
                 found, f"Could not find metric '{metric}' in pages/6_Signal_Overlay.py"
             )
+
+    def test_signal_overlay_download_button_tooltip(self):
+        """Verify that the download button in pages/6_Signal_Overlay.py has a help tooltip."""
+        file_path = os.path.join(
+            os.path.dirname(__file__), "..", "pages", "6_Signal_Overlay.py"
+        )
+        with open(file_path, "r") as f:
+            tree = ast.parse(f.read())
+
+        found_button = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "download_button":
+                has_help = False
+                for kw in node.keywords:
+                    if kw.arg == "help":
+                        has_help = True
+                        break
+                self.assertTrue(has_help, f"download_button missing tooltip help in {file_path}")
+                found_button = True
+        self.assertTrue(found_button, "No download_button found to check in Signal Overlay")
 
 
 class TestBrierAnalysisUX(unittest.TestCase):


### PR DESCRIPTION
**💡 What:** Added descriptive `help` tooltips to `st.download_button` components in `pages/6_Signal_Overlay.py` and `pages/10_The_Funnel.py`.
**🎯 Why:** Users downloading CSV data might not know exactly what the data contains. Tooltips provide contextual help improving clarity and accessibility.
**♿ Accessibility:** Enhanced context and accessibility via native Streamlit tooltips for interactive buttons.
Added robust AST-based unit tests to statically ensure `download_button` components retain their `help` arguments.

---
*PR created automatically by Jules for task [15416716867689960173](https://jules.google.com/task/15416716867689960173) started by @rozavala*