### PR TITLE
fix: KeyError 'survivors_raw' in funnel dashboard

### DIFF
--- a/pages/10_The_Funnel.py
+++ b/pages/10_The_Funnel.py
@@ -270,7 +270,11 @@ def build_true_funnel(
     # Build DataFrame with drop calculations
     result = pd.DataFrame(stages)
     # Backfill survivors_raw for stages that don't need capping (raw == capped)
-    result['survivors_raw'] = result['survivors_raw'].fillna(result['survivors']).astype(int)
+    if 'survivors_raw' not in result.columns:
+        result['survivors_raw'] = result['survivors']
+    else:
+        result['survivors_raw'] = result['survivors_raw'].fillna(result['survivors'])
+    result['survivors_raw'] = result['survivors_raw'].astype(int)
     result['drop'] = -result['survivors'].diff().fillna(0).astype(int).clip(upper=0)
     result.loc[0, 'drop'] = 0
     result['drop_pct'] = 0.0


### PR DESCRIPTION
## Summary
- Fix `KeyError: 'survivors_raw'` crash in `pages/10_The_Funnel.py` when loading the Funnel dashboard
- The `build_true_funnel()` function assumed the `survivors_raw` column existed in the stages DataFrame, but no stage dict includes that key (removed during prior PNL_RECONCILED fallback cleanup)
- Now creates the column from `survivors` if it doesn't exist

## Test plan
- [ ] Load the Funnel dashboard page — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)