### PR TITLE
fix: Perplexity fallback, list-wrapped LLM JSON, BAG close float

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -2100,7 +2100,7 @@ async def _attempt_bag_close(
 
         bag.comboLegs = combo_legs_list
         bag_action = 'BUY'  # IB convention: BAG action BUY with explicit leg actions
-        order_size = qty_gcd
+        order_size = int(qty_gcd)  # LimitOrder requires int; leg.position may be float
 
         # Get market data for each leg to calculate combo price
         calculated_combo_price = 0.0

--- a/trading_bot/agents.py
+++ b/trading_bot/agents.py
@@ -713,6 +713,14 @@ class TradingCouncil:
         try:
             if self._perplexity_enabled:
                 data = await self._gather_via_perplexity(search_instruction, persona_key)
+                # If Perplexity returned non-JSON (wrapped as raw_summary with LOW quality),
+                # fall back to Gemini rather than proceeding with degraded data.
+                if data.get('data_quality') == 'LOW' and not data.get('dated_facts'):
+                    logger.warning(f"[{persona_key}] Perplexity returned low-quality data, falling back to Gemini...")
+                    try:
+                        data = await self._gather_via_gemini(search_instruction, persona_key)
+                    except Exception as gem_err:
+                        logger.warning(f"[{persona_key}] Gemini fallback also failed: {gem_err}")
             else:
                 data = await self._gather_via_gemini(search_instruction, persona_key)
 
@@ -1114,6 +1122,9 @@ OUTPUT FORMAT (JSON):
             # Parse JSON
             try:
                 data = json.loads(self._clean_json_text(result_raw))
+                # Gemini Pro occasionally wraps the response in a list — unwrap if unambiguous
+                if isinstance(data, list) and len(data) == 1 and isinstance(data[0], dict):
+                    data = data[0]
                 if not isinstance(data, dict):
                     raise ValueError("LLM returned non-dict JSON")
                 # === A1-R1: Canonicalize confidence IMMEDIATELY after JSON parse ===
@@ -1263,6 +1274,8 @@ OUTPUT FORMAT (JSON ONLY):
 
         try:
             data = json.loads(self._clean_json_text(revised_raw))
+            if isinstance(data, list) and len(data) == 1 and isinstance(data[0], dict):
+                data = data[0]
             if not isinstance(data, dict):
                 raise ValueError("LLM returned non-dict JSON")
             # === A1-R1: Canonicalize confidence immediately (reflexion path) ===


### PR DESCRIPTION
## Summary
Three fixes from log review on 2026-03-18:

- **Perplexity low-quality fallback**: When Perplexity returns non-JSON, the client wraps it as `data_quality=LOW` with no `dated_facts`. Previously this degraded silently — Gemini fallback was dead code for this path (only triggered on exception). Now falls back to Gemini when `data_quality == "LOW"` and `dated_facts` is empty.

- **LLM list-wrapped JSON (geopolitical agent)**: Gemini Pro occasionally returns `[{...}]` (single-element list) instead of `{}`. This caused the geopolitical agent to fail on every NG cycle with `"LLM returned non-dict JSON"`. Unwrap unambiguous single-element lists before the `isinstance(data, dict)` check in both the main research path and the reflexion path.

- **BAG close float/int crash**: `leg.position` can be a float (e.g. `2.0`). `reduce(gcd, [2.0])` returns `2.0`, and `LimitOrder(action, 2.0, price)` raises `TypeError: 'float' object cannot be interpreted as an integer`. Cast `order_size = int(qty_gcd)`. The system fell back to individual leg closes gracefully, but this silently skipped the more efficient combo order every time.

## Also done (production, no restart needed)
- Cleared stale X API `since_id` files for KC and NG — XSentimentSentinel was rejecting all polls with Error 400 (since_id > 7 days old)

## Test plan
- [ ] NG geopolitical agent no longer logs `LLM returned non-dict JSON` on next signal cycle
- [ ] Perplexity non-JSON responses trigger `falling back to Gemini` log line instead of silent degradation
- [ ] BAG close no longer errors with float/int; combo order succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)