### PR TITLE
fix: use PNL_RECONCILED as fill count fallback to fix capped win rate

### DIFF
--- a/pages/10_The_Funnel.py
+++ b/pages/10_The_Funnel.py
@@ -242,16 +242,27 @@ def build_true_funnel(
     # Showing zeros mid-funnel looks broken — omit them entirely.
     if not observation_only:
         # 6. Orders Placed (from execution_funnel.csv)
+        # Backfill note: ORDER_PLACED count is often lower than PNL_RECONCILED because
+        # the backfill script creates PNL_RECONCILED from trade_ledger for all historical
+        # trades but only creates ORDER_PLACED for a subset. Use PNL_RECONCILED as a
+        # lower-bound fallback so the funnel doesn't artificially collapse at this stage.
         n_placed = 0
+        n_reconciled = 0
         if not funnel_df.empty and 'stage' in funnel_df.columns:
             n_placed = len(funnel_df[funnel_df['stage'] == 'ORDER_PLACED'])
+            n_reconciled = len(funnel_df[funnel_df['stage'] == 'PNL_RECONCILED'])
+        n_placed = max(n_placed, n_reconciled)
         stages.append({'stage': 'Orders Placed', 'survivors': n_placed,
                        'source_label': 'execution_funnel'})
 
         # 7. Orders Filled
+        # Same backfill issue: PNL_RECONCILED is the most reliable fill proxy for
+        # historical data. ORDER_FILLED events are only created for real-time cycles
+        # and a small backfill subset. Use max to avoid capping downstream P&L stages.
         n_filled = 0
         if not funnel_df.empty and 'stage' in funnel_df.columns:
             n_filled = len(funnel_df[funnel_df['stage'] == 'ORDER_FILLED'])
+        n_filled = max(n_filled, n_reconciled)
         stages.append({'stage': 'Orders Filled', 'survivors': n_filled,
                        'source_label': 'execution_funnel'})
 


### PR DESCRIPTION
## Summary

- `build_true_funnel()` was using raw `ORDER_FILLED` event count as the fill ceiling for P&L stages. The backfill script only produced 31 `ORDER_FILLED` events but 355 `PNL_RECONCILED` events — so the cap was cutting 406 resolved council trades down to 31, making the funnel show a bogus **100% win rate** (25/25) instead of the real **46.8%** (166/355).
- Fix: use `max(ORDER_FILLED, PNL_RECONCILED)` for both Orders Placed and Orders Filled. `PNL_RECONCILED` is the most reliable fill proxy for backfill data — a trade can't be reconciled without being filled.
- The data-source mismatch warning now disappears for normal configurations where PNL_RECONCILED covers the date range.

## Root cause

The backfill script creates `PNL_RECONCILED` from `trade_ledger.csv` for **all** historical trades, but `ORDER_PLACED`/`ORDER_FILLED` events are only created for real-time cycles and a partial backfill subset. Pre-fix state for KC:

| Stage | Count |
|---|---|
| ORDER_PLACED (backfill) | 80 |
| ORDER_FILLED (backfill) | 31 |
| PNL_RECONCILED (backfill) | 355 |
| council_history pnl_realized | 406 |

## Test plan
- [ ] Funnel win rate on KC matches Post-Funnel Outcome win rate (~47%)
- [ ] Data-source mismatch warning no longer fires for KC full-history view
- [ ] Funnel remains monotonically decreasing
- [ ] 39 UI/UX tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)