### PR TITLE
fix: persist prediction market topic disabled state across restarts

### DIFF
--- a/trading_bot/sentinels.py
+++ b/trading_bot/sentinels.py
@@ -2106,6 +2106,20 @@ class PredictionMarketSentinel(Sentinel):
 
         self.topics = self._merge_discovered_topics(static_topics)
 
+        # Re-apply disabled state for topics that already hit max_failures in a
+        # prior run. Failure counts are now persisted (see _save_state_cache),
+        # so we can restore them here without re-sending a Pushover notification.
+        _max_failures = self.sentinel_config.get('max_consecutive_failures', 50)
+        for topic in self.topics:
+            query = topic.get('query', '')
+            fc = self._topic_failure_counts.get(query, 0)
+            if fc >= _max_failures:
+                topic['enabled'] = False
+                logger.info(
+                    f"PredictionMarket: '{topic.get('display_name', query)}' "
+                    f"kept disabled (failure_count={fc} restored from state)"
+                )
+
         # Prune orphaned cache entries for topics no longer active
         active_queries = {t.get('query', '') for t in self.topics}
         orphaned = [key for key in self.state_cache if key not in active_queries]
@@ -2535,10 +2549,12 @@ class PredictionMarketSentinel(Sentinel):
             except Exception as topic_error:
                 logger.warning(f"Error processing prediction market topic '{query}': {topic_error}")
                 continue
-        # Persist failure counts alongside state cache
+        # Persist failure counts alongside state cache — always, even for topics
+        # that never had a successful market lookup (no state_cache entry yet).
         for query_key, fail_count in self._topic_failure_counts.items():
-            if query_key in self.state_cache:
-                self.state_cache[query_key]['failure_count'] = fail_count
+            if query_key not in self.state_cache:
+                self.state_cache[query_key] = {}
+            self.state_cache[query_key]['failure_count'] = fail_count
         self._save_state_cache()
         if triggers:
             triggers.sort(key=lambda t: t.severity, reverse=True)


### PR DESCRIPTION
## Summary

- Fixes repeated \"Prediction Market Topic Disabled\" Pushover notifications on every system restart
- Root cause: topics that never matched a Polymarket market had their failure counts reset to 0 on restart, re-enabling them and triggering a fresh flood of polling → re-hitting the disable threshold → re-notifying

## Root cause

Two bugs in `trading_bot/sentinels.py`:

1. **Failure count not persisted for topics without market data**: `_save_state_cache()` only wrote `failure_count` for topics already in `state_cache` (`if query_key in self.state_cache:`). Topics that never got a successful Polymarket lookup were never added to `state_cache`, so their count was lost on restart.

2. **Disabled state not restored on reload**: `reload_topics()` re-loads topics fresh from `discovered_topics.json` (which TopicDiscovery fully overwrites on each scan), so `enabled=False` set in-memory was lost. No mechanism existed to re-apply it.

## Fix

1. Always initialize `state_cache[query_key]` if missing before saving `failure_count`
2. In `reload_topics()`, after merging topics, silently re-apply `enabled=False` for any topic whose restored `failure_count >= max_consecutive_failures` (no notification — it was already sent in the prior run)

## Test plan

- [x] All 1033 tests pass
- [ ] DEV: Confirm no \"Prediction Market Topic Disabled\" notification fires on next restart for already-disabled topics

🤖 Generated with [Claude Code](https://claude.com/claude-code)