### PR TITLE
fix: add contract overlap guard to prevent IB position netting

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -4492,7 +4492,7 @@ async def run_emergency_cycle(trigger: SentinelTrigger, config: dict, ib: IB, pa
 
                         order_objects = await create_combo_order_object(ib, config, strategy_def)
                         if order_objects:
-                            contract, order = order_objects
+                            contract, order, _ = order_objects
 
                             # Queue and Execute (Fix Global Queue Collision)
                             # Pass specific list to place_queued_orders so we don't wipe the global queue

--- a/tests/test_ib_interface.py
+++ b/tests/test_ib_interface.py
@@ -94,7 +94,7 @@ class TestIbInterface(unittest.TestCase):
 
             # 4. Assertions
             self.assertIsNotNone(result)
-            _, market_order = result
+            _, market_order, _ = result
             self.assertIsInstance(market_order, Order)
             self.assertEqual(market_order.orderType, "MKT")
             self.assertEqual(market_order.action, "BUY")
@@ -150,7 +150,7 @@ class TestIbInterface(unittest.TestCase):
 
             # 4. Assertions
             self.assertIsNotNone(result)
-            _, limit_order = result
+            _, limit_order, _ = result
 
             # Theoretical Price: 1.0 (buy) - 0.5 (sell) = 0.5
             # Fixed Slippage: 0.2

--- a/trading_bot/ib_interface.py
+++ b/trading_bot/ib_interface.py
@@ -293,7 +293,7 @@ async def build_option_chain(ib: IB, future_contract: Contract) -> dict | None:
         logging.error(f"Failed to build option chain for {future_contract.localSymbol}: {e}"); return None
 
 
-async def create_combo_order_object(ib: IB, config: dict, strategy_def: dict) -> tuple[Contract, Order] | None:
+async def create_combo_order_object(ib: IB, config: dict, strategy_def: dict) -> tuple[Contract, Order, list] | None:
     """
     Prices a combo strategy and creates qualified Contract and Order objects without placing them.
 
@@ -673,7 +673,7 @@ async def create_combo_order_object(ib: IB, config: dict, strategy_def: dict) ->
     order.orderRef = str(uuid.uuid4())
     logging.info(f"Assigned OrderRef: {order.orderRef}")
 
-    return (combo, order)
+    return (combo, order, qualified_legs)
 
 
 def place_order(ib: IB, contract: Contract, order: Order) -> Trade | None:

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -846,6 +846,135 @@ def _check_thesis_coherence(
     return "PROCEED", []
 
 
+def _build_active_contract_map(config: dict) -> dict[str, list[tuple[str, int]]]:
+    """Build {localSymbol: [(tid, signed_net_qty), ...]} for all active theses.
+
+    Called once per order-generation cycle. The returned map is passed to
+    _check_contract_overlap() for each proposed order, avoiding redundant
+    trade ledger + TMS queries.
+
+    Returns empty dict on any failure (fail-open: no overlaps detected).
+
+    IMPORTANT: We store per-thesis quantities (not net across theses) because
+    emergency sentinel orders bypass this guard and can create opposing
+    positions. A net-only view would mask those conflicts.
+    """
+    trade_ledger = get_trade_ledger_df(config.get('data_dir'))
+    if trade_ledger.empty:
+        return {}
+
+    try:
+        tms = TransactiveMemory()
+        if not tms.collection:
+            logger.warning("Overlap map: TMS collection unavailable (fail-open)")
+            return {}
+
+        active_results = tms.collection.get(
+            where={"active": "true"},
+            include=['metadatas']
+        )
+        active_tids = [
+            m.get('trade_id')
+            for m in active_results.get('metadatas', [])
+            if m.get('trade_id')
+        ]
+    except Exception as e:
+        logger.warning(f"Overlap map: TMS query failed (fail-open): {e}")
+        return {}
+
+    if not active_tids:
+        return {}
+
+    active_map = {}  # {localSymbol: [(tid, signed_net_qty), ...]}
+    for tid in active_tids:
+        tid_rows = trade_ledger[trade_ledger['position_id'] == tid]
+        if tid_rows.empty:
+            continue
+        tid_valid = tid_rows[
+            tid_rows['local_symbol'].astype(str).str.strip() != ''
+        ].copy()
+        if tid_valid.empty:
+            continue
+
+        tid_valid['signed_qty'] = np.where(
+            tid_valid['action'] == 'BUY',
+            tid_valid['quantity'],
+            -tid_valid['quantity']
+        )
+        leg_map = tid_valid.groupby('local_symbol')['signed_qty'].sum()
+        for sym, net in leg_map.items():
+            if net != 0:
+                if sym not in active_map:
+                    active_map[sym] = []
+                active_map[sym].append((tid, int(net)))
+
+    return active_map
+
+
+def _check_contract_overlap(
+    qualified_legs: list,
+    legs_def: list,
+    order_qty: int,
+    active_contract_map: dict,
+) -> tuple[bool, str]:
+    """Check if a proposed order's legs overlap with active theses' legs
+    in opposing directions, which would cause IB position netting.
+
+    Args:
+        qualified_legs:      List of qualified FuturesOption contracts from
+                             create_combo_order_object(). Each has .localSymbol.
+        legs_def:            Strategy definition legs [(right, action, strike), ...].
+        order_qty:           Total order quantity (lots).
+        active_contract_map: Pre-built map from _build_active_contract_map().
+
+    Returns:
+        (blocked, reason) where blocked=True means the order must not proceed.
+    """
+    if not active_contract_map:
+        return False, ""
+
+    if len(qualified_legs) != len(legs_def):
+        logger.warning(
+            f"Overlap check: leg count mismatch "
+            f"(qualified={len(qualified_legs)}, def={len(legs_def)}). "
+            f"Skipping check (fail-open)."
+        )
+        return False, ""
+
+    # Build proposed legs: {localSymbol: signed_qty}
+    proposed = {}
+    for leg_contract, (_, action, strike) in zip(qualified_legs, legs_def):
+        sym = leg_contract.localSymbol
+        sign = 1 if action == 'BUY' else -1
+        proposed[sym] = proposed.get(sym, 0) + (sign * order_qty)
+
+    if not proposed:
+        return False, ""
+
+    # Check for opposing directions against each active thesis individually.
+    overlaps = []
+    for sym, proposed_qty in proposed.items():
+        for tid, existing_qty in active_contract_map.get(sym, []):
+            if (proposed_qty > 0 and existing_qty < 0) or \
+               (proposed_qty < 0 and existing_qty > 0):
+                overlaps.append(
+                    f"{sym}: proposed={proposed_qty:+d} vs "
+                    f"thesis {tid[:8]}={existing_qty:+d}"
+                )
+
+    if overlaps:
+        reason = (
+            f"BLOCKED - Contract Overlap: New order shares "
+            f"{len(overlaps)} contract(s) with existing theses in "
+            f"opposing directions (would cause IB netting). "
+            f"Details: {'; '.join(overlaps)}"
+        )
+        logger.warning(reason)
+        return True, reason
+
+    return False, ""
+
+
 async def generate_and_queue_orders(config: dict, connection_purpose: str = "orchestrator_orders", shutdown_check=None, trigger_type=None, schedule_id: str = None):
     """
     Generates trading strategies based on market data and API predictions,
@@ -1010,6 +1139,14 @@ async def generate_and_queue_orders(config: dict, connection_purpose: str = "orc
 
             if committed_capital > 0:
                 logger.info(f"L1 RECONCILED: Starting with ${committed_capital:,.2f} already committed")
+
+            # === BUILD ACTIVE CONTRACT MAP (once per cycle) ===
+            active_contract_map = _build_active_contract_map(config)
+            if active_contract_map:
+                logger.info(
+                    f"Active contract map: {len(active_contract_map)} symbols "
+                    f"across active theses"
+                )
 
             # === FLIGHT DIRECTOR WARNING ===
             # DO NOT PARALLELIZE THIS LOOP WITH asyncio.gather()
@@ -1227,7 +1364,29 @@ async def generate_and_queue_orders(config: dict, connection_purpose: str = "orc
 
                         order_objects = await create_combo_order_object(ib, config, strategy_def)
                         if order_objects:
-                            contract, order = order_objects
+                            contract, order, qualified_legs = order_objects
+
+                            # === CONTRACT OVERLAP GUARD ===
+                            overlap_blocked, overlap_reason = _check_contract_overlap(
+                                qualified_legs,
+                                strategy_def.get('legs_def', []),
+                                strategy_def.get('quantity', 1),
+                                active_contract_map,
+                            )
+                            if overlap_blocked:
+                                log_funnel_event(
+                                    cycle_id=signal.get('_cycle_id', 'unknown'),
+                                    contract=signal.get('contract_month', 'unknown'),
+                                    stage=FunnelStage.COMPLIANCE_CHECK,
+                                    outcome="BLOCK",
+                                    detail=overlap_reason[:200],
+                                    price_snapshot=signal.get('price'),
+                                    regime=signal.get('regime', 'UNKNOWN'),
+                                )
+                                logger.warning(
+                                    f"Skipping order for {future.localSymbol}: {overlap_reason}"
+                                )
+                                continue
 
                             # Calculate and track committed capital
                             estimated_risk = await calculate_spread_max_risk(ib, contract, order, config)


### PR DESCRIPTION
## Summary
- Adds a **Contract Overlap Guard** that blocks new orders whose legs oppose contracts held by active theses in the opposite direction, preventing IB position netting cascade
- `create_combo_order_object()` now returns qualified leg contracts (3-tuple) so the guard can check `localSymbol` overlap at order generation time
- Active contract map built once per cycle (per-thesis, not net) to catch conflicts even after emergency sentinel orders that bypass the guard

## Root Cause
On 2026-03-17, thesis `5fb3f201` (BUY P3450, SELL P3400) was placed while thesis `79503cd8` already held BUY P3400 in the opposing direction. IB netted P3400 to zero, making it invisible to `reqPositions`. This caused: false orphan alerts, naked single-leg stale closes, and phantom ledger entries.

## What's Blocked / Allowed
| Scenario | Result |
|---|---|
| Opposing direction on same contract | **BLOCK** |
| Same direction on same contract | PROCEED (additive) |
| Same strike, different expiry | PROCEED (different localSymbol) |
| Emergency sentinel orders | PROCEED (bypass by design) |
| TMS/ledger unavailable | PROCEED (fail-open) |

## Files Changed
- `trading_bot/ib_interface.py` — Return 3-tuple from `create_combo_order_object()`
- `trading_bot/order_manager.py` — `_build_active_contract_map()`, `_check_contract_overlap()`, wired into `generate_and_queue_orders()`
- `orchestrator.py` — Emergency path unpacks 3-tuple with `_` discard
- `tests/test_ib_interface.py` — Updated 2-tuple unpacking to 3-tuple

## Test plan
- [x] All 1032 tests pass (no regressions)
- [ ] Verify on next signal cycle: logs show `"Active contract map:"` message
- [ ] Confirm normal orders (no overlap) proceed unblocked
- [ ] Confirm emergency orders bypass the guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)