### PR TITLE
feat: escalate IB gateway outage to high-priority alert after 2 consecutive blocked cycles

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -5896,13 +5896,34 @@ async def guarded_generate_orders(config: dict, schedule_id: str = None):
              if not _dg.is_entry_allowed():
                  logger.warning("Order generation BLOCKED: Drawdown Guard Active")
                  return
+             # Success — reset consecutive failure streak
+             rt = get_engine_runtime()
+             if rt:
+                 rt.ib_drawdown_failure_streak = 0
         except Exception as e:
              logger.error(f"Drawdown guard check failed (fail-closed): {e}")
-             send_pushover_notification(
-                 config.get('notifications', {}),
-                 "⚠️ Drawdown Check Failed",
-                 f"Order generation blocked — drawdown guard unreachable: {e}"
-             )
+             rt = get_engine_runtime()
+             streak = 1
+             if rt:
+                 rt.ib_drawdown_failure_streak += 1
+                 streak = rt.ib_drawdown_failure_streak
+             ticker = get_active_ticker(config)
+             if streak >= 2:
+                 # Escalate: IB gateway is persistently down, orders silently blocked
+                 send_pushover_notification(
+                     config.get('notifications', {}),
+                     f"🚨 [{ticker}] IB Gateway Down — Orders Blocked ({streak} cycles)",
+                     f"Drawdown check has failed {streak} consecutive signal cycles. "
+                     f"No new orders can be placed until IB Gateway is reachable. "
+                     f"Restart the gateway. Error: {e}",
+                     priority=1,  # HIGH priority — requires acknowledgement
+                 )
+             else:
+                 send_pushover_notification(
+                     config.get('notifications', {}),
+                     f"⚠️ [{ticker}] Drawdown Check Failed",
+                     f"Order generation blocked — drawdown guard unreachable: {e}"
+                 )
              return
         finally:
              if ib is not None:

--- a/trading_bot/data_dir_context.py
+++ b/trading_bot/data_dir_context.py
@@ -91,6 +91,7 @@ class EngineRuntime:
     brier_zero_resolution_streak: int = 0
     scheduled_shutdown: bool = False  # Per-engine replacement for _SCHEDULED_SHUTDOWN global
     full_shutdown: bool = False        # Per-engine replacement for _FULL_SHUTDOWN global
+    ib_drawdown_failure_streak: int = 0  # Consecutive drawdown-check IB failures; resets on success
 
 
 # No default — LookupError triggers fallback to module globals in legacy mode


### PR DESCRIPTION
## Summary

- On first drawdown-check IB failure: keeps existing low-priority notification (could be transient)
- On **second consecutive failure**: fires a `priority=1` (HIGH) Pushover that requires acknowledgement, naming the ticker, failure count, and explicit action: "Restart the gateway"
- Streak counter lives in `EngineRuntime.ib_drawdown_failure_streak` — resets to 0 on any successful connection

## Motivation

On 2026-03-20, the IB drawdown check timed out at both `signal_early` (13:59 UTC) and `signal_mid` (15:39 UTC), silently blocking all KC orders for the day. The system sent individual per-failure notifications but nothing that communicated "this is now systemic — all orders are blocked." A gateway restart at 13:59 would have recovered the 15:39 cycle.

## Behaviour after this change

| Failure # | Pushover priority | Message |
|---|---|---|
| 1st | Normal (0) | "⚠️ [KC] Drawdown Check Failed" |
| 2nd+ | High (1) | "🚨 [KC] IB Gateway Down — Orders Blocked (2 cycles)" |
| Recovery | — | streak resets, no notification |

🤖 Generated with [Claude Code](https://claude.com/claude-code)