### PR TITLE
fix: correct swapped arguments in funnel dashboard

### DIFF
--- a/pages/10_The_Funnel.py
+++ b/pages/10_The_Funnel.py
@@ -35,7 +35,7 @@ st.caption("Where does alpha leak? Track every signal from council decision thro
 @st.cache_data(ttl=60)
 def load_funnel_data(ticker: str) -> pd.DataFrame:
     """Load execution funnel data for a commodity."""
-    path = _resolve_data_path_for(ticker, 'execution_funnel.csv')
+    path = _resolve_data_path_for('execution_funnel.csv', ticker)
     if not os.path.exists(path):
         return pd.DataFrame()
     try:
@@ -50,7 +50,7 @@ def load_funnel_data(ticker: str) -> pd.DataFrame:
 @st.cache_data(ttl=60)
 def load_order_events(ticker: str) -> pd.DataFrame:
     """Load order events for slippage analysis."""
-    path = _resolve_data_path_for(ticker, 'order_events.csv')
+    path = _resolve_data_path_for('order_events.csv', ticker)
     if not os.path.exists(path):
         return pd.DataFrame()
     try:


### PR DESCRIPTION
## Summary
- `_resolve_data_path_for(filename, ticker)` was called as `_resolve_data_path_for(ticker, filename)` in `pages/10_The_Funnel.py`, causing it to construct an invalid path like `data/execution_funnel.csv/KC` instead of `data/KC/execution_funnel.csv`
- The exception was silently swallowed by a bare `except`, returning empty DataFrames
- 3,900+ rows of funnel data (KC: 3,141, NG: 771) exist and were being recorded correctly — the dashboard just couldn't find them

## Test plan
- [x] 44 related tests pass
- [ ] Verify funnel dashboard loads data after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)