### PR TITLE
fix: include perplexity in providers display string

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -195,7 +195,7 @@ def load_config() -> dict | None:
     config['data_dir'] = os.path.join(base_dir, 'data', ticker)
 
     # Log successful load
-    loaded_providers = [p for p in ['gemini', 'anthropic', 'openai', 'xai'] if config.get(p, {}).get('api_key')]
+    loaded_providers = [p for p in ['gemini', 'anthropic', 'openai', 'xai', 'perplexity'] if config.get(p, {}).get('api_key')]
     logger.info(f"Config loaded successfully. Mode: {trading_mode}. Providers: {', '.join(loaded_providers)}")
 
     return config


### PR DESCRIPTION
## Summary
- `config_loader.py` line 198 only listed `['gemini', 'anthropic', 'openai', 'xai']` in the `loaded_providers` check
- Perplexity never appeared in the startup log line even when `PERPLEXITY_API_KEY` is present
- Adding `'perplexity'` to the list so the log now shows `Providers: gemini, anthropic, openai, xai, perplexity`

## Test plan
- [ ] Restart orchestrator and confirm startup log shows `Providers: ..., perplexity` when `PERPLEXITY_API_KEY` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)