### PR TITLE
fix: apply rate-limit interval to Perplexity Sonar Phase 1 calls

### DIFF
--- a/trading_bot/agents.py
+++ b/trading_bot/agents.py
@@ -802,6 +802,12 @@ class TradingCouncil:
         logger.info(f"[{persona_key}] Phase 1: Gathering grounded data via Perplexity Sonar...")
 
         async with self._grounded_data_semaphore:
+            import time as _time
+            elapsed = _time.monotonic() - self._last_grounded_call_time
+            if elapsed < self._grounded_data_min_interval:
+                await asyncio.sleep(self._grounded_data_min_interval - elapsed)
+            self._last_grounded_call_time = _time.monotonic()
+
             data = await perplexity_grounded_search(
                 search_instruction=search_instruction,
                 api_key=self._perplexity_api_key,


### PR DESCRIPTION
## Summary

- Fixes recurring Perplexity 429 burst errors on every signal cycle
- Root cause: `_gather_via_perplexity` had no rate-limiting between calls — only a semaphore (max 3 concurrent). All 8 agents fired Sonar requests as fast as the semaphore permitted, hitting the burst limit every cycle
- The Gemini path already had a `_last_grounded_call_time` / `_grounded_data_min_interval` (2.5s) guard; this PR applies the same pattern to the Perplexity path

## Effect

With 2.5s minimum stagger between calls inside the semaphore, 8 agents complete Phase 1 in ~20s total — well within Perplexity's rate limits and unnoticeable in the overall 2–3 minute signal cycle time.

## Test plan

- [x] All 1033 tests pass
- [ ] DEV: Confirm zero 429 errors on next signal cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)