### PR TITLE
fix: pre-production polish — dashboard exchange, VaR message, leg pricing retry

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -2963,10 +2963,16 @@ async def run_position_audit_cycle(config: dict, trigger_source: str = "Schedule
             var_result = await asyncio.wait_for(
                 var_calc.compute_portfolio_var(ib, config), timeout=30.0
             )
-            logger.info(
-                f"Post-audit VaR: 95%={var_result.var_95_pct:.2%} "
-                f"(${var_result.var_95:,.0f}), positions={var_result.position_count}"
-            )
+            if var_result.var_95 == 0 and var_result.position_count > 0:
+                logger.info(
+                    f"Post-audit VaR: 95%=0.00% ($0), positions={var_result.position_count} "
+                    f"— portfolio profitable in ≥95% of Monte Carlo scenarios (long put spread bias)"
+                )
+            else:
+                logger.info(
+                    f"Post-audit VaR: 95%={var_result.var_95_pct:.2%} "
+                    f"(${var_result.var_95:,.0f}), positions={var_result.position_count}"
+                )
 
             # Run AI Risk Agent (L1 + L2)
             try:

--- a/pages/5_Utilities.py
+++ b/pages/5_Utilities.py
@@ -238,11 +238,20 @@ with manual_cols[0]:
                     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
                     from trading_bot.order_manager import generate_and_execute_orders
 
+                    # Build commodity-specific config so NG gets NYMEX, not KC's NYBOT
+                    import copy
+                    from trading_bot.utils import get_ibkr_exchange
+                    cycle_config = copy.deepcopy(config)
+                    cycle_config['symbol'] = ticker
+                    cycle_config.setdefault('commodity', {})['ticker'] = ticker
+                    cycle_config['exchange'] = get_ibkr_exchange(cycle_config)
+                    cycle_config['data_dir'] = f'data/{ticker}'
+
                     # === FLIGHT DIRECTOR MANDATE: Connection Cleanup ===
                     async def run_with_cleanup():
                         """Run order generation with guaranteed connection cleanup."""
                         try:
-                            await generate_and_execute_orders(config, connection_purpose="dashboard_orders", trigger_type=TriggerType.MANUAL)
+                            await generate_and_execute_orders(cycle_config, connection_purpose="dashboard_orders", trigger_type=TriggerType.MANUAL)
                         finally:
                             # Ensure pool connections are released before loop closes
                             try:

--- a/trading_bot/order_manager.py
+++ b/trading_bot/order_manager.py
@@ -3443,6 +3443,13 @@ async def close_stale_positions(config: dict, connection_purpose: str = "orchest
                             leg_ask = leg_ticker.ask if not util.isNan(leg_ticker.ask) else 0
                             leg_last = leg_ticker.last if not util.isNan(leg_ticker.last) else 0
 
+                            # Retry once if no data yet (slow quote delivery on illiquid legs)
+                            if leg_bid == 0 and leg_ask == 0 and leg_last == 0:
+                                await asyncio.sleep(1.5)
+                                leg_bid = leg_ticker.bid if not util.isNan(leg_ticker.bid) else 0
+                                leg_ask = leg_ticker.ask if not util.isNan(leg_ticker.ask) else 0
+                                leg_last = leg_ticker.last if not util.isNan(leg_ticker.last) else 0
+
                             ib.cancelMktData(leg_contract)
 
                             if leg_bid > 0 and leg_ask > 0:
@@ -3450,7 +3457,11 @@ async def close_stale_positions(config: dict, connection_purpose: str = "orchest
                             elif leg_last > 0:
                                 leg_mid = leg_last
                             else:
-                                logger.warning(f"Leg {combo_leg.conId} ({leg_contract.localSymbol}): No valid price data")
+                                logger.warning(
+                                    f"Leg {combo_leg.conId} ({leg_contract.localSymbol}): No valid price data "
+                                    f"(bid={leg_ticker.bid}, ask={leg_ticker.ask}, last={leg_ticker.last}) — "
+                                    f"will fall back to market order"
+                                )
                                 leg_prices_valid = False
                                 break
 


### PR DESCRIPTION
## Summary

Three small fixes identified during DEV validation before production deployment:

- **Dashboard Force Signal Cycle (NYBOT → NYMEX)**: `pages/5_Utilities.py` was passing the base KC config (exchange=NYBOT) to `generate_and_execute_orders` regardless of the selected commodity. NG cycles would immediately fail with IB Error 200. Now builds a commodity-specific config from the selected ticker before executing.
- **VaR=0 misleading log**: When the portfolio is profitable in ≥95% of Monte Carlo scenarios (long put spread bias), `var_95` clips to 0. The log now reads `"portfolio profitable in ≥95% of Monte Carlo scenarios"` instead of the bare `$0` which looked like a missing value.
- **NG combo leg pricing retry**: Added a 1.5s retry when a combo leg returns no bid/ask/last data on first poll (illiquid NG options can be slow to deliver quotes). Also improved the fallback warning to include raw bid/ask/last values for easier diagnosis.

## Test plan

- [x] Syntax-checked all three files (`py_compile`)
- [x] Confirmed Perplexity stagger fix (PR #1352) working in DEV via manual test cycle — 8/8 agents, zero 429s, ~0.4s stagger visible
- [x] Force Signal Cycle exchange fix: verified `get_ibkr_exchange` returns NYMEX for NG when `commodity.ticker=NG`
- [ ] VaR=0 message: will appear on next audit cycle with long put spread positions
- [ ] Leg pricing retry: will exercise on next NG EOD close cycle with illiquid contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)