### PR TITLE
fix: COMPLIANCE_AUDIT not COMPLIANCE_CHECK in overlap guard

### DIFF
--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -1377,7 +1377,7 @@ async def generate_and_queue_orders(config: dict, connection_purpose: str = "orc
                                 log_funnel_event(
                                     cycle_id=signal.get('_cycle_id', 'unknown'),
                                     contract=signal.get('contract_month', 'unknown'),
-                                    stage=FunnelStage.COMPLIANCE_CHECK,
+                                    stage=FunnelStage.COMPLIANCE_AUDIT,
                                     outcome="BLOCK",
                                     detail=overlap_reason[:200],
                                     price_snapshot=signal.get('price'),


### PR DESCRIPTION
## Summary
- `FunnelStage.COMPLIANCE_CHECK` doesn't exist — the correct value is `COMPLIANCE_AUDIT`
- This caused a crash in `generate_and_queue_orders` any time the contract overlap guard blocked an order
- Introduced in PR #1332 (contract overlap guard)

## Root cause
`log_funnel_event(stage=FunnelStage.COMPLIANCE_CHECK, ...)` in the overlap guard block — wrong enum member name, should be `COMPLIANCE_AUDIT`

## Impact
Order generation crashed with `AttributeError` for any cycle where overlap guard triggered (NG dev, 14:10 UTC 2026-03-18). All other signals in that cycle were also dropped.

## Test plan
- [ ] Confirm no `AttributeError: type object 'FunnelStage' has no attribute 'COMPLIANCE_CHECK'` in logs after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)