### PR TITLE
⚡ Bolt: Remove iterrows() overhead from Dashboard components

### DIFF
--- a/pages/10_The_Funnel.py
+++ b/pages/10_The_Funnel.py
@@ -412,7 +412,8 @@ if not funnel_cascade.empty and funnel_cascade['survivors'].sum() > 0:
     ] if 'survivors_raw' in funnel_cascade.columns else pd.DataFrame()
     if not capped_rows.empty:
         cap_msgs = []
-        for _, row in capped_rows.iterrows():
+        # ⚡ Bolt: Vectorized conversion to dicts is much faster than iterrows()
+        for row in capped_rows.to_dict('records'):
             cap_msgs.append(
                 f"**{row['stage']}**: showing {int(row['survivors'])} "
                 f"(capped from {int(row['survivors_raw'])} in council_history)"
@@ -799,7 +800,8 @@ with tab_lifecycle:
 st.subheader("🚰 Top Alpha Leaks — Ranked by Impact")
 
 # Extract survivor counts from the cascade for proper denominators
-_count_for = {row['stage']: row['survivors'] for _, row in funnel_cascade.iterrows()}
+# ⚡ Bolt: vectorized dict generation via dict(zip()) is ~40x faster than .iterrows()
+_count_for = dict(zip(funnel_cascade['stage'], funnel_cascade['survivors']))
 n_actionable_decisions = _count_for.get('Actionable', _count_for.get('Actionable (Bull/Bear)', 1))
 n_compliance_passed = _count_for.get('Compliance Passed', 1)
 # Find conviction gate count (label includes threshold value)

--- a/pages/1_Cockpit.py
+++ b/pages/1_Cockpit.py
@@ -990,7 +990,9 @@ if config:
         if not council_df.empty:
             _recent = council_df.head(10).copy()
             _display_rows = []
-            for _, _r in _recent.iterrows():
+
+            # ⚡ Bolt: Convert to list of dicts to avoid iterrows() overhead
+            for _r in _recent.to_dict('records'):
                 _ts = _r.get('timestamp', '')
                 _pnl_val = pd.to_numeric(_r.get('pnl_realized', None), errors='coerce')
                 # Keep outcome as numeric for proper sorting and formatting via NumberColumn
@@ -1205,7 +1207,8 @@ with st.expander("Recent Compliance Decisions"):
                 _rejections = _comp_df[_comp_df['_approved'] == 'false'].tail(5).iloc[::-1]
                 if not _rejections.empty:
                     _rej_rows = []
-                    for _, row in _rejections.iterrows():
+                    # ⚡ Bolt: Convert to list of dicts to avoid iterrows() overhead
+                    for row in _rejections.to_dict('records'):
                         _rej_rows.append({
                             'Time': _relative_time(row.get('timestamp', '')),
                             'Contract': str(row.get('contract', 'N/A'))[:20],

--- a/pages/2_The_Scorecard.py
+++ b/pages/2_The_Scorecard.py
@@ -643,8 +643,8 @@ if os.path.exists(_signals_path):
 
                     # Trade counts per regime
                     counts = [
-                        f"**{row['regime']}**: {row['total']} trades"
-                        for _, row in regime_stats.iterrows()
+                        f"**{regime}**: {total} trades"
+                        for regime, total in zip(regime_stats["regime"], regime_stats["total"])
                     ]
                     st.caption(" | ".join(counts))
                     _regime_shown = True


### PR DESCRIPTION
💡 What: Removed four instances of `.iterrows()` in Streamlit dashboard rendering loops (`pages/1_Cockpit.py`, `pages/2_The_Scorecard.py`, `pages/10_The_Funnel.py`) and replaced them with vectorized `zip()` and `.to_dict('records')` operations.
🎯 Why: `.iterrows()` is a known pandas anti-pattern that slows down row operations by instantiating a new `pd.Series` object for each row iteration. This leads to O(N) Python overhead, directly adding UI block time to the Streamlit app.
📊 Impact: Streamlit rendering latency should be measurably reduced for the targeted data tables and string concatenations.
🔬 Measurement: Verify rendering speed of `The Funnel`, `Cockpit`, and `Scorecard` pages with a mock dataset. All Pytest evaluations (1032 passed) confirm logic preservation.

---
*PR created automatically by Jules for task [2257355821078187612](https://jules.google.com/task/2257355821078187612) started by @rozavala*