### PR TITLE
fix: global rate limiter for Perplexity (50 RPM + 1 QPS)

### DIFF
--- a/trading_bot/agents.py
+++ b/trading_bot/agents.py
@@ -801,20 +801,18 @@ class TradingCouncil:
         """Phase 1 via Perplexity Sonar — deterministic search cost."""
         logger.info(f"[{persona_key}] Phase 1: Gathering grounded data via Perplexity Sonar...")
 
-        async with self._grounded_data_semaphore:
-            import time as _time
-            elapsed = _time.monotonic() - self._last_grounded_call_time
-            if elapsed < self._grounded_data_min_interval:
-                await asyncio.sleep(self._grounded_data_min_interval - elapsed)
-            self._last_grounded_call_time = _time.monotonic()
+        from trading_bot.rate_limiter import acquire_api_slot
+        acquired = await acquire_api_slot('perplexity', timeout=60.0)
+        if not acquired:
+            raise RuntimeError("Perplexity rate limit timeout — all slots busy")
 
-            data = await perplexity_grounded_search(
-                search_instruction=search_instruction,
-                api_key=self._perplexity_api_key,
-                model=self._perplexity_model,
-                search_context_size=self._perplexity_search_context,
-                timeout_seconds=30,
-            )
+        data = await perplexity_grounded_search(
+            search_instruction=search_instruction,
+            api_key=self._perplexity_api_key,
+            model=self._perplexity_model,
+            search_context_size=self._perplexity_search_context,
+            timeout_seconds=30,
+        )
 
         # Budget tracking
         usage = data.pop("_usage", {})

--- a/trading_bot/rate_limiter.py
+++ b/trading_bot/rate_limiter.py
@@ -14,11 +14,13 @@ logger = logging.getLogger(__name__)
 class TokenBucketLimiter:
     """Token bucket rate limiter for API calls."""
 
-    def __init__(self, rate: int, burst: int = None):
+    def __init__(self, rate: int, burst: int = None, min_interval: float = 0.0):
         self.rate = rate
         self.burst = burst if burst is not None else max(1, rate // 10)
         self.tokens = float(self.burst)
         self.last_update = time.monotonic()
+        self.min_interval = min_interval  # minimum seconds between requests (e.g. 1.0 for 1 QPS)
+        self._last_acquire_time = 0.0
         self._lock = asyncio.Lock()
         self._request_times: deque = deque(maxlen=100)
         self._waiters = 0
@@ -34,15 +36,32 @@ class TokenBucketLimiter:
                     self._refill()
 
                     if self.tokens >= 1:
-                        self.tokens -= 1
-                        self._request_times.append(time.monotonic())
-                        logger.debug(
-                            f"Rate limiter: Token acquired. "
-                            f"Remaining: {self.tokens:.1f}, Queued: {self._waiters - 1}"
-                        )
-                        return True
+                        # Enforce min_interval between requests
+                        if self.min_interval > 0:
+                            since_last = time.monotonic() - self._last_acquire_time
+                            if since_last < self.min_interval:
+                                wait_for = self.min_interval - since_last
+                                # Release lock while waiting, then re-check
+                                break_to_wait = wait_for
+                            else:
+                                break_to_wait = 0
+                        else:
+                            break_to_wait = 0
+
+                        if break_to_wait == 0:
+                            self.tokens -= 1
+                            self._last_acquire_time = time.monotonic()
+                            self._request_times.append(time.monotonic())
+                            logger.debug(
+                                f"Rate limiter: Token acquired. "
+                                f"Remaining: {self.tokens:.1f}, Queued: {self._waiters - 1}"
+                            )
+                            return True
 
                 wait_time = 60.0 / self.rate
+                if self.min_interval > 0:
+                    since_last = time.monotonic() - self._last_acquire_time
+                    wait_time = max(wait_time, self.min_interval - since_last)
                 remaining = deadline - time.monotonic()
 
                 if self._waiters > 5:
@@ -95,6 +114,7 @@ class GlobalRateLimiter:
         'openai': 400,
         'anthropic': 80,
         'xai': 25,
+        'perplexity': 50,  # Sonar: 50 RPM (Tier 0), also 1 QPS hard limit
     }
 
     def __new__(cls):
@@ -102,11 +122,19 @@ class GlobalRateLimiter:
             cls._instance = super().__new__(cls)
         return cls._instance
 
+    # Per-provider minimum interval between requests (QPS limits).
+    PROVIDER_MIN_INTERVALS: Dict[str, float] = {
+        'perplexity': 1.05,  # 1 QPS hard limit + margin
+    }
+
     @classmethod
     def _ensure_initialized(cls):
         if not cls._initialized:
             for provider, rpm in cls.PROVIDER_LIMITS.items():
-                cls._limiters[provider] = TokenBucketLimiter(rate=rpm, burst=3)
+                min_interval = cls.PROVIDER_MIN_INTERVALS.get(provider, 0.0)
+                cls._limiters[provider] = TokenBucketLimiter(
+                    rate=rpm, burst=3, min_interval=min_interval,
+                )
             cls._initialized = True
             logger.info(f"GlobalRateLimiter initialized: {list(cls.PROVIDER_LIMITS.keys())}")
 


### PR DESCRIPTION
## Summary
- **Problem**: Each commodity engine (KC, NG, CC) had its own per-instance rate throttle for Perplexity Sonar calls. When engines ran trading cycles simultaneously, the combined rate exceeded Perplexity's Tier 0 limits (50 RPM, 1 QPS), causing 429 errors (8 occurrences on Mar 20).
- **Fix**: Route Perplexity calls through the singleton `GlobalRateLimiter` — same pattern already used for Gemini/OpenAI/Anthropic/xAI. Added `min_interval` support to `TokenBucketLimiter` to enforce the 1 QPS hard limit.
- **Config**: `PROVIDER_LIMITS['perplexity'] = 50` RPM, `PROVIDER_MIN_INTERVALS['perplexity'] = 1.05s`. Update these when moving to a higher Perplexity tier.

## Test plan
- [x] `test_grounded_research.py` — 4 passed
- [x] `test_agents.py` — 5 passed
- [x] Full suite — 915 passed (1 pre-existing UI test failure)
- [x] Manual verification: two rapid `acquire_api_slot('perplexity')` calls enforce >=1.05s gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)